### PR TITLE
🐛 Fix coloring for receiver firmware and software version in syncMeta comparison

### DIFF
--- a/src/tostools/tosGPS.py
+++ b/src/tostools/tosGPS.py
@@ -2417,6 +2417,8 @@ def _highlight_differences(session, other_session, colors, is_reference=False):
         ("start_date", 25, 43, colors["RED"]),  # Session start date
         ("end_date", 44, 62, colors["RED"]),  # Session end date
         ("antenna_height", 63, 71, colors["RED"]),  # Antenna height (critical)
+        ("receiver_fw", 118, 138, colors["CYAN"]),  # Receiver firmware
+        ("sw_version", 139, 146, colors["CYAN"]),  # Software version
         ("receiver_sn", 146, 163, colors["YELLOW"]),  # Receiver serial number
         (
             "antenna_sn",


### PR DESCRIPTION
## Summary
- Fix missing coloring for receiver firmware and software version fields in `syncMeta --compare` output
- Add receiver firmware highlighting (columns 118-138) in cyan color
- Add software version highlighting (columns 139-146) in cyan color

## Problem
When running `tosGPS syncMeta --compare`, differences in receiver firmware and software version were detected and reported in the summary, but the actual values were not being colored/highlighted in the comparison output like other differing fields (antenna S/N, station name, etc.).

## Solution
Added the missing `receiver_fw` and `sw_version` fields to the `column_ranges` list in the `_highlight_differences` function, using cyan color to distinguish them from other field types while maintaining consistency with the existing color scheme.

## Test plan
- [x] Test with station ASVE showing firmware/software differences
- [x] Verify firmware values are highlighted in cyan
- [x] Verify software version values are fully highlighted in cyan
- [x] Confirm other existing coloring still works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)