### PR TITLE
🐛 Fix missing id_entity for Landmælingar Íslands operator contacts

### DIFF
--- a/src/tostools/legacy/gps_metadata_qc.py
+++ b/src/tostools/legacy/gps_metadata_qc.py
@@ -480,10 +480,9 @@ def get_contacts(id_entity_parent, url_rest, loglevel=logging.WARNING):
         )
 
     if contact["owner"]["name"] == "Landmælingar Íslands":
-        contact["operator"] = {
-            "role_is": "Rekstraraðili stöðvar",
-            "name": "Landmælingar Íslands",
-        }
+        contact["operator"] = contact["owner"].copy()
+        contact["operator"]["role"] = "operator"
+        contact["operator"]["role_is"] = "Rekstraraðili stöðvar"
         module_logger.info(
             "Setting role of contact: %s: %s",
             contact["operator"]["role_is"],


### PR DESCRIPTION
## Summary
Fixes KeyError: 'id_entity' when generating site logs for GPS stations owned by Landmælingar Íslands.

## Problem
When Landmælingar Íslands was the station owner, the operator contact was created with incomplete fields:
- Missing `id_entity` field required for site log generation
- Missing other contact fields like address, email, phone, etc.
- Caused site log generation to fail with `KeyError: 'id_entity'`

## Solution
- Copy the complete owner contact data for operator when they're the same organization
- Override only the role-specific fields (`role` and `role_is`)
- Ensures all required fields are present including `id_entity`

## Test plan
- [x] Tested with HEID station (owned by Landmælingar Íslands)
- [x] Site log generation now succeeds: `✓ Site log saved to ./logs/sitelog/HEID00ISL/heid00isl_20250912.log`
- [x] Operator contact now includes all required fields including `id_entity`

🤖 Generated with [Claude Code](https://claude.ai/code)