### PR TITLE
feat: domain-generic archive validation + RINEX header formatter

### DIFF
--- a/src/tostools/rinex/formatter.py
+++ b/src/tostools/rinex/formatter.py
@@ -1,0 +1,160 @@
+"""RINEX header field formatting (fixed-width Fortran layout).
+
+Pure string-formatting helpers for writing RINEX 3.x headers. Each field
+has a defined width and column layout per the RINEX spec; callers hand in
+Python values (strings, tuples, numbers) and get back correctly-padded
+header lines.
+
+This module is the "write" side of the RINEX header story; ``reader.py``
+and ``corrector.py`` handle the "read" and "correct against TOS" sides.
+
+Originally lived in ``receivers.rinex.metadata_provider`` — moved here so
+the formatting can be shared with any RINEX-producing tool in the
+ecosystem, not just receivers.
+"""
+
+from typing import Any, Dict, Optional, Tuple
+
+
+# RINEX header field specifications: (Fortran format, total width).
+# Based on the RINEX 3.x spec and tostools.rinex.reader column layouts.
+RINEX_FIELD_SPECS: Dict[str, Tuple[str, int]] = {
+    "MARKER NAME": ("A60", 60),
+    "MARKER NUMBER": ("A20", 20),
+    "OBSERVER / AGENCY": ("A20,A40", 60),
+    "REC # / TYPE / VERS": ("A20,A20,A20", 60),
+    "ANT # / TYPE": ("A20,A20", 40),
+    "APPROX POSITION XYZ": ("3F14.4", 42),
+    "ANTENNA: DELTA H/E/N": ("3F14.4", 42),
+    "INTERVAL": ("F10.3", 10),
+}
+
+
+def format_rinex_field(field_name: str, value: Any) -> Optional[str]:
+    """Format a value for a specific RINEX header field.
+
+    Dispatches on ``field_name`` to produce fixed-width Fortran output per
+    :data:`RINEX_FIELD_SPECS`. Returns ``None`` when the value is empty or
+    ``None`` (so the caller can skip emitting the line entirely).
+
+    Args:
+        field_name: RINEX field label, e.g. ``"MARKER NAME"``, ``"ANT # / TYPE"``.
+        value: Value to format. Accepts:
+            - ``str`` — treated as a single value (split for multi-part fields).
+            - ``tuple`` / ``list`` — multi-part value (e.g. ``(observer, agency)``).
+            - ``float`` / ``int`` — numeric value.
+            - ``None`` — returns ``None``.
+
+    Returns:
+        The formatted, padded string, or ``None`` if the value yields
+        nothing meaningful to write.
+
+    Examples:
+        >>> format_rinex_field("MARKER NAME", "ELDC")[:4]
+        'ELDC'
+        >>> format_rinex_field("ANT # / TYPE", ("CR6200", "ASH701945C_M    SCIS"))[:6]
+        'CR6200'
+    """
+    if value is None:
+        return None
+
+    if field_name == "MARKER NAME":
+        v = str(value).strip()
+        if not v:
+            return None
+        return v.upper().ljust(60)[:60]
+
+    elif field_name == "MARKER NUMBER":
+        v = str(value).strip()
+        if not v:
+            return None
+        return v.ljust(20)[:20]
+
+    elif field_name == "OBSERVER / AGENCY":
+        if isinstance(value, (list, tuple)) and len(value) >= 2:
+            obs, agency = str(value[0]).strip(), str(value[1]).strip()
+        else:
+            parts = str(value).split(None, 1)
+            obs = parts[0] if parts else ""
+            agency = parts[1] if len(parts) > 1 else ""
+        if not obs and not agency:
+            return None
+        return f"{obs.ljust(20)[:20]}{agency.ljust(40)[:40]}"
+
+    elif field_name == "REC # / TYPE / VERS":
+        if isinstance(value, (list, tuple)) and len(value) >= 3:
+            serial, model, version = (
+                str(value[0]).strip(),
+                str(value[1]).strip(),
+                str(value[2]).strip(),
+            )
+        elif isinstance(value, (list, tuple)) and len(value) == 2:
+            serial, model, version = str(value[0]).strip(), str(value[1]).strip(), ""
+        else:
+            parts = str(value).split(None, 2)
+            serial = parts[0] if len(parts) > 0 else ""
+            model = parts[1] if len(parts) > 1 else ""
+            version = parts[2] if len(parts) > 2 else ""
+        if not serial and not model:
+            return None
+        return f"{serial.ljust(20)[:20]}{model.ljust(20)[:20]}{version.ljust(20)[:20]}"
+
+    elif field_name == "ANT # / TYPE":
+        if isinstance(value, (list, tuple)) and len(value) >= 2:
+            serial, ant_type = str(value[0]).strip(), str(value[1]).strip()
+        else:
+            parts = str(value).split(None, 1)
+            serial = parts[0] if parts else ""
+            ant_type = parts[1] if len(parts) > 1 else ""
+        if not serial:
+            return None
+        return f"{serial.ljust(20)[:20]}{ant_type.ljust(20)[:20]}"
+
+    elif field_name == "ANTENNA: DELTA H/E/N":
+        if isinstance(value, (list, tuple)) and len(value) >= 3:
+            h, e, n = float(value[0]), float(value[1]), float(value[2])
+        elif isinstance(value, (int, float)):
+            h, e, n = float(value), 0.0, 0.0
+        else:
+            try:
+                parts = str(value).split()
+                h = float(parts[0]) if len(parts) > 0 else 0.0
+                e = float(parts[1]) if len(parts) > 1 else 0.0
+                n = float(parts[2]) if len(parts) > 2 else 0.0
+            except (ValueError, IndexError):
+                return None
+        return f"{h:14.4f}{e:14.4f}{n:14.4f}"
+
+    elif field_name == "APPROX POSITION XYZ":
+        if isinstance(value, (list, tuple)) and len(value) >= 3:
+            x, y, z = float(value[0]), float(value[1]), float(value[2])
+        else:
+            return None
+        return f"{x:14.4f}{y:14.4f}{z:14.4f}"
+
+    elif field_name == "INTERVAL":
+        try:
+            return f"{float(value):10.3f}"
+        except (ValueError, TypeError):
+            return None
+
+    else:
+        v = str(value).strip()
+        return v if v else None
+
+
+def format_antenna_type_with_radome(antenna_model: str, radome: str = "NONE") -> str:
+    """Format antenna type + radome for the ``ANT # / TYPE`` field.
+
+    IGS convention: 15 chars antenna model + space + 4 chars radome = 20 chars.
+
+    Args:
+        antenna_model: Antenna model, e.g. ``"ASH701945C_M"``.
+        radome: Radome code, e.g. ``"SCIS"``. Defaults to ``"NONE"``.
+
+    Returns:
+        Exactly 20 characters: ``"ANT_MODEL_15CH SCIS"``.
+    """
+    model = antenna_model.ljust(15)[:15]
+    dome = (radome or "NONE").ljust(4)[:4]
+    return f"{model} {dome}"

--- a/src/tostools/rinex/formatter.py
+++ b/src/tostools/rinex/formatter.py
@@ -15,7 +15,6 @@ ecosystem, not just receivers.
 
 from typing import Any, Dict, Optional, Tuple
 
-
 # RINEX header field specifications: (Fortran format, total width).
 # Based on the RINEX 3.x spec and tostools.rinex.reader column layouts.
 RINEX_FIELD_SPECS: Dict[str, Tuple[str, int]] = {

--- a/src/tostools/utils/archive.py
+++ b/src/tostools/utils/archive.py
@@ -1,0 +1,274 @@
+"""Archive file validation and discovery utilities.
+
+Domain-generic archive integrity helpers: gzip/zip magic-byte validation,
+full-read integrity checks for partial-download detection, size thresholds,
+and multi-location archive discovery. Originally extracted from the
+``receivers`` package (``receivers.utils.archive_validator``) because the
+logic is not GPS-specific — any pipeline that writes compressed files to a
+"permanent archive" + "temp staging" layout can use it.
+
+Design:
+- Plugin architecture for compression format validators
+  (:class:`CompressionValidator` protocol). New formats (bz2, xz, zstd) can
+  register without touching :class:`ArchiveValidator`.
+- Configurable minimum file size threshold.
+- :meth:`ArchiveValidator.find_existing_archive` handles the common pattern
+  of "check archive location first, then compressed variant, then temp
+  staging".
+"""
+
+import gzip
+import logging
+from enum import Enum
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Protocol, Tuple
+
+
+class ArchiveLocation(Enum):
+    """Where an archive file was found by
+    :meth:`ArchiveValidator.find_existing_archive`."""
+
+    ARCHIVE = "archive"
+    ARCHIVE_COMPRESSED = "archive_compressed"
+    TMP = "tmp"
+    NOT_FOUND = "not_found"
+
+
+class CompressionValidator(Protocol):
+    """Protocol for compression-format magic-byte validators."""
+
+    def validate_magic_bytes(self, file_path: Path) -> bool:
+        ...
+
+    def get_extension(self) -> str:
+        ...
+
+
+class GzipValidator:
+    """Gzip magic-byte validator."""
+
+    MAGIC_BYTES = b"\x1f\x8b"
+
+    def validate_magic_bytes(self, file_path: Path) -> bool:
+        try:
+            with open(file_path, "rb") as f:
+                return f.read(2) == self.MAGIC_BYTES
+        except (OSError, IOError):
+            return False
+
+    def get_extension(self) -> str:
+        return ".gz"
+
+
+class ArchiveValidator:
+    """Unified archive file validation and multi-location discovery."""
+
+    def __init__(
+        self,
+        logger: Optional[logging.Logger] = None,
+        min_file_size: int = 1024,
+    ):
+        self.logger = logger or logging.getLogger(__name__)
+        self.min_file_size = min_file_size
+        self._compression_validators: Dict[str, CompressionValidator] = {
+            ".gz": GzipValidator(),
+        }
+
+    def register_compression_validator(
+        self, extension: str, validator: CompressionValidator
+    ) -> None:
+        self._compression_validators[extension] = validator
+        self.logger.debug(f"Registered compression validator for {extension}")
+
+    def validate_archived_file(self, file_path: Path) -> bool:
+        """Size + magic-byte sanity check. Does not decompress."""
+        try:
+            if not file_path.exists():
+                self.logger.debug(f"File does not exist: {file_path}")
+                return False
+
+            file_size = file_path.stat().st_size
+            if file_size < self.min_file_size:
+                self.logger.debug(
+                    f"File too small ({file_size} bytes, minimum {self.min_file_size}): {file_path}"
+                )
+                return False
+
+            file_extension = "".join(file_path.suffixes[-1:])
+            if file_extension in self._compression_validators:
+                validator = self._compression_validators[file_extension]
+                if not validator.validate_magic_bytes(file_path):
+                    self.logger.debug(
+                        f"File doesn't have valid {file_extension} magic header: {file_path}"
+                    )
+                    return False
+
+            return True
+
+        except (OSError, IOError) as e:
+            self.logger.debug(f"Error validating archived file {file_path}: {e}")
+            return False
+
+    def _validate_tmp_file_integrity(self, file_path: Path) -> bool:
+        """Full-read integrity check for tmp/partial files."""
+        try:
+            if not file_path.exists():
+                return False
+
+            file_size = file_path.stat().st_size
+            if file_size < self.min_file_size:
+                self.logger.debug(
+                    f"Tmp file too small ({file_size} bytes): {file_path.name}"
+                )
+                return False
+
+            file_extension = "".join(file_path.suffixes[-1:])
+            if file_extension == ".gz":
+                try:
+                    with gzip.open(file_path, "rb") as gz_file:
+                        while True:
+                            chunk = gz_file.read(1024 * 1024)
+                            if not chunk:
+                                break
+                    self.logger.debug(
+                        f"Tmp file gzip integrity verified: {file_path.name}"
+                    )
+                    return True
+                except (OSError, gzip.BadGzipFile) as e:
+                    self.logger.debug(
+                        f"Tmp file gzip integrity FAILED (partial?): {file_path.name} - {e}"
+                    )
+                    return False
+            else:
+                return self.validate_archived_file(file_path)
+
+        except Exception as e:
+            self.logger.debug(f"Error validating tmp file {file_path}: {e}")
+            return False
+
+    def find_existing_archive(
+        self,
+        filename: str,
+        archive_path: str,
+        tmp_dir: Optional[Path] = None,
+    ) -> Tuple[bool, Optional[Path], ArchiveLocation]:
+        archive_path_obj = Path(archive_path)
+
+        if archive_path_obj.exists():
+            if self.validate_archived_file(archive_path_obj):
+                return True, archive_path_obj, ArchiveLocation.ARCHIVE
+            else:
+                self.logger.warning(
+                    f"Archived file failed validation: {archive_path_obj}"
+                )
+
+        for ext, _validator in self._compression_validators.items():
+            compressed_path = Path(str(archive_path) + ext)
+            if compressed_path.exists():
+                if self.validate_archived_file(compressed_path):
+                    return True, compressed_path, ArchiveLocation.ARCHIVE_COMPRESSED
+                else:
+                    self.logger.warning(
+                        f"Compressed archived file failed validation: {compressed_path}"
+                    )
+
+        if tmp_dir:
+            tmp_file_path = tmp_dir / filename
+            if tmp_file_path.exists():
+                if self._validate_tmp_file_integrity(tmp_file_path):
+                    return True, tmp_file_path, ArchiveLocation.TMP
+                else:
+                    self.logger.debug(
+                        f"Tmp file exists but incomplete/invalid: {tmp_file_path}"
+                    )
+
+        return False, None, ArchiveLocation.NOT_FOUND
+
+    def batch_validate_archives(
+        self,
+        files_dict: Dict[str, str],
+        archive_files_dict: Dict[str, str],
+        tmp_dir: Optional[Path] = None,
+    ) -> Tuple[Dict[str, str], int, int, Dict[str, Path]]:
+        missing_files_dict: Dict[str, str] = {}
+        files_in_tmp_dict: Dict[str, Path] = {}
+        files_found_in_archive = 0
+        validated_files = 0
+
+        for filename, remote_dir in files_dict.items():
+            validated_files += 1
+            archive_path = archive_files_dict.get(filename)
+
+            if archive_path:
+                found, path, location = self.find_existing_archive(
+                    filename, archive_path, tmp_dir
+                )
+                if found:
+                    if location == ArchiveLocation.TMP:
+                        files_in_tmp_dict[filename] = path  # type: ignore[assignment]
+                    else:
+                        files_found_in_archive += 1
+                    continue
+
+            missing_files_dict[filename] = remote_dir
+
+        if files_found_in_archive > 0:
+            self.logger.info(
+                f"Found {files_found_in_archive} files already archived, "
+                f"skipping re-download"
+            )
+        if files_in_tmp_dict:
+            self.logger.info(
+                f"Found {len(files_in_tmp_dict)} files in tmp directory that need archiving"
+            )
+
+        return missing_files_dict, files_found_in_archive, validated_files, files_in_tmp_dict
+
+    def get_compression_extensions(self) -> List[str]:
+        return list(self._compression_validators.keys())
+
+    def set_min_file_size(self, min_size: int) -> None:
+        self.min_file_size = min_size
+        self.logger.debug(f"Updated minimum file size to {min_size} bytes")
+
+    def validate_with_detailed_report(self, file_path: Path) -> Dict[str, Any]:
+        report: Dict[str, Any] = {
+            "valid": False,
+            "file_exists": False,
+            "file_size": 0,
+            "meets_min_size": False,
+            "compression_format": None,
+            "compression_valid": None,
+            "errors": [],
+        }
+
+        if not file_path.exists():
+            report["errors"].append(f"File does not exist: {file_path}")
+            return report
+
+        report["file_exists"] = True
+
+        try:
+            file_size = file_path.stat().st_size
+            report["file_size"] = file_size
+            report["meets_min_size"] = file_size >= self.min_file_size
+            if not report["meets_min_size"]:
+                report["errors"].append(
+                    f"File size {file_size} bytes < minimum {self.min_file_size} bytes"
+                )
+        except (OSError, IOError) as e:
+            report["errors"].append(f"Error reading file size: {e}")
+            return report
+
+        file_extension = "".join(file_path.suffixes[-1:])
+        if file_extension in self._compression_validators:
+            report["compression_format"] = file_extension
+            validator = self._compression_validators[file_extension]
+            report["compression_valid"] = validator.validate_magic_bytes(file_path)
+            if not report["compression_valid"]:
+                report["errors"].append(
+                    f"Invalid {file_extension} compression format"
+                )
+
+        report["valid"] = len(report["errors"]) == 0
+        return report

--- a/src/tostools/utils/archive.py
+++ b/src/tostools/utils/archive.py
@@ -37,11 +37,9 @@ class ArchiveLocation(Enum):
 class CompressionValidator(Protocol):
     """Protocol for compression-format magic-byte validators."""
 
-    def validate_magic_bytes(self, file_path: Path) -> bool:
-        ...
+    def validate_magic_bytes(self, file_path: Path) -> bool: ...
 
-    def get_extension(self) -> str:
-        ...
+    def get_extension(self) -> str: ...
 
 
 class GzipValidator:
@@ -90,7 +88,10 @@ class ArchiveValidator:
             file_size = file_path.stat().st_size
             if file_size < self.min_file_size:
                 self.logger.debug(
-                    f"File too small ({file_size} bytes, minimum {self.min_file_size}): {file_path}"
+                    "File too small (%s bytes, minimum %s): %s",
+                    file_size,
+                    self.min_file_size,
+                    file_path,
                 )
                 return False
 
@@ -99,7 +100,9 @@ class ArchiveValidator:
                 validator = self._compression_validators[file_extension]
                 if not validator.validate_magic_bytes(file_path):
                     self.logger.debug(
-                        f"File doesn't have valid {file_extension} magic header: {file_path}"
+                        "File doesn't have valid %s magic header: %s",
+                        file_extension,
+                        file_path,
                     )
                     return False
 
@@ -136,7 +139,9 @@ class ArchiveValidator:
                     return True
                 except (OSError, gzip.BadGzipFile) as e:
                     self.logger.debug(
-                        f"Tmp file gzip integrity FAILED (partial?): {file_path.name} - {e}"
+                        "Tmp file gzip integrity FAILED (partial?): %s - %s",
+                        file_path.name,
+                        e,
                     )
                     return False
             else:
@@ -219,10 +224,16 @@ class ArchiveValidator:
             )
         if files_in_tmp_dict:
             self.logger.info(
-                f"Found {len(files_in_tmp_dict)} files in tmp directory that need archiving"
+                "Found %s files in tmp directory that need archiving",
+                len(files_in_tmp_dict),
             )
 
-        return missing_files_dict, files_found_in_archive, validated_files, files_in_tmp_dict
+        return (
+            missing_files_dict,
+            files_found_in_archive,
+            validated_files,
+            files_in_tmp_dict,
+        )
 
     def get_compression_extensions(self) -> List[str]:
         return list(self._compression_validators.keys())
@@ -266,9 +277,7 @@ class ArchiveValidator:
             validator = self._compression_validators[file_extension]
             report["compression_valid"] = validator.validate_magic_bytes(file_path)
             if not report["compression_valid"]:
-                report["errors"].append(
-                    f"Invalid {file_extension} compression format"
-                )
+                report["errors"].append(f"Invalid {file_extension} compression format")
 
         report["valid"] = len(report["errors"]) == 0
         return report

--- a/tests/test_archive_utils.py
+++ b/tests/test_archive_utils.py
@@ -1,0 +1,128 @@
+"""Tests for tostools.utils.archive (migrated from receivers)."""
+
+import gzip
+from pathlib import Path
+
+import pytest
+
+from tostools.utils.archive import (
+    ArchiveLocation,
+    ArchiveValidator,
+    GzipValidator,
+)
+
+
+@pytest.fixture
+def tmp_gzip_file(tmp_path: Path) -> Path:
+    path = tmp_path / "sample.txt.gz"
+    with gzip.open(path, "wb") as f:
+        f.write(b"x" * 4096)
+    return path
+
+
+@pytest.fixture
+def tmp_broken_gzip(tmp_path: Path) -> Path:
+    path = tmp_path / "broken.txt.gz"
+    path.write_bytes(b"\x1f\x8b" + b"garbage" * 500)  # valid magic, bad body
+    return path
+
+
+class TestGzipValidator:
+    def test_recognizes_valid_gzip(self, tmp_gzip_file):
+        assert GzipValidator().validate_magic_bytes(tmp_gzip_file) is True
+
+    def test_rejects_plain_file(self, tmp_path):
+        plain = tmp_path / "plain.txt"
+        plain.write_text("hello")
+        assert GzipValidator().validate_magic_bytes(plain) is False
+
+    def test_returns_dot_gz_extension(self):
+        assert GzipValidator().get_extension() == ".gz"
+
+
+class TestArchiveValidator:
+    def test_valid_gz_passes(self, tmp_gzip_file):
+        v = ArchiveValidator(min_file_size=1)
+        assert v.validate_archived_file(tmp_gzip_file) is True
+
+    def test_below_min_size_fails(self, tmp_gzip_file):
+        v = ArchiveValidator(min_file_size=10_000_000)
+        assert v.validate_archived_file(tmp_gzip_file) is False
+
+    def test_missing_file_fails(self, tmp_path):
+        v = ArchiveValidator(min_file_size=1)
+        assert v.validate_archived_file(tmp_path / "nope.gz") is False
+
+    def test_magic_byte_mismatch_fails(self, tmp_path):
+        fake = tmp_path / "fake.gz"
+        fake.write_bytes(b"not a real gzip body")
+        v = ArchiveValidator(min_file_size=1)
+        assert v.validate_archived_file(fake) is False
+
+    def test_tmp_integrity_detects_corruption(self, tmp_broken_gzip):
+        v = ArchiveValidator(min_file_size=1)
+        assert v._validate_tmp_file_integrity(tmp_broken_gzip) is False
+
+    def test_tmp_integrity_passes_valid_file(self, tmp_gzip_file):
+        v = ArchiveValidator(min_file_size=1)
+        assert v._validate_tmp_file_integrity(tmp_gzip_file) is True
+
+    def test_find_existing_archive_hits_archive(self, tmp_gzip_file, tmp_path):
+        v = ArchiveValidator(min_file_size=1)
+        found, path, location = v.find_existing_archive(
+            tmp_gzip_file.name, str(tmp_gzip_file).replace(".gz", "")
+        )
+        assert found is True
+        assert location == ArchiveLocation.ARCHIVE_COMPRESSED
+        assert path == tmp_gzip_file
+
+    def test_find_existing_archive_hits_tmp(self, tmp_gzip_file, tmp_path):
+        # Move into a "tmp" directory, no archive
+        tmp_dir = tmp_path / "tmp"
+        tmp_dir.mkdir()
+        moved = tmp_dir / tmp_gzip_file.name
+        tmp_gzip_file.rename(moved)
+
+        v = ArchiveValidator(min_file_size=1)
+        found, path, location = v.find_existing_archive(
+            moved.name, str(tmp_path / "archive_that_doesnt_exist"), tmp_dir=tmp_dir
+        )
+        assert found is True
+        assert location == ArchiveLocation.TMP
+        assert path == moved
+
+    def test_find_existing_archive_not_found(self, tmp_path):
+        v = ArchiveValidator(min_file_size=1)
+        found, path, location = v.find_existing_archive(
+            "nope.gz", str(tmp_path / "nowhere")
+        )
+        assert found is False
+        assert path is None
+        assert location == ArchiveLocation.NOT_FOUND
+
+    def test_batch_validate_separates_missing_and_found(self, tmp_gzip_file, tmp_path):
+        v = ArchiveValidator(min_file_size=1)
+        files = {tmp_gzip_file.name: "/remote/a", "missing.gz": "/remote/b"}
+        archive = {
+            tmp_gzip_file.name: str(tmp_gzip_file).replace(".gz", ""),
+            "missing.gz": str(tmp_path / "nowhere"),
+        }
+        missing, found_count, _total, tmp = v.batch_validate_archives(files, archive)
+        assert "missing.gz" in missing
+        assert tmp_gzip_file.name not in missing
+        assert found_count == 1
+        assert tmp == {}
+
+    def test_detailed_report_structure(self, tmp_gzip_file):
+        v = ArchiveValidator(min_file_size=1)
+        report = v.validate_with_detailed_report(tmp_gzip_file)
+        assert report["valid"] is True
+        assert report["file_exists"] is True
+        assert report["compression_format"] == ".gz"
+        assert report["compression_valid"] is True
+        assert report["errors"] == []
+
+    def test_set_min_file_size_updates(self):
+        v = ArchiveValidator(min_file_size=100)
+        v.set_min_file_size(2048)
+        assert v.min_file_size == 2048

--- a/tests/test_rinex_formatter.py
+++ b/tests/test_rinex_formatter.py
@@ -1,0 +1,123 @@
+"""Tests for tostools.rinex.formatter (migrated from receivers)."""
+
+import pytest
+
+from tostools.rinex.formatter import (
+    RINEX_FIELD_SPECS,
+    format_antenna_type_with_radome,
+    format_rinex_field,
+)
+
+
+class TestFormatRinexField:
+    def test_marker_name_uppercase_padded_to_60(self):
+        result = format_rinex_field("MARKER NAME", "eldc")
+        assert result is not None
+        assert result.startswith("ELDC")
+        assert len(result) == 60
+
+    def test_marker_name_empty_returns_none(self):
+        assert format_rinex_field("MARKER NAME", "") is None
+        assert format_rinex_field("MARKER NAME", None) is None
+
+    def test_marker_number_padded_to_20(self):
+        result = format_rinex_field("MARKER NUMBER", "12345M001")
+        assert result is not None
+        assert result.startswith("12345M001")
+        assert len(result) == 20
+
+    def test_observer_agency_tuple(self):
+        result = format_rinex_field("OBSERVER / AGENCY", ("BGO", "IMO"))
+        assert result is not None
+        assert result.startswith("BGO")
+        assert "IMO" in result
+        assert len(result) == 60
+
+    def test_observer_agency_string_split(self):
+        result = format_rinex_field("OBSERVER / AGENCY", "BGO IMO")
+        assert result is not None
+        assert result.startswith("BGO")
+        assert "IMO" in result
+        assert len(result) == 60
+
+    def test_rec_type_vers_three_parts(self):
+        result = format_rinex_field(
+            "REC # / TYPE / VERS", ("1234567", "SEPT POLARX5", "5.4.0")
+        )
+        assert result is not None
+        assert result.startswith("1234567")
+        assert "SEPT POLARX5" in result
+        assert "5.4.0" in result
+        assert len(result) == 60
+
+    def test_ant_type_with_radome(self):
+        result = format_rinex_field(
+            "ANT # / TYPE", ("CR6200", "ASH701945C_M    SCIS")
+        )
+        assert result is not None
+        assert result.startswith("CR6200")
+        assert "ASH701945C_M" in result
+        assert len(result) == 40
+
+    def test_antenna_delta_h_e_n_tuple(self):
+        result = format_rinex_field("ANTENNA: DELTA H/E/N", (0.1234, 0.0, 0.0))
+        assert result is not None
+        assert len(result) == 42
+        assert "0.1234" in result
+
+    def test_antenna_delta_height_only(self):
+        result = format_rinex_field("ANTENNA: DELTA H/E/N", 0.5)
+        assert result is not None
+        assert len(result) == 42
+        assert "0.5000" in result
+
+    def test_approx_position_xyz(self):
+        result = format_rinex_field(
+            "APPROX POSITION XYZ", (2470000.0, -1100000.0, 5800000.0)
+        )
+        assert result is not None
+        assert len(result) == 42
+
+    def test_interval_float(self):
+        assert format_rinex_field("INTERVAL", 15.0) == "    15.000"
+
+    def test_interval_invalid_returns_none(self):
+        assert format_rinex_field("INTERVAL", "not-a-number") is None
+
+    def test_unknown_field_passthrough(self):
+        assert format_rinex_field("CUSTOM FIELD", "value") == "value"
+
+
+class TestFormatAntennaTypeWithRadome:
+    def test_basic(self):
+        result = format_antenna_type_with_radome("ASH701945C_M", "SCIS")
+        assert len(result) == 20
+        assert result.startswith("ASH701945C_M")
+        assert result.endswith("SCIS")
+
+    def test_default_radome_is_none(self):
+        result = format_antenna_type_with_radome("SEPPOLANT_X_MF")
+        assert result.endswith("NONE")
+
+    def test_long_model_truncated_to_15(self):
+        result = format_antenna_type_with_radome("A" * 20, "DOME")
+        assert result[:15] == "A" * 15
+        assert result.endswith("DOME")
+        assert len(result) == 20
+
+    def test_long_radome_truncated_to_4(self):
+        result = format_antenna_type_with_radome("ANT", "DOMEXYZ")
+        assert result.endswith("DOME")
+        assert len(result) == 20
+
+
+class TestFieldSpecs:
+    def test_marker_name_spec(self):
+        fmt, width = RINEX_FIELD_SPECS["MARKER NAME"]
+        assert fmt == "A60"
+        assert width == 60
+
+    def test_ant_type_spec(self):
+        fmt, width = RINEX_FIELD_SPECS["ANT # / TYPE"]
+        assert fmt == "A20,A20"
+        assert width == 40

--- a/tests/test_rinex_formatter.py
+++ b/tests/test_rinex_formatter.py
@@ -1,7 +1,5 @@
 """Tests for tostools.rinex.formatter (migrated from receivers)."""
 
-import pytest
-
 from tostools.rinex.formatter import (
     RINEX_FIELD_SPECS,
     format_antenna_type_with_radome,
@@ -51,9 +49,7 @@ class TestFormatRinexField:
         assert len(result) == 60
 
     def test_ant_type_with_radome(self):
-        result = format_rinex_field(
-            "ANT # / TYPE", ("CR6200", "ASH701945C_M    SCIS")
-        )
+        result = format_rinex_field("ANT # / TYPE", ("CR6200", "ASH701945C_M    SCIS"))
         assert result is not None
         assert result.startswith("CR6200")
         assert "ASH701945C_M" in result


### PR DESCRIPTION
## Summary

Migrates two domain-generic modules out of `receivers` into `tostools`, where they fit the "rich RINEX + metadata toolkit" tier of the GPS library ecosystem.

- **Phase 4.4** — `tostools.utils.archive`: `ArchiveValidator` with size + compression magic-byte validation, multi-location discovery (archive → compressed → tmp), batch filtering, and a `CompressionValidator` protocol for extension to bz2/xz/zstd. `GzipValidator` ships as the default. **+15 tests.**
- **Phase 4.5** — `tostools.rinex.formatter`: Fortran-width RINEX header field formatters, migrated from `receivers/rinex/metadata_provider.py`. Joins the existing RINEX reader + corrector in `tostools.rinex`. **+19 tests.**

Both modules now live in `tostools`; `receivers` keeps thin re-export shims so existing importers keep working.

## Test plan

- [ ] `pytest tests/test_archive_utils.py -v` — 15 archive validation tests pass
- [ ] `pytest tests/test_rinex_formatter.py -v` — 19 formatter tests pass
- [ ] `ruff check src/` + `black --check src/` clean
- [ ] Verify `receivers` shims still resolve after this merges + a release tag: `from tostools.utils.archive import ArchiveValidator` and `from tostools.rinex.formatter import format_rinex_field`

## Context

Part of a cross-library refactor documented in session note `1776509554-gps-library-ecosystem-refactor-session`. Companion gtimes work (RINEX filename API, time-range helpers, `parse_datetime_flexible`) already merged as v0.5.0. The `receivers` cleanup PR (~−3,400 LOC) will follow once a `tostools` release tag is cut against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)