### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tostools"
-version = "0.1.0"
+version = "0.3.0"
 authors = [
     { name = "Benedikt Gunnar Ófeigsson", email = "bgo@vedur.is" },
     { name = "Tryggvi Hjörvar" },


### PR DESCRIPTION
## Summary

First tagged release. Minor bump for the new public API surface shipped in #6:

- `tostools.utils.archive` — domain-generic archive validation
- `tostools.rinex.formatter` — Fortran-width RINEX header field formatters

## Why 0.3.0

`pyproject.toml` was sitting at `0.1.0` despite docs claiming `0.2.x`. Jumping to `0.3.0` to reflect the new API surface and give downstream `receivers` a concrete version pin (it has been using editable installs and needs to switch to `tostools>=0.3.0`).

## Test plan

- [ ] CI builds cleanly on the new version (package metadata)
- [ ] `python -c "import tostools; print(tostools.__version__)"` where available, or `pip show tostools`
- [ ] Follow-up: tag `v0.3.0` once merged; open receivers PR pinning `tostools>=0.3.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)