### PR TITLE
✨ Add timespan subcommand for TOS vs archive date comparison

### DIFF
--- a/src/tostools/rinex/reader.py
+++ b/src/tostools/rinex/reader.py
@@ -6,11 +6,105 @@ including support for various compression formats.
 """
 
 import logging
+import re
+from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from ..io.file_utils import read_gzip_file, read_text_file, read_zzipped_file
 from ..utils.logging import get_logger
+
+MONTHS = ["jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"]
+
+
+def _parse_daily_rinex_date(name: str, station: str) -> Optional[datetime]:
+    """
+    Parse the observation date from a daily Hatanaka RINEX filename.
+
+    Expected pattern: ``STA<DDD>0.<YY>[DO][.Z|.gz]`` where DDD is day of year
+    and YY is two-digit year (pivot 80: <80 → 2000+YY, otherwise 1900+YY).
+
+    Args:
+        name: Bare filename (no directory)
+        station: Four-character station code
+
+    Returns:
+        ``datetime`` at 00:00 on the parsed date, or ``None`` if the name
+        does not match the daily pattern
+    """
+    m = re.match(
+        rf"^{re.escape(station)}(\d{{3}})\d\.(\d{{2}})[DO](?:\.Z|\.gz)?$",
+        name,
+        re.IGNORECASE,
+    )
+    if not m:
+        return None
+    doy = int(m.group(1))
+    yy = int(m.group(2))
+    year = 2000 + yy if yy < 80 else 1900 + yy
+    return datetime(year, 1, 1) + timedelta(days=doy - 1)
+
+
+def _scan_dir_dates(
+    directory: Path,
+    parser,
+    station: str,
+) -> List[Tuple[datetime, Path]]:
+    """Return ``(date, path)`` pairs for every file in ``directory`` whose
+    name is recognised by ``parser``. Returns an empty list if the directory
+    does not exist.
+    """
+    if not directory.is_dir():
+        return []
+    dates: List[Tuple[datetime, Path]] = []
+    for f in directory.iterdir():
+        dt = parser(f.name, station)
+        if dt is not None:
+            dates.append((dt, f))
+    return dates
+
+
+def find_most_recent_rinex(
+    station: str,
+    base_dir: Union[str, Path] = "/mnt_data/rawgpsdata",
+    rate_dir: str = "15s_24hr",
+) -> Optional[Path]:
+    """
+    Return the most recent daily RINEX file for a station.
+
+    Archive layout:
+    ``<base_dir>/<YYYY>/<mon>/<STATION>/<rate_dir>/rinex/<STA><DDD>0.<YY>[DO][.Z|.gz]``
+
+    Walks years and months descending and, within the first populated month
+    found, returns the file with the highest ``(year, DOY)``.
+
+    Args:
+        station: Four-character station code (case-insensitive)
+        base_dir: Archive root directory
+        rate_dir: Sampling-rate subdirectory (default ``"15s_24hr"``)
+
+    Returns:
+        Path to the most recent daily RINEX file, or ``None`` if no
+        matching file is found under ``base_dir``.
+    """
+    base = Path(base_dir)
+    if not base.is_dir():
+        return None
+
+    sta = station.upper()
+    years = sorted(
+        (p for p in base.iterdir() if p.is_dir() and p.name.isdigit()),
+        reverse=True,
+    )
+    for year_dir in years:
+        months_present = [m for m in MONTHS if (year_dir / m).is_dir()]
+        for mon in reversed(months_present):
+            rinex_dir = year_dir / mon / sta / rate_dir / "rinex"
+            dates = _scan_dir_dates(rinex_dir, _parse_daily_rinex_date, sta)
+            if dates:
+                dates.sort()
+                return dates[-1][1]
+    return None
 
 
 def get_rinex_labels() -> Tuple[List[str], List[str]]:

--- a/src/tostools/rinex/reader.py
+++ b/src/tostools/rinex/reader.py
@@ -45,6 +45,39 @@ def _parse_daily_rinex_date(name: str, station: str) -> Optional[datetime]:
     return datetime(year, 1, 1) + timedelta(days=doy - 1)
 
 
+def _parse_hourly_raw_date(name: str, station: str) -> Optional[datetime]:
+    """
+    Parse the observation timestamp from a 1 Hz raw filename.
+
+    Expected prefix: ``STA<YYYY><MM><DD><HHMM>`` (followed by any suffix/extension).
+
+    Args:
+        name: Bare filename (no directory)
+        station: Four-character station code
+
+    Returns:
+        ``datetime`` at the parsed timestamp, or ``None`` if the name does
+        not match the hourly pattern
+    """
+    m = re.match(
+        rf"^{re.escape(station)}(\d{{4}})(\d{{2}})(\d{{2}})(\d{{2}})(\d{{2}})",
+        name,
+        re.IGNORECASE,
+    )
+    if not m:
+        return None
+    try:
+        return datetime(
+            int(m.group(1)),
+            int(m.group(2)),
+            int(m.group(3)),
+            int(m.group(4)),
+            int(m.group(5)),
+        )
+    except ValueError:
+        return None
+
+
 def _scan_dir_dates(
     directory: Path,
     parser,
@@ -62,6 +95,89 @@ def _scan_dir_dates(
         if dt is not None:
             dates.append((dt, f))
     return dates
+
+
+def find_station_archive_range(
+    station: str,
+    base_dir: Union[str, Path] = "/mnt_data/rawgpsdata",
+) -> Dict[str, Any]:
+    """
+    Find the first and last archived file for a station.
+
+    Scans the archive layout
+    ``<base_dir>/<YYYY>/<mon>/<STATION>/<rate>/<leaf>/`` for two rate kinds:
+
+    * ``15s_24hr/rinex`` — daily Hatanaka RINEX (``STA<DDD>0.<YY>D[.Z|.gz]``)
+    * ``1Hz_1hr/raw``   — hourly raw (``STA<YYYY><MM><DD><HHMM>...``)
+
+    For each kind, walks years ascending to find the earliest month that
+    contains matching files (and picks the earliest file in that month),
+    then mirrors the walk descending for the latest.
+
+    Args:
+        station: Four-character station code (case-insensitive)
+        base_dir: Archive root directory
+
+    Returns:
+        Dict with per-kind results under keys ``"15s_24hr"`` and ``"1Hz_1hr"``
+        (each containing ``first``, ``last``, ``first_file``, ``last_file``)
+        plus the overall ``first`` and ``last`` across kinds.
+    """
+    base = Path(base_dir)
+    sta = station.upper()
+    kinds = [
+        ("15s_24hr", "15s_24hr", "rinex", _parse_daily_rinex_date),
+        ("1Hz_1hr", "1Hz_1hr", "raw", _parse_hourly_raw_date),
+    ]
+
+    if not base.is_dir():
+        return {"first": None, "last": None, "15s_24hr": {}, "1Hz_1hr": {}}
+
+    years = sorted(
+        [p.name for p in base.iterdir() if p.is_dir() and p.name.isdigit()]
+    )
+
+    result: Dict[str, Any] = {}
+    for kind, rate, leaf, parser in kinds:
+        first_dt = last_dt = None
+        first_file = last_file = None
+
+        for y in years:
+            found = False
+            for mon in MONTHS:
+                dates = _scan_dir_dates(base / y / mon / sta / rate / leaf, parser, sta)
+                if dates:
+                    dates.sort()
+                    first_dt, first_file = dates[0]
+                    found = True
+                    break
+            if found:
+                break
+
+        for y in reversed(years):
+            found = False
+            for mon in reversed(MONTHS):
+                dates = _scan_dir_dates(base / y / mon / sta / rate / leaf, parser, sta)
+                if dates:
+                    dates.sort()
+                    last_dt, last_file = dates[-1]
+                    found = True
+                    break
+            if found:
+                break
+
+        result[kind] = {
+            "first": first_dt,
+            "last": last_dt,
+            "first_file": first_file,
+            "last_file": last_file,
+        }
+
+    firsts = [result[k]["first"] for k in ("15s_24hr", "1Hz_1hr") if result[k]["first"]]
+    lasts = [result[k]["last"] for k in ("15s_24hr", "1Hz_1hr") if result[k]["last"]]
+    result["first"] = min(firsts) if firsts else None
+    result["last"] = max(lasts) if lasts else None
+    return result
 
 
 def find_most_recent_rinex(

--- a/src/tostools/tosGPS.py
+++ b/src/tostools/tosGPS.py
@@ -21,7 +21,11 @@ from .legacy import gps_metadata_functions as gpsf
 # Use the comprehensive legacy site log generator
 # from .core.site_log import generate_igs_site_log
 from .rinex.editor import update_rinex_files
-from .rinex.reader import extract_header_info, read_rinex_header
+from .rinex.reader import (
+    extract_header_info,
+    find_most_recent_rinex,
+    read_rinex_header,
+)
 from .rinex.validator import compare_rinex_to_tos
 from .utils.data_quality import data_quality_manager
 
@@ -549,7 +553,17 @@ Examples:
     rinex_parser.add_argument(
         "stations", nargs="+", help="GPS stations to validate against"
     )
-    rinex_parser.add_argument("rinex_files", nargs="+", help="RINEX files to validate")
+    rinex_parser.add_argument(
+        "rinex_files",
+        nargs="*",
+        help="RINEX files to validate (if omitted, the most recent daily file per station is resolved from --rinex-base-dir)",
+    )
+    rinex_parser.add_argument(
+        "--rinex-base-dir",
+        type=str,
+        default="/mnt_data/rawgpsdata",
+        help="Archive root when rinex_files is omitted (default: /mnt_data/rawgpsdata)",
+    )
     rinex_parser.add_argument(
         "--fix", action="store_true", help="Apply corrections to RINEX headers"
     )
@@ -1111,8 +1125,22 @@ def _handle_rinex_subcommand(args, stations, url, log_level):
             print(f"Error retrieving station data: {e}", file=sys.stderr)
             continue
 
+        # Resolve the list of RINEX files: explicit args, or most-recent-from-archive
+        if args.rinex_files:
+            files_for_station = list(args.rinex_files)
+        else:
+            resolved = find_most_recent_rinex(station, base_dir=args.rinex_base_dir)
+            if resolved is None:
+                print(
+                    f"Warning: No RINEX file found for {station} under {args.rinex_base_dir}",
+                    file=sys.stderr,
+                )
+                continue
+            print(f"Using most recent RINEX file: {resolved}", file=sys.stderr)
+            files_for_station = [str(resolved)]
+
         # Validate each RINEX file
-        for rinex_file in args.rinex_files:
+        for rinex_file in files_for_station:
             rinex_path = Path(rinex_file)
             if not rinex_path.exists():
                 print(f"Warning: RINEX file {rinex_file} not found", file=sys.stderr)

--- a/src/tostools/tosGPS.py
+++ b/src/tostools/tosGPS.py
@@ -24,6 +24,7 @@ from .rinex.editor import update_rinex_files
 from .rinex.reader import (
     extract_header_info,
     find_most_recent_rinex,
+    find_station_archive_range,
     read_rinex_header,
 )
 from .rinex.validator import compare_rinex_to_tos
@@ -587,6 +588,38 @@ Examples:
         help="Save human-readable data quality report to file (e.g., tos_quality_report.txt)",
     )
 
+    # Station timespan subcommand: TOS start/end vs archive first/last file dates
+    timespan_parser = subparsers.add_parser(
+        "timespan",
+        help="Compare TOS station start/end dates with first/last files in the archive",
+        epilog="""
+Examples:
+  tosGPS timespan HAUC
+  tosGPS timespan HAUC REYK HOFN
+  tosGPS timespan HAUC --rinex-base-dir /mnt_data/rawgpsdata
+        """,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    timespan_parser.add_argument("stations", nargs="+", help="List of stations")
+    timespan_parser.add_argument(
+        "--rinex-base-dir",
+        type=str,
+        default="/mnt_data/rawgpsdata",
+        help="Archive root (default: /mnt_data/rawgpsdata)",
+    )
+    timespan_parser.add_argument(
+        "--start-tolerance-days",
+        type=int,
+        default=1,
+        help="Max |TOS start - archive first| in days before flagging (default: 1)",
+    )
+    timespan_parser.add_argument(
+        "--end-tolerance-days",
+        type=int,
+        default=7,
+        help="Max |TOS end - archive last| in days before flagging when station is closed in TOS (default: 7)",
+    )
+
     # Site log generation subcommand
     sitelog_parser = subparsers.add_parser(
         "sitelog",
@@ -876,6 +909,8 @@ Examples:
     # Handle different subcommands
     if args.subcommand == "rinex":
         _handle_rinex_subcommand(args, stations, url, log_level)
+    elif args.subcommand == "timespan":
+        _handle_timespan_subcommand(args, stations, url, log_level)
     elif args.subcommand == "sitelog":
         _handle_sitelog_subcommand(args, stations, url, log_level)
     elif args.subcommand == "syncMeta":
@@ -1210,6 +1245,111 @@ def _handle_rinex_subcommand(args, stations, url, log_level):
             print(f"\n✓ QC report saved to {args.report}", file=sys.stderr)
         except Exception as e:
             print(f"Error writing report: {e}", file=sys.stderr)
+
+
+def _fmt_date(dt):
+    """Format a ``datetime`` as ``YYYY-MM-DD``, or ``"—"`` when ``None``."""
+    return dt.strftime("%Y-%m-%d") if dt else "—"
+
+
+def _delta_days(a, b):
+    """Return ``|a - b|`` in whole days, or ``None`` if either date is missing."""
+    if a is None or b is None:
+        return None
+    return abs((a.date() - b.date()).days)
+
+
+def _coerce_to_datetime(value):
+    """Best-effort coercion of a TOS date field to a ``datetime``.
+
+    Accepts ``datetime`` instances, ISO-8601 strings, and bare ``YYYY-MM-DD``
+    strings. Returns ``None`` for missing or unparseable values.
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    try:
+        return datetime.fromisoformat(str(value))
+    except ValueError:
+        try:
+            return datetime.strptime(str(value)[:10], "%Y-%m-%d")
+        except ValueError:
+            return None
+
+
+def _handle_timespan_subcommand(args, stations, url, log_level):
+    """Compare TOS station start/end dates with first/last files in the archive."""
+    for station in stations:
+        print(f"\n=== {station} ===")
+
+        try:
+            station_data = gpsqc.gps_metadata(station, url, loglevel=log_level.value)
+        except Exception as e:
+            print(f"  TOS error: {e}", file=sys.stderr)
+            continue
+        if not station_data:
+            print(f"  No TOS metadata for {station}", file=sys.stderr)
+            continue
+
+        sessions = station_data.get("device_history", []) or []
+        tos_end_raw = sessions[-1].get("time_to") if sessions else None
+        tos_active = tos_end_raw is None and bool(sessions)
+
+        tos_start = _coerce_to_datetime(station_data.get("date_start"))
+        tos_end = _coerce_to_datetime(tos_end_raw)
+
+        archive = find_station_archive_range(station, base_dir=args.rinex_base_dir)
+        arch_first = archive.get("first")
+        arch_last = archive.get("last")
+
+        # Start comparison
+        start_delta = _delta_days(tos_start, arch_first)
+        if tos_start is None:
+            start_flag = "✗ no TOS start"
+        elif arch_first is None:
+            start_flag = "✗ no archive files"
+        elif start_delta <= args.start_tolerance_days:
+            start_flag = f"✓ (Δ {start_delta} d)"
+        else:
+            start_flag = f"⚠ (Δ {start_delta} d)"
+        print(
+            f"  TOS start:  {_fmt_date(tos_start):<12} "
+            f"Archive first: {_fmt_date(arch_first):<12} {start_flag}"
+        )
+
+        # End comparison
+        if tos_active:
+            print(
+                f"  TOS end:    {'active':<12} "
+                f"Archive last:  {_fmt_date(arch_last):<12} "
+                "active in TOS; latest file reported"
+            )
+        else:
+            end_delta = _delta_days(tos_end, arch_last)
+            if tos_end is None:
+                end_flag = "✗ no TOS end"
+            elif arch_last is None:
+                end_flag = "✗ no archive files"
+            elif end_delta <= args.end_tolerance_days:
+                end_flag = f"✓ (Δ {end_delta} d)"
+            else:
+                end_flag = f"⚠ (Δ {end_delta} d)"
+            print(
+                f"  TOS end:    {_fmt_date(tos_end):<12} "
+                f"Archive last:  {_fmt_date(arch_last):<12} {end_flag}"
+            )
+
+        # Per-kind breakdown
+        for kind in ("15s_24hr", "1Hz_1hr"):
+            k = archive.get(kind, {})
+            if k.get("first") or k.get("last"):
+                print(
+                    f"    {kind:<9} {_fmt_date(k.get('first'))} "
+                    f"→ {_fmt_date(k.get('last'))}"
+                )
+            else:
+                print(f"    {kind:<9} (no files)")
 
 
 def _handle_sitelog_subcommand(args, stations, url, log_level):


### PR DESCRIPTION
## Summary

Adds a new `tosGPS timespan STATIONS...` subcommand that, per station, compares the TOS `date_start` (and last-session `time_to`) against the earliest and latest files in the raw GPS archive. For stations still active in TOS, the archive's latest file is shown without flagging.

The archive scan covers two layouts under `<base_dir>/<YYYY>/<mon>/<STA>/`:
- `15s_24hr/rinex/` — daily Hatanaka RINEX
- `1Hz_1hr/raw/`   — hourly raw (Trimble T02)

The 1 Hz raw kind often captures the true first/last minute of a station's service, so it's scanned in addition to the daily RINEX.

## Example output

```
=== HAUC ===
  TOS start:  2007-09-02   Archive first: 2007-09-02   ✓ (Δ 0 d)
  TOS end:    active       Archive last:  2026-04-21   active in TOS; latest file reported
    15s_24hr  2007-09-02 → 2026-04-21
    1Hz_1hr   2009-01-01 → 2018-02-23
```

## Changes

- `find_station_archive_range()` and `_parse_hourly_raw_date()` in `rinex/reader.py`
- `timespan` subparser, dispatcher, and handler in `tosGPS.py`
- `--rinex-base-dir`, `--start-tolerance-days` (default 1), `--end-tolerance-days` (default 7)

## Depends on

Stacked on #9 (auto-resolve) — reuses the `_parse_daily_rinex_date` / `_scan_dir_dates` / `MONTHS` helpers introduced there. Please merge #9 first; GitHub will retarget this PR's base automatically.

## Test plan

- [x] Normal active station — start match, end reported without flag
- [x] Closed station — end mismatch flagged with day delta
- [x] Station missing from TOS — graceful skip with warning
- [x] Station with missing TOS start — ✗ flag, no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)