### PR TITLE
feat(cli): tos owners list (step 2 of device-warehouse)

### DIFF
--- a/src/tostools/api/tos_client.py
+++ b/src/tostools/api/tos_client.py
@@ -376,6 +376,27 @@ class TOSClient:
         result = self._make_request(f"entity_contacts/{entity_id}/")
         return result if result else []
 
+    def basic_search(self, search_term: str) -> List[Dict[str, Any]]:
+        """
+        Substring search across TOS attribute values.
+
+        POSTs to /basic_search/ and returns the raw hit list. Each hit
+        describes an attribute (e.g. code='owner', value_varchar='...')
+        attached to an entity, plus the entity it belongs to. Used by the
+        owners module to verify that recognized owner labels are still in
+        use in TOS.
+
+        Args:
+            search_term: substring to match (case- and diacritic-sensitive)
+
+        Returns:
+            List of attribute hits; empty list on error or no match.
+        """
+        result = self._make_request(
+            "/basic_search/", method="POST", data={"search_term": search_term}
+        )
+        return result if isinstance(result, list) else []
+
     def get_device_sessions(
         self, device_history: Dict[str, Any]
     ) -> List[Dict[str, Any]]:

--- a/src/tostools/api/tos_writer.py
+++ b/src/tostools/api/tos_writer.py
@@ -366,18 +366,21 @@ class TOSWriter:
         params: Optional[Dict[str, Any]] = None,
         *,
         _retry: bool = True,
+        _force_send: bool = False,
     ) -> Any:
         """Send an authenticated HTTP request.
 
         GET requests are always sent (reads are safe). Mutating requests
-        (POST, PATCH, PUT, DELETE) are intercepted in dry-run mode.
+        (POST, PATCH, PUT, DELETE) are intercepted in dry-run mode unless
+        ``_force_send=True`` — used for read-only POST endpoints like
+        ``/basic_search/``.
         """
         self._ensure_authenticated()
 
         url = f"{self.base_url}/{endpoint.lstrip('/')}"
         is_mutating = method.upper() not in ("GET", "HEAD", "OPTIONS")
 
-        if is_mutating and self.dry_run:
+        if is_mutating and self.dry_run and not _force_send:
             self._logger.info(
                 "[DRY-RUN] %s %s — payload: %s",
                 method.upper(),
@@ -444,6 +447,54 @@ class TOSWriter:
         """Return the full history dict for an entity."""
         return self._request("GET", f"/history/entity/{id_entity}/")
 
+    def find_device_by_serial(
+        self,
+        entity_subtype: str,
+        serial_number: str,
+    ) -> Optional[Dict[str, Any]]:
+        """Look up a device entity by serial number, filtered to a subtype.
+
+        Uses ``POST /basic_search/`` to find entities by serial_number, then
+        ``GET /entity/{id}/`` on each candidate to verify the
+        ``code_entity_subtype`` matches. Match is exact (case-sensitive, no
+        whitespace normalization).
+
+        Args:
+            entity_subtype: e.g. ``"gnss_receiver"``, ``"antenna"``, ``"radome"``.
+            serial_number: serial to search for. Empty/None returns ``None``.
+
+        Returns:
+            First matching entity dict (``id_entity``, ``code_entity_subtype``,
+            ``attributes``, ...) or ``None`` if no device with that
+            (subtype, serial) exists.
+        """
+        if not serial_number:
+            return None
+
+        results = self._request(
+            "POST",
+            "/basic_search/",
+            data={"search_term": serial_number},
+            _force_send=True,
+        )
+        if not isinstance(results, list):
+            return None
+
+        for hit in results:
+            if hit.get("code") != "serial_number":
+                continue
+            if hit.get("distance") != 0:
+                continue
+            if hit.get("value_varchar") != serial_number:
+                continue
+            device_id = hit.get("id_lvl_three")
+            if not device_id:
+                continue
+            entity = self._request("GET", f"/entity/{device_id}/")
+            if entity and entity.get("code_entity_subtype") == entity_subtype:
+                return entity
+        return None
+
     def get_attribute_values(
         self,
         id_entity: int,
@@ -490,6 +541,64 @@ class TOSWriter:
                 "/entities",
                 data={"entity_subtype": entity_subtype, "attributes": attributes},
             )
+
+    def create_device(
+        self,
+        entity_subtype: str,
+        attributes: List[Dict[str, Any]],
+        *,
+        force: bool = False,
+        dry_run: Optional[bool] = None,
+    ) -> Any:
+        """Create a device entity (gnss_receiver, antenna, radome, ...).
+
+        Wraps :meth:`create_entity` with a duplicate-serial guard:
+        :meth:`find_device_by_serial` is called before POSTing. A
+        :class:`ValueError` is raised if the (subtype, serial_number) pair
+        already exists. Pass ``force=True`` to override — should be a manual
+        conscious decision (warranty replacement, manufacturer reusing a
+        serial across product lines, etc.).
+
+        Args:
+            entity_subtype: device subtype, e.g. ``"gnss_receiver"``.
+            attributes: list of ``{code, value, date_from, date_to?}`` dicts;
+                must include a ``serial_number`` attribute.
+            force: skip the duplicate-serial guard.
+            dry_run: per-call override of instance-level dry_run.
+
+        Returns:
+            API response dict from :meth:`create_entity`, or
+            :class:`DryRunResult` in dry-run mode.
+
+        Raises:
+            ValueError: no ``serial_number`` attribute in ``attributes``;
+                or duplicate (subtype, serial_number) exists and not ``force``.
+        """
+        serial = next(
+            (a.get("value") for a in attributes if a.get("code") == "serial_number"),
+            None,
+        )
+        if serial is None or serial == "":
+            raise ValueError(
+                "create_device requires a non-empty 'serial_number' attribute "
+                "(use create_entity to bypass the duplicate-serial guard)"
+            )
+
+        if not force:
+            existing = self.find_device_by_serial(entity_subtype, str(serial))
+            if existing is not None:
+                existing_id = existing.get("id_entity")
+                raise ValueError(
+                    f"Device with serial_number={serial!r} already exists "
+                    f"as {entity_subtype} (id_entity={existing_id}). "
+                    f"Pass force=True to add a duplicate."
+                )
+
+        return self.create_entity(
+            entity_subtype=entity_subtype,
+            attributes=attributes,
+            dry_run=dry_run,
+        )
 
     @staticmethod
     def _tos_date(dt: Optional[str]) -> Optional[str]:

--- a/src/tostools/owners.py
+++ b/src/tostools/owners.py
@@ -1,0 +1,109 @@
+"""TOS device owners — curated allow-list with TOS-verification refresh.
+
+Device ownership in TOS is a free-text string stored as ``value_varchar`` on a
+``code=owner`` attribute attached to device entities (antenna, gnss_receiver,
+radome, etc.). There is no separate "owner entity" — the seed list below is
+the canonical set of recognized owner labels used across the IMO GNSS network.
+
+The local cache (default ``~/.config/tostools/owners.yaml``) holds the curated
+list. ``OwnersCache.refresh`` verifies each known owner is still present in TOS
+via ``basic_search``; it does NOT discover new owner strings. New entries must
+be added manually (edit the cache file) or via a future ``tos owners add``
+subcommand.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, List, Optional, Tuple
+
+import yaml
+
+from .api.tos_client import TOSClient
+
+# Canonical seed list of recognized owner labels.
+KNOWN_OWNERS: Tuple[str, ...] = (
+    "Veðurstofa Íslands",
+    "Jarðeðlismælihópur",
+    "Vatnamælihópur",
+    "Veðurmælihópur",
+    "Cambridge",
+    "ÍSOR",
+)
+
+DEFAULT_CACHE_PATH = Path.home() / ".config" / "tostools" / "owners.yaml"
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RefreshResult:
+    """Outcome of a refresh probe against TOS."""
+
+    in_use: List[str] = field(default_factory=list)
+    missing: List[str] = field(default_factory=list)
+
+
+class OwnersCache:
+    """File-backed cache of recognized TOS device owner strings."""
+
+    def __init__(self, cache_path: Optional[Path] = None) -> None:
+        self.cache_path = Path(cache_path) if cache_path else DEFAULT_CACHE_PATH
+
+    def load(self) -> List[str]:
+        """Return the sorted list of owners.
+
+        Falls back to ``KNOWN_OWNERS`` when no cache file exists or the file
+        does not declare an ``owners`` list.
+        """
+        if not self.cache_path.exists():
+            return sorted(KNOWN_OWNERS)
+        with self.cache_path.open("r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+        owners = data.get("owners") if isinstance(data, dict) else None
+        if not owners:
+            return sorted(KNOWN_OWNERS)
+        return sorted({str(o) for o in owners})
+
+    def save(self, owners: Iterable[str]) -> None:
+        """Write owners list to the cache file (creates parent dirs)."""
+        self.cache_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {"owners": sorted({str(o) for o in owners})}
+        with self.cache_path.open("w", encoding="utf-8") as f:
+            yaml.safe_dump(payload, f, allow_unicode=True, sort_keys=False)
+
+    def refresh(self, client: TOSClient) -> RefreshResult:
+        """Verify each ``KNOWN_OWNERS`` entry is still in use in TOS.
+
+        Probes ``basic_search`` once per seed name and looks for at least one
+        hit with ``code='owner'``, ``value_varchar`` matching the seed exactly,
+        and ``distance=0`` (TOS substring match score; 0 means exact value).
+
+        This is verify-only — it does not discover new owner strings. The
+        cache is rewritten with the in-use owners so missing seeds drop out.
+        """
+        in_use: List[str] = []
+        missing: List[str] = []
+        for name in KNOWN_OWNERS:
+            hits = client.basic_search(name)
+            if any(
+                h.get("code") == "owner"
+                and h.get("value_varchar") == name
+                and h.get("distance") == 0
+                for h in hits
+            ):
+                in_use.append(name)
+            else:
+                missing.append(name)
+                logger.warning("Owner %r not found in TOS basic_search hits", name)
+        self.save(in_use)
+        return RefreshResult(in_use=in_use, missing=missing)
+
+
+def find_by_name(name: str, cache: Optional[OwnersCache] = None) -> Optional[str]:
+    """Exact-match lookup against the cache. Returns the owner or None."""
+    c = cache if cache is not None else OwnersCache()
+    owners = c.load()
+    return name if name in owners else None

--- a/src/tostools/tos.py
+++ b/src/tostools/tos.py
@@ -1700,8 +1700,85 @@ def generateFDSNXML(station_list=None):
     # inv.write("station.txt", format="stationtxt")
 
 
-if __name__ == "__main__":
+KNOWN_SUBCOMMANDS = {"owners"}
 
+
+def _owners_main(argv):
+    """Handle `tos owners ...` subcommands."""
+    from .owners import KNOWN_OWNERS, OwnersCache
+    from .api.tos_client import TOSClient
+
+    p = argparse.ArgumentParser(
+        prog="tos owners",
+        description="Manage the recognized TOS device-owner allow-list.",
+    )
+    sub = p.add_subparsers(dest="action", required=True)
+
+    p_list = sub.add_parser("list", help="List recognized owner labels.")
+    p_list.add_argument(
+        "--refresh",
+        action="store_true",
+        help="Probe TOS to verify each owner is still in use; rewrites the cache.",
+    )
+    p_list.add_argument(
+        "--json", action="store_true", help="Emit JSON instead of plain text."
+    )
+    p_list.add_argument(
+        "--cache-path",
+        help="Override the cache file path (default: ~/.config/tostools/owners.yaml).",
+    )
+    p_list.add_argument(
+        "--server",
+        default="vi-api.vedur.is",
+        help="TOS API host (default: vi-api.vedur.is).",
+    )
+    p_list.add_argument("--port", type=int, default=443)
+
+    args = p.parse_args(argv)
+
+    if args.action != "list":
+        p.error(f"unknown action: {args.action}")
+        return 2
+
+    cache_path = args.cache_path
+    cache = OwnersCache(cache_path) if cache_path else OwnersCache()
+
+    if args.refresh:
+        scheme = "https" if args.port == 443 else "http"
+        base_url = f"{scheme}://{args.server}:{args.port}/tos/v1"
+        client = TOSClient(base_url=base_url)
+        result = cache.refresh(client)
+        owners = result.in_use
+        missing = result.missing
+    else:
+        owners = cache.load()
+        missing = []
+
+    if args.json:
+        import json as _json
+
+        payload = {
+            "owners": owners,
+            "missing": missing,
+            "cache_path": str(cache.cache_path),
+            "seed": list(KNOWN_OWNERS),
+        }
+        print(_json.dumps(payload, ensure_ascii=False, indent=2))
+    else:
+        for o in owners:
+            print(o)
+        if missing:
+            print(
+                "\nMissing from TOS (not found via basic_search):",
+                file=sys.stderr,
+            )
+            for o in missing:
+                print(f"  - {o}", file=sys.stderr)
+    return 0
+
+
+def _legacy_main(argv):
+    """Pre-subcommand flat-arg behavior — kept for backward compatibility."""
     parser = argparse.ArgumentParser(
         add_help=True, description="TOS tools - Version 0.3"
     )
@@ -1764,14 +1841,26 @@ if __name__ == "__main__":
     # parser.add_argument('-p', '--pdf', action="store_true", help='Export PDF')
     # parser.add_argument('-l', '--language', help='Language for output. Default IS')
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     # Check args
-    if not len(sys.argv) > 1:
-        logging.error("No arguments passed, see --help")
-        sys.exit(2)
+    if not argv:
+        parser.print_help(sys.stderr)
+        return 2
 
-    elif args.serial_number:
+    # Detect flag-only invocation (no action selected, no identifiers).
+    action_selected = (
+        args.serial_number
+        or args.galvos
+        or args.sc3ml
+        or args.fdsnxml
+        or bool(args.identifiers)
+    )
+    if not action_selected:
+        parser.print_help(sys.stderr)
+        return 2
+
+    if args.serial_number:
         if args.exclude:
             logging.warning("Ignoring option --exclude with serial_number search")
         devices = []
@@ -1809,7 +1898,7 @@ if __name__ == "__main__":
                 logging.critical(
                     f"Unsupported XML schema version {args.schema_version}"
                 )
-                sys.exit()
+                return 2
 
         if args.identifiers:
             sc3ml = generateSC3ML(args.identifiers, args.schema_version)
@@ -1861,3 +1950,20 @@ if __name__ == "__main__":
 
         for station in stations:
             display(station, args.output, args.tablefmt)
+
+    return 0
+
+
+def main(argv=None):
+    """Entry point — dispatches to `tos owners ...` or the legacy flat-arg CLI."""
+    argv = list(sys.argv[1:] if argv is None else argv)
+    if argv and argv[0] in KNOWN_SUBCOMMANDS:
+        subcmd = argv[0]
+        rest = argv[1:]
+        if subcmd == "owners":
+            return _owners_main(rest)
+    return _legacy_main(argv)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_owners.py
+++ b/tests/test_owners.py
@@ -1,0 +1,196 @@
+"""Unit tests for the owners module — no network required."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+from unittest.mock import MagicMock
+
+import yaml
+
+from tostools.owners import (
+    KNOWN_OWNERS,
+    OwnersCache,
+    RefreshResult,
+    find_by_name,
+)
+
+
+# ---------------------------------------------------------------------------
+# OwnersCache.load
+# ---------------------------------------------------------------------------
+
+
+def test_load_returns_seed_when_no_cache(tmp_path: Path) -> None:
+    cache = OwnersCache(tmp_path / "missing.yaml")
+    assert cache.load() == sorted(KNOWN_OWNERS)
+
+
+def test_load_returns_cache_contents(tmp_path: Path) -> None:
+    p = tmp_path / "owners.yaml"
+    p.write_text(yaml.safe_dump({"owners": ["Foo", "Bar"]}, allow_unicode=True))
+    cache = OwnersCache(p)
+    assert cache.load() == ["Bar", "Foo"]
+
+
+def test_load_falls_back_when_owners_key_empty(tmp_path: Path) -> None:
+    p = tmp_path / "owners.yaml"
+    p.write_text(yaml.safe_dump({"owners": []}, allow_unicode=True))
+    cache = OwnersCache(p)
+    assert cache.load() == sorted(KNOWN_OWNERS)
+
+
+def test_load_falls_back_when_file_empty(tmp_path: Path) -> None:
+    p = tmp_path / "owners.yaml"
+    p.write_text("")
+    cache = OwnersCache(p)
+    assert cache.load() == sorted(KNOWN_OWNERS)
+
+
+def test_load_handles_unicode_owner_names(tmp_path: Path) -> None:
+    p = tmp_path / "owners.yaml"
+    p.write_text(
+        yaml.safe_dump(
+            {"owners": ["Veðurstofa Íslands", "Jarðeðlismælihópur"]},
+            allow_unicode=True,
+        )
+    )
+    cache = OwnersCache(p)
+    loaded = cache.load()
+    assert "Veðurstofa Íslands" in loaded
+    assert "Jarðeðlismælihópur" in loaded
+
+
+# ---------------------------------------------------------------------------
+# OwnersCache.save
+# ---------------------------------------------------------------------------
+
+
+def test_save_creates_parent_dirs(tmp_path: Path) -> None:
+    target = tmp_path / "nested" / "dir" / "owners.yaml"
+    cache = OwnersCache(target)
+    cache.save(["A", "B"])
+    assert target.exists()
+    data = yaml.safe_load(target.read_text())
+    assert data == {"owners": ["A", "B"]}
+
+
+def test_save_deduplicates(tmp_path: Path) -> None:
+    p = tmp_path / "owners.yaml"
+    OwnersCache(p).save(["Foo", "Foo", "Bar"])
+    data = yaml.safe_load(p.read_text())
+    assert data == {"owners": ["Bar", "Foo"]}
+
+
+def test_save_preserves_unicode(tmp_path: Path) -> None:
+    p = tmp_path / "owners.yaml"
+    OwnersCache(p).save(["Veðurstofa Íslands", "ÍSOR"])
+    text = p.read_text()
+    assert "Veðurstofa Íslands" in text  # not escaped to \uXXXX
+
+
+# ---------------------------------------------------------------------------
+# OwnersCache.refresh
+# ---------------------------------------------------------------------------
+
+
+def _hit(name: str, code: str = "owner", distance: int = 0) -> dict:
+    return {"code": code, "value_varchar": name, "distance": distance}
+
+
+def test_refresh_marks_all_in_use_when_hits_match(tmp_path: Path) -> None:
+    client = MagicMock()
+    client.basic_search.side_effect = lambda name: [_hit(name)]
+
+    cache = OwnersCache(tmp_path / "owners.yaml")
+    result = cache.refresh(client)
+
+    assert isinstance(result, RefreshResult)
+    assert sorted(result.in_use) == sorted(KNOWN_OWNERS)
+    assert result.missing == []
+    assert client.basic_search.call_count == len(KNOWN_OWNERS)
+
+
+def test_refresh_flags_missing_owners(tmp_path: Path) -> None:
+    def fake_search(name: str) -> List[dict]:
+        # Cambridge has no hits
+        return [] if name == "Cambridge" else [_hit(name)]
+
+    client = MagicMock()
+    client.basic_search.side_effect = fake_search
+
+    cache = OwnersCache(tmp_path / "owners.yaml")
+    result = cache.refresh(client)
+
+    assert result.missing == ["Cambridge"]
+    assert "Cambridge" not in result.in_use
+
+
+def test_refresh_ignores_non_owner_hits(tmp_path: Path) -> None:
+    """A hit with code != 'owner' must not count as a match."""
+    client = MagicMock()
+    client.basic_search.return_value = [_hit("Cambridge", code="description")]
+
+    cache = OwnersCache(tmp_path / "owners.yaml")
+    result = cache.refresh(client)
+
+    # All seeds appear missing because no hit has code='owner'
+    assert sorted(result.missing) == sorted(KNOWN_OWNERS)
+    assert result.in_use == []
+
+
+def test_refresh_ignores_partial_matches(tmp_path: Path) -> None:
+    """Hits with distance != 0 (substring partial) must not count."""
+    client = MagicMock()
+    client.basic_search.return_value = [_hit("Cambridge", distance=4)]
+
+    cache = OwnersCache(tmp_path / "owners.yaml")
+    result = cache.refresh(client)
+
+    assert sorted(result.missing) == sorted(KNOWN_OWNERS)
+
+
+def test_refresh_persists_in_use_owners(tmp_path: Path) -> None:
+    def fake_search(name: str) -> List[dict]:
+        return [] if name == "Cambridge" else [_hit(name)]
+
+    client = MagicMock()
+    client.basic_search.side_effect = fake_search
+
+    p = tmp_path / "owners.yaml"
+    OwnersCache(p).refresh(client)
+
+    data = yaml.safe_load(p.read_text())
+    assert "Cambridge" not in data["owners"]
+    assert "Veðurstofa Íslands" in data["owners"]
+
+
+# ---------------------------------------------------------------------------
+# find_by_name
+# ---------------------------------------------------------------------------
+
+
+def test_find_by_name_exact_match(tmp_path: Path) -> None:
+    cache = OwnersCache(tmp_path / "missing.yaml")  # falls back to seed
+    assert find_by_name("Veðurstofa Íslands", cache=cache) == "Veðurstofa Íslands"
+
+
+def test_find_by_name_missing_returns_none(tmp_path: Path) -> None:
+    cache = OwnersCache(tmp_path / "missing.yaml")
+    assert find_by_name("Acme Co", cache=cache) is None
+
+
+def test_find_by_name_is_case_sensitive(tmp_path: Path) -> None:
+    cache = OwnersCache(tmp_path / "missing.yaml")
+    assert find_by_name("veðurstofa íslands", cache=cache) is None
+
+
+def test_find_by_name_uses_default_cache_when_none_passed(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """No cache arg → uses DEFAULT_CACHE_PATH; fallback seed still resolves."""
+    monkeypatch.setattr(
+        "tostools.owners.DEFAULT_CACHE_PATH", tmp_path / "owners.yaml"
+    )
+    assert find_by_name("Veðurstofa Íslands") == "Veðurstofa Íslands"
+    assert find_by_name("definitely-not-an-owner") is None

--- a/tests/test_tos_writer.py
+++ b/tests/test_tos_writer.py
@@ -338,3 +338,187 @@ def test_request_retries_on_401():
 
     assert mock_req.call_count == 2
     assert result == {"ok": True}
+
+
+# ---------------------------------------------------------------------------
+# TOSWriter — find_device_by_serial / create_device duplicate-serial guard
+# ---------------------------------------------------------------------------
+
+
+def _basic_search_hit(
+    serial: str,
+    device_id: int,
+    code: str = "serial_number",
+    distance: int = 0,
+) -> dict:
+    return {
+        "code": code,
+        "value_varchar": serial,
+        "distance": distance,
+        "id_lvl_three": device_id,
+    }
+
+
+def test_find_device_by_serial_returns_match_when_subtype_matches():
+    w = _logged_in_writer(dry_run=False)
+    search_results = [_basic_search_hit("SN123", device_id=999)]
+    entity = {
+        "id_entity": 999,
+        "code_entity_subtype": "gnss_receiver",
+        "attributes": [],
+    }
+
+    with patch.object(w, "_request") as mock_req:
+        mock_req.side_effect = [search_results, entity]
+        result = w.find_device_by_serial("gnss_receiver", "SN123")
+
+    assert result is entity
+    assert mock_req.call_count == 2
+    # First call should be the search; second the entity GET
+    assert mock_req.call_args_list[0].args[0] == "POST"
+    assert "/basic_search" in mock_req.call_args_list[0].args[1]
+    assert mock_req.call_args_list[1].args[0] == "GET"
+    assert mock_req.call_args_list[1].args[1] == "/entity/999/"
+
+
+def test_find_device_by_serial_returns_none_when_no_hits():
+    w = _logged_in_writer(dry_run=False)
+    with patch.object(w, "_request", return_value=[]):
+        assert w.find_device_by_serial("gnss_receiver", "SN-MISSING") is None
+
+
+def test_find_device_by_serial_skips_subtype_mismatch():
+    w = _logged_in_writer(dry_run=False)
+    search_results = [_basic_search_hit("SN123", device_id=999)]
+    entity_wrong_subtype = {
+        "id_entity": 999,
+        "code_entity_subtype": "antenna",
+        "attributes": [],
+    }
+
+    with patch.object(w, "_request") as mock_req:
+        mock_req.side_effect = [search_results, entity_wrong_subtype]
+        result = w.find_device_by_serial("gnss_receiver", "SN123")
+
+    assert result is None
+
+
+def test_find_device_by_serial_filters_distance_and_code():
+    w = _logged_in_writer(dry_run=False)
+    search_results = [
+        # wrong code (matches a model field, not a serial)
+        _basic_search_hit("SN123", device_id=111, code="model"),
+        # right code but distance > 0 (fuzzy match)
+        _basic_search_hit("SN123", device_id=222, distance=2),
+        # exact value-mismatch even though code matches
+        {"code": "serial_number", "value_varchar": "SN999", "distance": 0,
+         "id_lvl_three": 333},
+        # the real exact match
+        _basic_search_hit("SN123", device_id=444),
+    ]
+    entity = {"id_entity": 444, "code_entity_subtype": "gnss_receiver"}
+
+    with patch.object(w, "_request") as mock_req:
+        mock_req.side_effect = [search_results, entity]
+        result = w.find_device_by_serial("gnss_receiver", "SN123")
+
+    assert result is entity
+    # Only 1 entity GET — confirms the other hits were filtered out
+    get_calls = [c for c in mock_req.call_args_list if c.args[0] == "GET"]
+    assert len(get_calls) == 1
+
+
+def test_find_device_by_serial_empty_serial_short_circuits():
+    w = _logged_in_writer(dry_run=False)
+    with patch.object(w, "_request") as mock_req:
+        assert w.find_device_by_serial("gnss_receiver", "") is None
+    mock_req.assert_not_called()
+
+
+def test_find_device_by_serial_search_runs_in_dry_run_mode():
+    """The basic_search POST must bypass dry-run interception."""
+    w = _logged_in_writer(dry_run=True)
+    with patch("requests.request") as mock_req:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.content = b"[]"
+        mock_resp.json.return_value = []
+        mock_resp.raise_for_status = MagicMock()
+        mock_req.return_value = mock_resp
+        result = w.find_device_by_serial("gnss_receiver", "SN123")
+
+    assert result is None
+    # Confirms an actual HTTP POST was sent despite dry_run=True
+    assert mock_req.called
+    assert mock_req.call_args.args[0] == "POST"
+
+
+def test_create_device_rejects_duplicate_serial():
+    w = _logged_in_writer(dry_run=True)
+    existing = {
+        "id_entity": 19140,
+        "code_entity_subtype": "gnss_receiver",
+        "attributes": [],
+    }
+    with patch.object(w, "find_device_by_serial", return_value=existing):
+        with pytest.raises(ValueError, match=r"already exists.*id_entity=19140"):
+            w.create_device(
+                "gnss_receiver",
+                [{"code": "serial_number", "value": "SN123",
+                  "date_from": "2026-05-10T00:00:00"}],
+            )
+
+
+def test_create_device_force_bypasses_duplicate_check():
+    w = _logged_in_writer(dry_run=True)
+    with patch.object(w, "find_device_by_serial") as mock_find:
+        with patch.object(w, "create_entity", return_value={"id_entity": 99}) as mock_create:
+            result = w.create_device(
+                "gnss_receiver",
+                [{"code": "serial_number", "value": "SN123",
+                  "date_from": "2026-05-10T00:00:00"}],
+                force=True,
+            )
+
+    mock_find.assert_not_called()
+    mock_create.assert_called_once()
+    assert result == {"id_entity": 99}
+
+
+def test_create_device_creates_when_no_duplicate():
+    w = _logged_in_writer(dry_run=True)
+    with patch.object(w, "find_device_by_serial", return_value=None):
+        with patch.object(w, "create_entity",
+                          return_value=DryRunResult("POST", "/entities", {})) as mock_create:
+            result = w.create_device(
+                "antenna",
+                [{"code": "serial_number", "value": "ANT-1",
+                  "date_from": "2026-05-10T00:00:00"},
+                 {"code": "model", "value": "TRM57971.00",
+                  "date_from": "2026-05-10T00:00:00"}],
+            )
+
+    mock_create.assert_called_once()
+    call = mock_create.call_args
+    assert call.kwargs["entity_subtype"] == "antenna"
+    assert isinstance(result, DryRunResult)
+
+
+def test_create_device_raises_without_serial():
+    w = _logged_in_writer(dry_run=True)
+    with pytest.raises(ValueError, match="non-empty 'serial_number'"):
+        w.create_device(
+            "gnss_receiver",
+            [{"code": "model", "value": "SEPT POLARX5",
+              "date_from": "2026-05-10T00:00:00"}],
+        )
+
+
+def test_create_device_raises_with_empty_serial():
+    w = _logged_in_writer(dry_run=True)
+    with pytest.raises(ValueError, match="non-empty 'serial_number'"):
+        w.create_device(
+            "gnss_receiver",
+            [{"code": "serial_number", "value": "",
+              "date_from": "2026-05-10T00:00:00"}],
+        )


### PR DESCRIPTION
## Summary
Second step of the [tostools device-warehouse interface](https://github.com/bennigo/tostools/blob/master/CLAUDE.md) work. Adds the curated TOS device-owner allow-list and a `tos owners list` subcommand. Step 3 (`tos device add --owner …`) will validate against this list.

This PR contains **two commits**:
1. `4b0ff4d` — step 1 (`find_device_by_serial` + `create_device` duplicate guard) — already complete on local branch, surfaced here for the first time.
2. `279c5ea` — step 2 (this work).

Reviewer can merge as-is or split into sequential PRs if preferred.

## What changes

**New module** `src/tostools/owners.py`:
- `KNOWN_OWNERS` seed (Veðurstofa Íslands, Jarðeðlismælihópur, Vatnamælihópur, Veðurmælihópur, Cambridge, ÍSOR)
- `OwnersCache` backed by `~/.config/tostools/owners.yaml`
- `refresh()` verifies seeds against TOS via `basic_search` — **verify-only**, does NOT discover new owner strings
- `find_by_name()` exact-match lookup

**TOSClient**: new `basic_search(term)` — thin wrapper over POST `/basic_search/`. Used by `refresh()` and reusable by later steps.

**`tos.py` CLI restructure**:
- Fixes the broken `tos` entry point (`pyproject.toml` declared `tostools.tos:main` but no `main()` existed)
- Manual subcommand dispatcher (`KNOWN_SUBCOMMANDS = {"owners"}`) avoids argparse subparser/positional ambiguity — important because the legacy `tos` CLI has positional `identifiers` that conflicts with subparser detection
- Existing flat-arg behavior preserved verbatim in `_legacy_main()`
- Fixes a latent bug: `tos --output json` (flag-only, no identifiers) silently exited 0; now prints help and exits 2

## Validated against live TOS
```bash
$ tos owners list --refresh
Veðurstofa Íslands
Jarðeðlismælihópur
Vatnamælihópur
Veðurmælihópur
Cambridge
ÍSOR
```
All 6 seeds resolve via `basic_search` with exact (distance=0) hits on `code=owner` attributes.

## Test plan
- [x] 17 new unit tests for `owners.py` — load/save/refresh/find_by_name with `tmp_path`, refresh mocked
- [x] `tos owners list` — prints sorted seed when no cache exists
- [x] `tos owners list --json` — JSON output with seed, cache_path, missing fields
- [x] `tos owners list --refresh --cache-path /tmp/...` — verified against live TOS, all 6 seeds in_use, cache file written
- [x] `tos owners --help`, `tos owners`, `tos owners nonsense` — sensible error/usage
- [x] `tos` (no args), `tos --output json` (flag-only) — exit 2 with help
- [x] `tos --help` (legacy) — unchanged
- [x] Full test suite: 17 new pass; the 2 pre-existing failures + 2 errors in `test_tos_writer.py` / `test_tostool.py` exist on master too (confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)