### PR TITLE
feat(cli): tos device add — step 3 of device-warehouse

### DIFF
--- a/src/tostools/device.py
+++ b/src/tostools/device.py
@@ -1,0 +1,237 @@
+"""Helpers for the ``tos device add`` CLI — warehouse intake of GNSS hardware.
+
+The CLI in ``tostools.tos._device_main`` is the user-facing entrypoint; the
+helpers here exist so the validation, attribute shaping, and IGS lookup logic
+can be unit-tested without spinning up argparse or hitting the TOS API.
+
+A "device" in TOS is an entity with ``code_entity_subtype`` of
+``gnss_receiver``, ``antenna``, ``radome``, or ``monument``. Warehouse intake
+creates the entity with the required attributes (serial, model, owner,
+location) and then layers optional attributes (firmware, comment, galvos) via
+:meth:`tostools.api.tos_writer.TOSWriter.upsert_attribute_value`.
+
+Extending to seismic / non-GPS devices
+--------------------------------------
+The required/optional attribute codes and the dry-run flow are intentionally
+domain-agnostic — adding a seismometer or digitizer subtype is a two-line
+change:
+
+1. Append the new ``code_entity_subtype`` to :data:`VALID_SUBTYPES`.
+2. Add a case in :func:`validate_model`. If the new subtype has no IGS lookup
+   (most non-GPS instruments don't), fall through to the ``monument`` branch's
+   pass-through behaviour. If it does have a standard model list, add a lookup
+   table in :mod:`tostools.standards` and a dispatch branch here.
+
+The CLI itself (``_device_main`` in ``tostools.tos``) needs no change beyond
+broadening its ``--subtype`` argparse ``choices``.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from typing import Dict, List, Optional, Tuple
+
+from .standards.igs_equipment import (
+    ANTENNA_IGS,
+    RADOME_IGS,
+    RECEIVER_IGS,
+    to_igs_antenna,
+    to_igs_radome,
+    to_igs_receiver,
+)
+
+VALID_SUBTYPES: Tuple[str, ...] = (
+    "gnss_receiver",
+    "antenna",
+    "radome",
+    "monument",
+)
+
+REQUIRED_ATTR_CODES: Tuple[str, ...] = (
+    "serial_number",
+    "model",
+    "owner",
+    "location",
+)
+
+# Order here drives the iteration order in :func:`iter_optional_attributes`
+# and therefore the order of ``upsert_attribute_value`` calls in the CLI.
+OPTIONAL_ATTR_CODES: Tuple[str, ...] = (
+    "firmware_version",
+    "comment",
+    "galvos",
+)
+
+_DATE_ONLY_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_DATETIME_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$")
+
+
+def normalize_date_start(raw: str) -> str:
+    """Normalise ``--date-start`` to ``YYYY-MM-DDTHH:MM:SS``.
+
+    Accepts a calendar date (``YYYY-MM-DD``, expanded to midnight) or a full
+    ISO-8601 datetime without timezone. Anything else raises ``ValueError``.
+    ``TOSWriter._tos_date`` will still strip a trailing ``Z`` / ``+HH:MM`` from
+    the wire payload if one slips through.
+    """
+    if not raw:
+        raise ValueError("date_start must be a non-empty string")
+    if _DATE_ONLY_RE.match(raw):
+        candidate = f"{raw}T00:00:00"
+    elif _DATETIME_RE.match(raw):
+        candidate = raw
+    else:
+        raise ValueError(
+            f"date_start must be YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS, got {raw!r}"
+        )
+    # Calendar sanity check (catches 2026-02-30 etc.).
+    datetime.strptime(candidate, "%Y-%m-%dT%H:%M:%S")
+    return candidate
+
+
+def _format_known_models(table: Dict[str, str], header: str) -> str:
+    """Render an IGS lookup table as ``IGS_NAME (aliases: a, b, c)`` lines."""
+    aliases_by_value: Dict[str, List[str]] = {}
+    for alias, igs in table.items():
+        aliases_by_value.setdefault(igs, []).append(alias)
+    lines = [header]
+    for igs in sorted(aliases_by_value):
+        extras = [a for a in aliases_by_value[igs] if a != igs]
+        if extras:
+            lines.append(f"  {igs}    (aliases: {', '.join(sorted(extras))})")
+        else:
+            lines.append(f"  {igs}")
+    return "\n".join(lines)
+
+
+def validate_model(subtype: str, raw: str) -> str:
+    """Return the IGS-standard model string for *raw*, or raise ``ValueError``.
+
+    For ``gnss_receiver`` and ``antenna`` the IGS lookup is authoritative: an
+    unknown model is rejected and the error message lists the known IGS values
+    (with accepted aliases) so the user can either fix the typo or extend
+    :mod:`tostools.standards.igs_equipment`. ``radome`` defers to the IGS table
+    but the table maps unknown radomes to ``"NONE"`` rather than raising.
+    ``monument`` has no IGS table — the raw string is returned unchanged after
+    a non-empty check.
+    """
+    if not raw:
+        raise ValueError(f"--model is required for subtype {subtype!r}")
+
+    if subtype == "gnss_receiver":
+        result = to_igs_receiver(raw)
+        if result is None:
+            raise ValueError(
+                _format_known_models(
+                    RECEIVER_IGS,
+                    f"Unknown gnss_receiver model: {raw!r}.\n"
+                    "Known IGS receiver names (accepted aliases in parentheses):",
+                )
+                + "\n\nAdd the alias in tostools/standards/igs_equipment.py "
+                "if your model is missing."
+            )
+        return result
+
+    if subtype == "antenna":
+        result = to_igs_antenna(raw)
+        if result is None:
+            raise ValueError(
+                _format_known_models(
+                    ANTENNA_IGS,
+                    f"Unknown antenna model: {raw!r}.\n"
+                    "Known IGS antenna names (accepted aliases in parentheses):",
+                )
+                + "\n\nAdd the alias in tostools/standards/igs_equipment.py "
+                "if your model is missing."
+            )
+        return result
+
+    if subtype == "radome":
+        # to_igs_radome silently coerces unknown values to "NONE" — we
+        # surface the available codes when the caller passed something that
+        # was not an exact alias, so the coercion never happens behind a
+        # warehouse-intake user's back.
+        if raw not in RADOME_IGS and raw.upper() not in {k.upper() for k in RADOME_IGS}:
+            raise ValueError(
+                _format_known_models(
+                    RADOME_IGS,
+                    f"Unknown radome model: {raw!r}.\n"
+                    "Known IGS radome codes (accepted aliases in parentheses):",
+                )
+                + "\n\nUse 'NONE' for no radome, or add the alias in "
+                "tostools/standards/igs_equipment.py."
+            )
+        return to_igs_radome(raw) or "NONE"
+
+    if subtype == "monument":
+        # No IGS table for monuments — accept the raw string.
+        return raw
+
+    raise ValueError(
+        f"Unknown subtype {subtype!r}. Valid subtypes: {', '.join(VALID_SUBTYPES)}"
+    )
+
+
+def build_required_attributes(
+    serial: str,
+    model: str,
+    owner: str,
+    location: str,
+    date_start: str,
+) -> List[Dict[str, Optional[str]]]:
+    """Build the attribute list passed to :meth:`TOSWriter.create_device`.
+
+    Each attribute carries an explicit ``date_to: None`` — the TOS ``/entities``
+    endpoint treats the field as required-present even when the period is open.
+    """
+    return [
+        {
+            "code": "serial_number",
+            "value": serial,
+            "date_from": date_start,
+            "date_to": None,
+        },
+        {
+            "code": "model",
+            "value": model,
+            "date_from": date_start,
+            "date_to": None,
+        },
+        {
+            "code": "owner",
+            "value": owner,
+            "date_from": date_start,
+            "date_to": None,
+        },
+        {
+            "code": "location",
+            "value": location,
+            "date_from": date_start,
+            "date_to": None,
+        },
+    ]
+
+
+def iter_optional_attributes(
+    firmware: Optional[str] = None,
+    comment: Optional[str] = None,
+    galvos: Optional[str] = None,
+) -> List[Tuple[str, str]]:
+    """Return ``(code, value)`` pairs for the supplied optional attributes.
+
+    Empty / ``None`` inputs are dropped so the caller can iterate the result
+    directly and call ``upsert_attribute_value`` once per pair. Order matches
+    :data:`OPTIONAL_ATTR_CODES`.
+    """
+    by_code: Dict[str, Optional[str]] = {
+        "firmware_version": firmware,
+        "comment": comment,
+        "galvos": galvos,
+    }
+    pairs: List[Tuple[str, str]] = []
+    for code in OPTIONAL_ATTR_CODES:
+        value = by_code[code]
+        if value:
+            pairs.append((code, value))
+    return pairs

--- a/src/tostools/tos.py
+++ b/src/tostools/tos.py
@@ -1700,7 +1700,7 @@ def generateFDSNXML(station_list=None):
     # inv.write("station.txt", format="stationtxt")
 
 
-KNOWN_SUBCOMMANDS = {"owners"}
+KNOWN_SUBCOMMANDS = {"owners", "device"}
 
 
 def _owners_main(argv):
@@ -1774,6 +1774,196 @@ def _owners_main(argv):
             )
             for o in missing:
                 print(f"  - {o}", file=sys.stderr)
+    return 0
+
+
+def _device_main(argv):
+    """Handle ``tos device ...`` subcommands.
+
+    Step 3 of the device-warehouse interface — adds a brand-new device entity
+    (gnss_receiver, antenna, radome, monument) to TOS with strict input
+    validation, owner allow-list checking, IGS model normalisation, and a
+    duplicate-serial guard (bypassable with ``--force``). Defaults to dry-run.
+    """
+    from . import device as device_helpers
+    from .api.tos_writer import TOSWriter
+    from .owners import OwnersCache
+
+    p = argparse.ArgumentParser(
+        prog="tos device",
+        description="Manage TOS device entities (warehouse intake).",
+    )
+    sub = p.add_subparsers(dest="action", required=True)
+
+    p_add = sub.add_parser("add", help="Add a new device entity to TOS.")
+    p_add.add_argument(
+        "--subtype",
+        required=True,
+        choices=device_helpers.VALID_SUBTYPES,
+        help="Device subtype.",
+    )
+    p_add.add_argument("--serial", required=True, help="Device serial number.")
+    p_add.add_argument(
+        "--model",
+        required=True,
+        help="Equipment model. Normalised to IGS rcvr_ant.tab format.",
+    )
+    p_add.add_argument(
+        "--owner",
+        required=True,
+        help="Owner label; must match an entry in the OwnersCache.",
+    )
+    p_add.add_argument("--location", required=True, help="Physical location.")
+    p_add.add_argument(
+        "--date-start",
+        required=True,
+        help="Start date for all attribute values (YYYY-MM-DD or "
+        "YYYY-MM-DDTHH:MM:SS).",
+    )
+    p_add.add_argument("--firmware", help="Optional firmware_version attribute.")
+    p_add.add_argument("--comment", help="Optional free-form comment attribute.")
+    p_add.add_argument(
+        "--galvos", help="Optional galvos (inventory/registration) number."
+    )
+    p_add.add_argument(
+        "--force",
+        action="store_true",
+        help="Bypass the duplicate-serial guard from create_device.",
+    )
+    p_add.add_argument(
+        "--no-dry-run",
+        action="store_true",
+        help="Commit the writes. Without this flag, payloads are logged only.",
+    )
+    p_add.add_argument(
+        "--owners-cache",
+        help="Override the owners cache path "
+        "(default: ~/.config/tostools/owners.yaml).",
+    )
+    p_add.add_argument(
+        "--server",
+        default="vi-api.vedur.is",
+        help="TOS API host (default: vi-api.vedur.is).",
+    )
+    p_add.add_argument("--port", type=int, default=443)
+    p_add.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a structured JSON summary instead of plain text.",
+    )
+
+    args = p.parse_args(argv)
+    if args.action != "add":
+        p.error(f"unknown action: {args.action}")
+        return 2
+
+    # ---- Input validation ------------------------------------------------
+    try:
+        date_start = device_helpers.normalize_date_start(args.date_start)
+    except ValueError as e:
+        print(f"Invalid --date-start: {e}", file=sys.stderr)
+        return 2
+
+    cache = (
+        OwnersCache(args.owners_cache) if args.owners_cache else OwnersCache()
+    )
+    known_owners = cache.load()
+    if args.owner not in known_owners:
+        print(
+            f"Unknown owner: {args.owner!r}. "
+            f"Run 'tos owners list' to see allowed values, or "
+            f"'tos owners list --refresh' if you recently added one in TOS.",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        igs_model = device_helpers.validate_model(args.subtype, args.model)
+    except ValueError as e:
+        print(str(e), file=sys.stderr)
+        return 2
+
+    required = device_helpers.build_required_attributes(
+        serial=args.serial,
+        model=igs_model,
+        owner=args.owner,
+        location=args.location,
+        date_start=date_start,
+    )
+    optional = device_helpers.iter_optional_attributes(
+        firmware=args.firmware,
+        comment=args.comment,
+        galvos=args.galvos,
+    )
+
+    # ---- Writer setup ----------------------------------------------------
+    scheme = "https" if args.port == 443 else "http"
+    base_url = f"{scheme}://{args.server}:{args.port}/tos/v1"
+    dry_run = not args.no_dry_run
+    writer = TOSWriter(base_url=base_url, dry_run=dry_run)
+
+    # ---- Create entity ---------------------------------------------------
+    try:
+        response = writer.create_device(
+            args.subtype, required, force=args.force
+        )
+    except ValueError as e:
+        msg = str(e)
+        if "already exists" in msg and not args.force:
+            print(f"{msg}\nPass --force to add the duplicate anyway.", file=sys.stderr)
+        else:
+            print(msg, file=sys.stderr)
+        return 1
+
+    # In dry-run, response is a DryRunResult (no id_entity). In live mode,
+    # response is the TOS API dict containing id_entity for the new entity.
+    id_entity = None
+    if isinstance(response, dict):
+        id_entity = response.get("id_entity")
+
+    # ---- Optional attributes --------------------------------------------
+    upsert_responses = []
+    for code, value in optional:
+        if dry_run or id_entity is None:
+            print(
+                f"DRY RUN: would upsert {code}={value!r} "
+                f"from {date_start} on id_entity="
+                f"{id_entity if id_entity is not None else '<new entity>'}"
+            )
+            upsert_responses.append({"code": code, "value": value, "dry_run": True})
+        else:
+            r = writer.upsert_attribute_value(
+                id_entity, code=code, value=value, date_from=date_start
+            )
+            upsert_responses.append({"code": code, "value": value, "response": r})
+
+    # ---- Summary ---------------------------------------------------------
+    if args.json:
+        import json as _json
+
+        payload = {
+            "subtype": args.subtype,
+            "serial": args.serial,
+            "model": igs_model,
+            "owner": args.owner,
+            "location": args.location,
+            "date_start": date_start,
+            "id_entity": id_entity,
+            "dry_run": dry_run,
+            "required_attributes": required,
+            "optional_attributes": [
+                {"code": c, "value": v} for c, v in optional
+            ],
+            "upsert_results": upsert_responses,
+        }
+        print(_json.dumps(payload, ensure_ascii=False, indent=2))
+    else:
+        suffix = " (dry-run)" if dry_run else ""
+        id_str = id_entity if id_entity is not None else "<would be assigned>"
+        print(
+            f"Created {args.subtype} serial={args.serial} "
+            f"id_entity={id_str}{suffix}"
+        )
     return 0
 
 
@@ -1955,13 +2145,15 @@ def _legacy_main(argv):
 
 
 def main(argv=None):
-    """Entry point — dispatches to `tos owners ...` or the legacy flat-arg CLI."""
+    """Entry point — dispatches to `tos <subcommand> ...` or the legacy CLI."""
     argv = list(sys.argv[1:] if argv is None else argv)
     if argv and argv[0] in KNOWN_SUBCOMMANDS:
         subcmd = argv[0]
         rest = argv[1:]
         if subcmd == "owners":
             return _owners_main(rest)
+        if subcmd == "device":
+            return _device_main(rest)
     return _legacy_main(argv)
 
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,0 +1,397 @@
+"""Unit tests for the device module + the ``tos device add`` CLI handler.
+
+No network required — TOSWriter and TOSClient are mocked.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from tostools.device import (
+    OPTIONAL_ATTR_CODES,
+    REQUIRED_ATTR_CODES,
+    VALID_SUBTYPES,
+    build_required_attributes,
+    iter_optional_attributes,
+    normalize_date_start,
+    validate_model,
+)
+
+# ---------------------------------------------------------------------------
+# normalize_date_start
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_date_start_expands_calendar_date() -> None:
+    assert normalize_date_start("2026-05-11") == "2026-05-11T00:00:00"
+
+
+def test_normalize_date_start_passes_full_iso_through() -> None:
+    assert normalize_date_start("2026-05-11T14:30:00") == "2026-05-11T14:30:00"
+
+
+def test_normalize_date_start_rejects_empty() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        normalize_date_start("")
+
+
+def test_normalize_date_start_rejects_garbage() -> None:
+    with pytest.raises(ValueError, match="YYYY-MM-DD"):
+        normalize_date_start("11/05/2026")
+
+
+def test_normalize_date_start_rejects_timezone_suffix() -> None:
+    # We let TOSWriter._tos_date strip Z/+HH:MM downstream; our normaliser is
+    # strict so the user sees the mismatch up-front.
+    with pytest.raises(ValueError, match="YYYY-MM-DD"):
+        normalize_date_start("2026-05-11T14:30:00Z")
+
+
+def test_normalize_date_start_rejects_invalid_calendar() -> None:
+    with pytest.raises(ValueError):
+        normalize_date_start("2026-02-30")
+
+
+# ---------------------------------------------------------------------------
+# validate_model
+# ---------------------------------------------------------------------------
+
+
+def test_validate_model_gnss_receiver_alias_resolves_to_igs() -> None:
+    assert validate_model("gnss_receiver", "PolaRx5") == "SEPT POLARX5"
+
+
+def test_validate_model_gnss_receiver_identity_for_igs_name() -> None:
+    # The IGS dict maps canonical strings only through alias keys — the
+    # canonical "SEPT POLARX5" is not itself a key, so this exercises the
+    # case-folded fallback in to_igs_receiver.
+    assert validate_model("gnss_receiver", "POLARX5") == "SEPT POLARX5"
+
+
+def test_validate_model_antenna_identity() -> None:
+    assert validate_model("antenna", "TRM57971.00") == "TRM57971.00"
+
+
+def test_validate_model_radome_none() -> None:
+    assert validate_model("radome", "NONE") == "NONE"
+
+
+def test_validate_model_monument_passthrough() -> None:
+    assert validate_model("monument", "Steel pillar v3") == "Steel pillar v3"
+
+
+def test_validate_model_rejects_empty() -> None:
+    with pytest.raises(ValueError, match="--model is required"):
+        validate_model("gnss_receiver", "")
+
+
+def test_validate_model_unknown_receiver_lists_known_names() -> None:
+    with pytest.raises(ValueError) as exc:
+        validate_model("gnss_receiver", "NotAReceiver")
+    msg = str(exc.value)
+    assert "NotAReceiver" in msg
+    assert "SEPT POLARX5" in msg
+    assert "TRIMBLE NETR9" in msg
+    assert "igs_equipment" in msg
+
+
+def test_validate_model_unknown_antenna_lists_known_names() -> None:
+    with pytest.raises(ValueError) as exc:
+        validate_model("antenna", "BogusAntenna")
+    msg = str(exc.value)
+    assert "BogusAntenna" in msg
+    assert "TRM57971.00" in msg
+
+
+def test_validate_model_unknown_radome_lists_known_codes() -> None:
+    with pytest.raises(ValueError) as exc:
+        validate_model("radome", "WIBBLE")
+    msg = str(exc.value)
+    assert "WIBBLE" in msg
+    assert "SPKE" in msg
+    assert "NONE" in msg
+
+
+def test_validate_model_rejects_unknown_subtype() -> None:
+    with pytest.raises(ValueError, match="Unknown subtype"):
+        validate_model("starship", "Falcon-9")
+
+
+# ---------------------------------------------------------------------------
+# build_required_attributes
+# ---------------------------------------------------------------------------
+
+
+def test_build_required_attributes_shape() -> None:
+    attrs = build_required_attributes(
+        serial="SN1",
+        model="SEPT POLARX5",
+        owner="Veðurstofa Íslands",
+        location="Bench A",
+        date_start="2026-05-11T00:00:00",
+    )
+    assert [a["code"] for a in attrs] == list(REQUIRED_ATTR_CODES)
+    assert all(a["date_from"] == "2026-05-11T00:00:00" for a in attrs)
+    by_code = {a["code"]: a["value"] for a in attrs}
+    assert by_code["serial_number"] == "SN1"
+    assert by_code["model"] == "SEPT POLARX5"
+    assert by_code["owner"] == "Veðurstofa Íslands"
+    assert by_code["location"] == "Bench A"
+
+
+# ---------------------------------------------------------------------------
+# iter_optional_attributes
+# ---------------------------------------------------------------------------
+
+
+def test_iter_optional_attributes_drops_empty_and_none() -> None:
+    assert iter_optional_attributes(firmware="", comment=None, galvos="") == []
+
+
+def test_iter_optional_attributes_canonical_order() -> None:
+    pairs = iter_optional_attributes(firmware="4.14.0", comment="hello", galvos="99999")
+    assert pairs == [
+        ("firmware_version", "4.14.0"),
+        ("comment", "hello"),
+        ("galvos", "99999"),
+    ]
+    assert [code for code, _ in pairs] == list(OPTIONAL_ATTR_CODES)
+
+
+def test_iter_optional_attributes_partial() -> None:
+    assert iter_optional_attributes(firmware=None, comment="note", galvos=None) == [
+        ("comment", "note"),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# VALID_SUBTYPES contract
+# ---------------------------------------------------------------------------
+
+
+def test_valid_subtypes_are_the_supported_ones() -> None:
+    assert set(VALID_SUBTYPES) == {"gnss_receiver", "antenna", "radome", "monument"}
+
+
+# ---------------------------------------------------------------------------
+# _device_main CLI handler
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def owners_yaml(tmp_path: Path) -> Path:
+    """Materialise a small owners cache file with one known owner."""
+    p = tmp_path / "owners.yaml"
+    p.write_text(yaml.safe_dump({"owners": ["Veðurstofa Íslands"]}, allow_unicode=True))
+    return p
+
+
+@pytest.fixture
+def base_argv(owners_yaml: Path) -> list:
+    """Argv for the happy-path `add` invocation (dry-run by default)."""
+    return [
+        "add",
+        "--subtype",
+        "gnss_receiver",
+        "--serial",
+        "SN_HAPPY",
+        "--model",
+        "PolaRx5",
+        "--owner",
+        "Veðurstofa Íslands",
+        "--location",
+        "Bench A",
+        "--date-start",
+        "2026-05-11",
+        "--owners-cache",
+        str(owners_yaml),
+    ]
+
+
+def _make_writer_mock(*, dry_run_response=None, live_response=None) -> MagicMock:
+    """Build a TOSWriter mock that mimics the real return contract."""
+    writer = MagicMock()
+    writer.create_device.return_value = (
+        dry_run_response or live_response or {"id_entity": 12345}
+    )
+    writer.upsert_attribute_value.return_value = {"ok": True}
+    return writer
+
+
+def test_device_main_dry_run_happy_path(base_argv: list, capsys) -> None:
+    from tostools.tos import _device_main
+
+    writer = _make_writer_mock()
+    with patch("tostools.api.tos_writer.TOSWriter", return_value=writer) as tw_cls:
+        rc = _device_main(base_argv)
+    out = capsys.readouterr()
+
+    assert rc == 0, out.err
+    # TOSWriter was constructed in dry-run by default.
+    assert tw_cls.call_args.kwargs["dry_run"] is True
+    # create_device received the canonical IGS receiver name.
+    call = writer.create_device.call_args
+    assert call.args[0] == "gnss_receiver"
+    attrs = {a["code"]: a["value"] for a in call.args[1]}
+    assert attrs["model"] == "SEPT POLARX5"
+    assert attrs["serial_number"] == "SN_HAPPY"
+    assert attrs["owner"] == "Veðurstofa Íslands"
+    assert attrs["location"] == "Bench A"
+    assert call.kwargs["force"] is False
+    # No optional inputs → no upsert calls.
+    writer.upsert_attribute_value.assert_not_called()
+    assert "DRY RUN" in out.out or "dry-run" in out.out.lower()
+
+
+def test_device_main_unknown_owner(base_argv: list, capsys) -> None:
+    from tostools.tos import _device_main
+
+    argv = list(base_argv)
+    argv[argv.index("Veðurstofa Íslands")] = "Bogus Group"
+
+    with patch("tostools.api.tos_writer.TOSWriter") as tw_cls:
+        rc = _device_main(argv)
+    err = capsys.readouterr().err
+
+    assert rc == 2
+    assert "Bogus Group" in err
+    assert "tos owners list" in err
+    tw_cls.assert_not_called()
+
+
+def test_device_main_unknown_model(base_argv: list, capsys) -> None:
+    from tostools.tos import _device_main
+
+    argv = list(base_argv)
+    argv[argv.index("PolaRx5")] = "NotAReceiver"
+
+    with patch("tostools.api.tos_writer.TOSWriter") as tw_cls:
+        rc = _device_main(argv)
+    err = capsys.readouterr().err
+
+    assert rc == 2
+    assert "NotAReceiver" in err
+    assert "SEPT POLARX5" in err  # known-models table
+    tw_cls.assert_not_called()
+
+
+def test_device_main_duplicate_serial_without_force(base_argv: list, capsys) -> None:
+    from tostools.tos import _device_main
+
+    writer = MagicMock()
+    writer.create_device.side_effect = ValueError(
+        "Device with serial_number='SN_HAPPY' already exists as gnss_receiver "
+        "(id_entity=42). Pass force=True to add a duplicate."
+    )
+    with patch("tostools.api.tos_writer.TOSWriter", return_value=writer):
+        rc = _device_main(base_argv)
+    err = capsys.readouterr().err
+
+    assert rc == 1
+    assert "already exists" in err
+    assert "--force" in err
+
+
+def test_device_main_force_flag_passes_through(base_argv: list) -> None:
+    from tostools.tos import _device_main
+
+    writer = _make_writer_mock()
+    argv = base_argv + ["--force"]
+    with patch("tostools.api.tos_writer.TOSWriter", return_value=writer):
+        rc = _device_main(argv)
+
+    assert rc == 0
+    assert writer.create_device.call_args.kwargs["force"] is True
+
+
+def test_device_main_no_dry_run_flips_writer_flag(base_argv: list) -> None:
+    from tostools.tos import _device_main
+
+    writer = _make_writer_mock()
+    argv = base_argv + ["--no-dry-run"]
+    with patch("tostools.api.tos_writer.TOSWriter", return_value=writer) as tw_cls:
+        rc = _device_main(argv)
+
+    assert rc == 0
+    assert tw_cls.call_args.kwargs["dry_run"] is False
+
+
+def test_device_main_optional_attrs_drive_upserts_in_live_mode(
+    base_argv: list,
+) -> None:
+    from tostools.tos import _device_main
+
+    writer = _make_writer_mock(live_response={"id_entity": 999})
+    argv = base_argv + [
+        "--no-dry-run",
+        "--firmware",
+        "4.14.0",
+        "--comment",
+        "warehouse intake",
+        "--galvos",
+        "12345",
+    ]
+    with patch("tostools.api.tos_writer.TOSWriter", return_value=writer):
+        rc = _device_main(argv)
+
+    assert rc == 0
+    # Each optional attribute → one upsert against the new id_entity.
+    upsert_calls = writer.upsert_attribute_value.call_args_list
+    assert len(upsert_calls) == 3
+    codes = [c.kwargs.get("code") or c.args[1] for c in upsert_calls]
+    assert codes == ["firmware_version", "comment", "galvos"]
+    for call in upsert_calls:
+        # id_entity is the first positional, date_from carries date_start.
+        assert call.args[0] == 999
+        assert call.kwargs.get("date_from") == "2026-05-11T00:00:00"
+
+
+def test_device_main_dry_run_logs_optional_upserts_without_calling_them(
+    base_argv: list, capsys
+) -> None:
+    from tostools.tos import _device_main
+
+    writer = _make_writer_mock()
+    argv = base_argv + ["--firmware", "4.14.0", "--galvos", "55555"]
+    with patch("tostools.api.tos_writer.TOSWriter", return_value=writer):
+        rc = _device_main(argv)
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    writer.upsert_attribute_value.assert_not_called()
+    assert "firmware_version" in out
+    assert "4.14.0" in out
+    assert "galvos" in out
+    assert "55555" in out
+
+
+def test_device_main_json_output(base_argv: list, capsys) -> None:
+    import json as _json
+
+    from tostools.tos import _device_main
+
+    writer = _make_writer_mock()
+    argv = base_argv + ["--json"]
+    with patch("tostools.api.tos_writer.TOSWriter", return_value=writer):
+        rc = _device_main(argv)
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    payload = _json.loads(out)
+    assert payload["subtype"] == "gnss_receiver"
+    assert payload["serial"] == "SN_HAPPY"
+    assert payload["model"] == "SEPT POLARX5"
+    assert payload["dry_run"] is True
+
+
+def test_device_main_requires_add_action() -> None:
+    from tostools.tos import _device_main
+
+    # `tos device` with no action → argparse should abort with non-zero exit.
+    with pytest.raises(SystemExit) as exc:
+        _device_main([])
+    assert exc.value.code != 0


### PR DESCRIPTION
## Summary

Step 3 of the device-warehouse roadmap. Adds `tos device add`, the CLI for creating a new gnss_receiver / antenna / radome / monument entity in TOS with strict input validation and a dry-run default.

- Reuses the step-1 `TOSWriter.create_device` duplicate-serial guard (commit 4b0ff4d) and the step-2 `OwnersCache` allow-list (commit 279c5ea).
- Normalises `--model` against the IGS rcvr_ant.tab tables in `tostools.standards.igs_equipment`; rejects unknown values with an error that lists the accepted IGS names and aliases for that subtype.
- Validates `--owner` against the cached owner allow-list; rejects with a pointer to `tos owners list --refresh`.
- All four required attributes (`serial_number`, `model`, `owner`, `location`) are written via `TOSWriter.create_device`; the three optional ones (`firmware_version`, `comment`, `galvos`) are layered via `TOSWriter.upsert_attribute_value` in live mode and logged in dry-run.
- `src/tostools/device.py` is intentionally domain-agnostic — the module docstring describes the two-line extension for seismic / non-GPS subtypes.

## CLI shape

```
tos device add --subtype {gnss_receiver|antenna|radome|monument} \
               --serial S --model M --owner O --location L \
               --date-start YYYY-MM-DD [--firmware F] [--comment C] \
               [--galvos G] [--force] [--no-dry-run] \
               [--owners-cache PATH] [--server H] [--port P] [--json]
```

## Test plan

- [x] Unit tests: 31/31 pass in `tests/test_device.py` — helpers (`validate_model`, `build_required_attributes`, `iter_optional_attributes`, `normalize_date_start`) + `_device_main` with TOSWriter mocked.
- [x] `uv run ruff check src/tostools/device.py tests/test_device.py` and `uv run black --check` clean.
- [x] Full `uv run pytest tests/` — the 2 pre-existing failures + 2 errors in `test_tos_writer.py` / `test_tostool.py` are unchanged from master (verified by stash + checkout).
- [x] Dry-run against live TOS — happy path (text and `--json`) and three failure modes (unknown owner, unknown model, malformed date) all behave correctly.
- [x] One real `--no-dry-run` write against live TOS:
  - new gnss_receiver: **`id_entity=21489`**, serial `TOSTOOLS_TEST_1778510398`
  - 4 required attributes + 3 optional upserts (`firmware_version`=152732, `comment`=152733, `galvos`=152734)
  - TOS has no delete API; this entity persists as a test fixture. Cleanup is either DB-level removal by IT, or closing each attribute via `patch_attribute_value` once that workflow lands.

## Known limitations (carried over from step 1)

- `find_device_by_serial` relies on `basic_search`, which appears to have indexing latency for freshly-created device serials. The duplicate-guard unit tests confirm the code path; in practice the guard catches established serials reliably and is best-effort for serials written in the same session.

## Out of scope (deferred to later steps)

- `tos device list` / `tos device find`
- Pattern-2 writes (close-old + open-new for instrument changes)
- Device → station connection via `/joins` (installation, not warehouse intake)

🤖 Generated with [Claude Code](https://claude.com/claude-code)