### PR TITLE
feat(tos_writer): add delete_entity_connection (step 2 of device-warehouse)

### DIFF
--- a/src/tostools/api/tos_writer.py
+++ b/src/tostools/api/tos_writer.py
@@ -748,6 +748,35 @@ class TOSWriter:
             )
         return self._request("PATCH", f"/join/{id_connection}", data=kwargs)
 
+    def delete_entity_connection(
+        self,
+        id_connection: int,
+        dry_run: Optional[bool] = None,
+    ) -> Any:
+        """Delete a parent→child entity connection.
+
+        Used by ``cfg move`` for rollback: when a POST succeeds but a
+        subsequent operation fails, the orchestrator DELETEs the
+        newly-created joins to leave TOS unchanged.
+
+        TOS path quirk: DELETE uses the **plural** ``/joins/<id>/`` path
+        (same as the collection POST endpoint at :meth:`create_entity_connection`),
+        while PATCH uses the **singular** ``/join/<id>/`` (see
+        :meth:`patch_entity_connection`). POSTing to ``/join`` or PATCHing
+        ``/joins/<id>`` returns the wrong HTTP error. Don't confuse them.
+
+        Dry-run interception is handled by :meth:`_request` (DELETE is
+        classified as a mutating method), so a dry-run call returns a
+        :class:`DryRunResult` without contacting TOS.
+
+        Args:
+            id_connection: The join's own id (the value patched by
+                :meth:`patch_entity_connection`).
+            dry_run: Override the instance-level ``dry_run`` for this call.
+        """
+        with _dry_run_override(self, dry_run):
+            return self._request("DELETE", f"/joins/{id_connection}/")
+
 
 # ---------------------------------------------------------------------------
 # Context manager helper for per-call dry_run override

--- a/tests/test_tos_writer.py
+++ b/tests/test_tos_writer.py
@@ -264,6 +264,62 @@ def test_patch_entity_connection_raises_with_no_kwargs():
 
 
 # ---------------------------------------------------------------------------
+# TOSWriter — delete_entity_connection
+# ---------------------------------------------------------------------------
+
+
+def test_delete_entity_connection_dry_run_returns_dry_run_result():
+    """The shared dry-run interception in TOSWriter._request must cover
+    DELETE — that's how `cfg move` rollback stays safe in dry-run mode."""
+    w = _logged_in_writer(dry_run=True)
+    result = w.delete_entity_connection(id_connection=42)
+    assert isinstance(result, DryRunResult)
+    assert result.method == "DELETE"
+    assert result.endpoint == "/joins/42/"
+
+
+def test_delete_entity_connection_dry_run_does_not_send_http():
+    w = _logged_in_writer(dry_run=True)
+    with patch("requests.request") as mock_req:
+        w.delete_entity_connection(id_connection=42)
+    mock_req.assert_not_called()
+
+
+def test_delete_entity_connection_live_sends_delete_request():
+    w = _logged_in_writer(dry_run=False)
+    mock_resp = MagicMock()
+    mock_resp.status_code = 204
+    mock_resp.content = b""
+    mock_resp.raise_for_status = MagicMock()
+
+    with patch("requests.request", return_value=mock_resp) as mock_req:
+        w.delete_entity_connection(id_connection=42)
+
+    mock_req.assert_called_once()
+    call = mock_req.call_args
+    # Verifies the TOS path quirk: DELETE on /joins/<id>/ (plural), not
+    # /join/<id>/ which is reserved for PATCH.
+    assert call.args[0] == "DELETE"
+    assert call.args[1].endswith("/joins/42/")
+
+
+def test_delete_entity_connection_per_call_dry_run_override():
+    """Per-call dry_run=False overrides the instance-level dry_run=True."""
+    w = _logged_in_writer(dry_run=True)
+    mock_resp = MagicMock()
+    mock_resp.status_code = 204
+    mock_resp.content = b""
+    mock_resp.raise_for_status = MagicMock()
+
+    with patch("requests.request", return_value=mock_resp) as mock_req:
+        w.delete_entity_connection(id_connection=42, dry_run=False)
+
+    mock_req.assert_called_once()
+    # Instance dry_run is restored after the call.
+    assert w.dry_run is True
+
+
+# ---------------------------------------------------------------------------
 # TOSWriter — upsert_attribute_value logic
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Adds `TOSWriter.delete_entity_connection(id_connection, dry_run=None)` — the DELETE primitive needed by `cfg move`'s rollback path (POST a new join, fail mid-flight, DELETE the newly-created join so TOS state is unchanged).
- No new dry-run plumbing needed: `_request` already classifies DELETE as mutating, so dry-run interception works for free. Verified by `test_delete_entity_connection_dry_run_returns_dry_run_result`.
- Documents the TOS path quirk in the method docstring: **DELETE uses `/joins/<id>/` (plural), PATCH uses `/join/<id>/` (singular).** Mixing them up returns the wrong HTTP error from TOS.

This is step 2 of the device-warehouse implementation order ([design doc](https://github.com/bennigo/tostools/blob/master/docs/architecture/tos-write-api.md)). Step 1 (`tostools.audit`) landed in #15. Step 3 (`receivers cfg move`) consumes this verb next.

## Test plan

- [x] `pytest tests/test_tos_writer.py -v` — 162 tests passing (was 158, +4 for this verb)
- [x] Ruff + black clean
- [ ] Reviewer: confirm DELETE path is `/joins/<id>/` (plural) by spot-checking the TOS Swagger / a known dev-env join id
- [ ] Live smoke deferred to step 3 — `cfg move`'s rollback path will exercise this end-to-end in dry-run first, then `--no-dry-run` against a sacrificial test connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)