### PR TITLE
feat(history): bootstrap parent enumeration (step 2 of synthesis plan)

### DIFF
--- a/src/tostools/history.py
+++ b/src/tostools/history.py
@@ -1,0 +1,353 @@
+"""Device-history-reconstruction primitives (step 2 of the synthesis plan).
+
+This module owns the read-only primitives used to walk and reconstruct the
+full join history of GNSS devices in TOS. The first deliverable here is
+:func:`enumerate_known_parents` — the "bootstrap parent list" needed by the
+forthcoming :func:`build_join_index` (step 3 of the synthesis).
+
+Why a separate module
+---------------------
+TOS exposes ``children_connections`` only from the parent side; a device's
+own ``id_entity_parent`` attribute can be stale (see GitHub issue #17, fixed
+in PR #18). So to reconstruct a device's complete timeline we have to walk
+every parent the device might have touched. That requires knowing the parent
+set up front.
+
+The synthesis note
+``~/notes/bgovault/2.Areas/VI_GPS_Library/1778612553-tostools-history-reconstruction-leverage.md``
+captures the full design (§2.3 for the join index, §5 step 2 for this
+enumeration).
+
+What this module is NOT
+-----------------------
+- Not a writer (no auth needed).
+- Not a substitute for ``tostools.audit``; the audit module continues to
+  serve the I1/I2 invariant-check CLI. Both modules read TOS but answer
+  different questions.
+- Not a replacement for any ``tosGPS`` functionality. Pure addition.
+
+API surface
+-----------
+* :class:`ParentEntity` — frozen dataclass describing one parent.
+* :data:`KNOWN_INFRASTRUCTURE_IDS` — hardcoded entity IDs for the warehouse
+  network + graveyard. Stable across deployments.
+* :func:`enumerate_known_parents` — top-level entry point. Returns the
+  bootstrap parent list (infrastructure + stations from ``stations.cfg``,
+  optionally augmented).
+"""
+
+from __future__ import annotations
+
+import configparser
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional
+
+from .api.tos_client import TOSClient
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Hardcoded infrastructure
+# ---------------------------------------------------------------------------
+#
+# These IDs are stable across TOS deployments and discovered through the
+# 2026-05-12 probe of vi-api.vedur.is. They cannot be enumerated by any
+# basic_search query (the device graveyard in particular has no attribute
+# that matches "Lager" / "warehouse"), hence the hardcoded list.
+#
+# Verify membership with::
+#
+#   for eid in KNOWN_INFRASTRUCTURE_IDS:
+#       h = client.get_entity_history(eid)
+#       print(eid, h.get("code_entity_subtype"), h.get("attributes"))
+#
+# If any ID disappears from TOS, :func:`enumerate_known_parents` logs a
+# warning and skips it; it does not raise. New warehouses should be
+# discovered via ``basic_search('Lager')`` and added here.
+
+KNOWN_WAREHOUSE_IDS: tuple[int, ...] = (
+    4,  # B9 - Kjallari - Jörð         (primary GPS warehouse)
+    5,  # B9 - Kjallari - Vatn         (hydrological sister warehouse)
+    8,  # Vagnhöfði                    (offsite warehouse — parent location)
+    10,  # Vagnhöfði - Kjallari - Jörð  (Vagnhöfði sub-warehouse, host of 3 audit-orphans)
+    13,  # Vagnhöfði - Rafgeymaskúr     (Vagnhöfði sub-warehouse, battery shed)
+    16920,  # B9 - Verkstæði - Veður       (weather workshop warehouse)
+)
+
+# The "device graveyard": id_entity=14, name='Hent', subtype='discarded'.
+# Description: "Tæki sem hefur verið hent og eru ekki lengur í eigu VÍ"
+#              (devices that have been thrown away, no longer owned by IMO).
+# Has ~1989 children_connections — covers most retired device endpoints.
+DEVICE_GRAVEYARD_ID: int = 14
+
+KNOWN_INFRASTRUCTURE_IDS: tuple[int, ...] = KNOWN_WAREHOUSE_IDS + (DEVICE_GRAVEYARD_ID,)
+
+
+# Subtypes treated as "station" (a device deployed in the field has one of these
+# as its current parent). Sourced from the TOS /entity_subtypes endpoint
+# probed 2026-05-12. Not exhaustive of TOS's full subtype universe — only
+# those a GNSS receiver might plausibly be joined to.
+STATION_SUBTYPES: frozenset[str] = frozenset(
+    {
+        "geophysical",  # SIL, GPS, gas, infrasound — the GNSS-receiver host type
+        "meteorological",  # weather stations
+        "general_station",  # generic station
+        "remote_sensing",  # radar
+        "ocean",  # ocean-based
+        "ship",  # ship-based
+        "total_station",
+        "land",  # land-based location parent
+    }
+)
+
+# Subtypes treated as "warehouse" (storage/inventory parents). Distinct from
+# STATION_SUBTYPES because warehouse children aren't "deployed". Discovered
+# 2026-05-12: ``area`` is the canonical warehouse subtype (B9, Vagnhöfði
+# sub-locations), ``stock`` is used for parent locations that group multiple
+# sub-warehouses (e.g. id=8 'Vagnhöfði' is subtype=stock and contains
+# id=10 'Vagnhöfði - Kjallari - Jörð' which is subtype=area).
+WAREHOUSE_SUBTYPES: frozenset[str] = frozenset({"area", "stock"})
+
+
+# ---------------------------------------------------------------------------
+# Data class
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ParentEntity:
+    """One entity that can host devices (station / warehouse / graveyard).
+
+    ``role`` is a coarse classification derived from ``code_subtype``; it
+    exists so callers can format / group / colour-code without re-encoding
+    the subtype taxonomy.
+    """
+
+    id_entity: int
+    name: Optional[str]
+    code_subtype: str
+    role: str  # "station" | "warehouse" | "graveyard" | "other"
+
+    @classmethod
+    def from_history(cls, id_entity: int, history: Dict[str, Any]) -> "ParentEntity":
+        """Build a :class:`ParentEntity` from a TOS ``/history/entity/<id>/`` response.
+
+        Falls back gracefully when the entity has no ``name`` attribute
+        in its own ``attributes`` payload (which happens for some legacy
+        station entities — see :func:`enumerate_known_parents`'s docstring
+        for the basic_search-based name-recovery path).
+        """
+        name = _open_attr(history.get("attributes"), "name")
+        subtype = str(history.get("code_entity_subtype") or "")
+        return cls(
+            id_entity=int(id_entity),
+            name=name,
+            code_subtype=subtype,
+            role=_role_for(subtype),
+        )
+
+
+def _role_for(code_subtype: str) -> str:
+    if code_subtype in WAREHOUSE_SUBTYPES:
+        return "warehouse"
+    if code_subtype == "discarded":
+        return "graveyard"
+    if code_subtype in STATION_SUBTYPES:
+        return "station"
+    return "other"
+
+
+def _open_attr(attributes: Optional[list], code: str) -> Optional[str]:
+    """Return the value of the open (``time_to is None``) attribute with the
+    given ``code``, or None."""
+    if not attributes:
+        return None
+    for a in attributes:
+        if a.get("code") != code:
+            continue
+        if a.get("time_to") is not None:
+            continue
+        value = a.get("value_varchar")
+        if value is None:
+            value = a.get("value")
+        return str(value) if value is not None else None
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def default_station_cfg_path() -> Optional[str]:
+    """Return the conventional path to the deployed ``stations.cfg``, or
+    ``None`` if not present.
+
+    Search order mirrors what the rest of the ecosystem already does:
+    ``$GPS_CONFIG_PATH/stations.cfg`` → ``~/.config/gpsconfig/stations.cfg``.
+    """
+    env_dir = os.environ.get("GPS_CONFIG_PATH")
+    candidates = []
+    if env_dir:
+        candidates.append(os.path.join(env_dir, "stations.cfg"))
+    candidates.append(os.path.expanduser("~/.config/gpsconfig/stations.cfg"))
+    for c in candidates:
+        if os.path.isfile(c):
+            return c
+    return None
+
+
+def read_station_markers(cfg_path: str) -> List[str]:
+    """Return the list of station markers (section names) from a stations.cfg.
+
+    Stations.cfg uses one INI section per station, keyed by the marker
+    (e.g. ``[RHOF]``).  Sections that look like global config (lowercase
+    or contain ``=`` characters) are skipped.
+    """
+    cfg = configparser.ConfigParser()
+    cfg.read(cfg_path)
+    return [s for s in cfg.sections() if s and s.isupper()]
+
+
+def resolve_marker_to_entity_id(client: TOSClient, marker: str) -> Optional[int]:
+    """Resolve a 4-letter station marker to its TOS ``id_entity``.
+
+    Uses ``basic_search`` and accepts only hits where:
+
+    - ``code == 'marker'``
+    - ``distance == 0`` (exact match)
+    - ``value_varchar`` matches the marker case-insensitively
+
+    Returns ``None`` if no exact match is found (e.g. for markers that
+    are in ``stations.cfg`` but not yet in TOS).
+    """
+    target = marker.lower()
+    for h in client.basic_search(marker):
+        if h.get("code") != "marker":
+            continue
+        if h.get("distance") not in (0, None):
+            continue
+        value = h.get("value_varchar")
+        if not isinstance(value, str) or value.lower() != target:
+            continue
+        eid = h.get("id_entity") or h.get("id_lvl_three")
+        if eid:
+            return int(eid)
+    return None
+
+
+def enumerate_known_parents(
+    client: TOSClient,
+    *,
+    station_cfg_path: Optional[str] = None,
+    extra_parent_ids: Iterable[int] = (),
+) -> List[ParentEntity]:
+    """Return the bootstrap parent list for device-history reconstruction.
+
+    The returned list is the union of:
+
+    1. **Hardcoded infrastructure**: warehouses (B9 + Vagnhöfði) and the
+       device graveyard. See :data:`KNOWN_INFRASTRUCTURE_IDS`. These cannot
+       be enumerated via ``basic_search``; the IDs are stable per TOS
+       deployment.
+    2. **Stations from ``stations.cfg``** (optional): each section name in
+       the cfg is a station marker; we resolve it to its TOS ``id_entity``
+       via :func:`resolve_marker_to_entity_id`. Markers that don't exist
+       in TOS are silently skipped.
+    3. **Caller-supplied** ``extra_parent_ids``: useful for hardening the
+       list against the known gap that ``stations.cfg`` is incomplete
+       (e.g., Fagradalsfjall (18409), Bláfjöll (4243), Bárðabunga (4239),
+       Hestalda (5444) — these are parents in TOS that aren't in cfg).
+
+    Each id is looked up once via ``/history/entity/<id>/``. Entities that
+    cannot be read (404, transient errors) are logged at WARNING and
+    skipped — the returned list is best-effort, never raises on a single
+    missing entity.
+
+    Note on stale ``id_entity_parent`` attributes: some legacy station
+    entities have ``name=None`` in their own attribute history (the name
+    is exposed only via ``basic_search`` lvl chains, not via the entity's
+    own attributes). In those cases the returned :class:`ParentEntity`
+    carries ``name=None`` rather than a name from another source — the
+    caller can backfill from ``basic_search`` if cosmetic naming matters.
+
+    Args:
+        client: An unauthenticated :class:`TOSClient`.
+        station_cfg_path: Path to ``stations.cfg``. If ``None``, falls back
+            to :func:`default_station_cfg_path`; if still nothing, the
+            stations-from-cfg step is skipped (only infrastructure and
+            ``extra_parent_ids`` are returned).
+        extra_parent_ids: Caller-supplied additional parent entity ids.
+            Useful for known-missing stations not in ``stations.cfg``.
+
+    Returns:
+        List of :class:`ParentEntity`, deduplicated by ``id_entity``.
+        Order: infrastructure first, then stations (in cfg order), then
+        extras. Useful as a stable bootstrap input for the join index.
+    """
+    seen: Dict[int, ParentEntity] = {}
+
+    def _add(eid: int) -> None:
+        if eid in seen:
+            return
+        try:
+            h = client.get_entity_history(eid)
+        except Exception as exc:  # network errors are non-fatal
+            logger.warning(
+                "enumerate_known_parents: get_entity_history(%d) raised: %s; skipping",
+                eid,
+                exc,
+            )
+            return
+        if not h:
+            logger.warning(
+                "enumerate_known_parents: no history for id_entity=%d; skipping",
+                eid,
+            )
+            return
+        seen[eid] = ParentEntity.from_history(eid, h)
+
+    # 1. Infrastructure
+    for eid in KNOWN_INFRASTRUCTURE_IDS:
+        _add(eid)
+
+    # 2. Stations from stations.cfg
+    cfg_path = station_cfg_path or default_station_cfg_path()
+    if cfg_path:
+        markers = read_station_markers(cfg_path)
+        logger.info(
+            "enumerate_known_parents: resolving %d markers from %s",
+            len(markers),
+            cfg_path,
+        )
+        for marker in markers:
+            try:
+                eid = resolve_marker_to_entity_id(client, marker)
+            except Exception as exc:
+                logger.warning(
+                    "enumerate_known_parents: resolve_marker_to_entity_id(%r) raised: %s",
+                    marker,
+                    exc,
+                )
+                continue
+            if eid is None:
+                logger.debug(
+                    "enumerate_known_parents: marker %r not found in TOS; skipping",
+                    marker,
+                )
+                continue
+            _add(eid)
+    else:
+        logger.info(
+            "enumerate_known_parents: no stations.cfg available; "
+            "returning infrastructure + extra_parent_ids only"
+        )
+
+    # 3. Caller-supplied extras
+    for eid in extra_parent_ids:
+        _add(int(eid))
+
+    return list(seen.values())

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,0 +1,467 @@
+"""Unit tests for :mod:`tostools.history`.
+
+Covers the bootstrap-parent-list enumeration. TOSClient is mocked; no
+network.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock
+
+from tostools.history import (
+    DEVICE_GRAVEYARD_ID,
+    KNOWN_INFRASTRUCTURE_IDS,
+    KNOWN_WAREHOUSE_IDS,
+    STATION_SUBTYPES,
+    ParentEntity,
+    default_station_cfg_path,
+    enumerate_known_parents,
+    read_station_markers,
+    resolve_marker_to_entity_id,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _history(
+    id_entity: int,
+    subtype: str = "geophysical",
+    name: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Build a minimal ``/history/entity/<id>/`` response."""
+    attrs: List[Dict[str, Any]] = []
+    if name is not None:
+        attrs.append({"code": "name", "value_varchar": name, "time_to": None})
+    return {
+        "id_entity": id_entity,
+        "code_entity_subtype": subtype,
+        "attributes": attrs,
+        "children_connections": [],
+    }
+
+
+def _marker_hit(
+    marker: str,
+    id_entity: int,
+    *,
+    distance: int = 0,
+    name_lvl_two: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Build a basic_search hit with ``code='marker'``."""
+    return {
+        "code": "marker",
+        "distance": distance,
+        "value_varchar": marker,
+        "id_entity": id_entity,
+        "id_lvl_three": id_entity,
+        "name_lvl_two": name_lvl_two,
+    }
+
+
+def _client(
+    histories: Dict[int, Dict[str, Any]],
+    search_hits: Optional[List[Dict[str, Any]]] = None,
+) -> MagicMock:
+    c = MagicMock()
+    c.get_entity_history.side_effect = lambda i: histories.get(int(i))
+    c.basic_search.return_value = list(search_hits or [])
+    return c
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+def test_known_infrastructure_includes_warehouses_and_graveyard():
+    """Sanity: the infrastructure tuple is the warehouse tuple + graveyard."""
+    assert set(KNOWN_INFRASTRUCTURE_IDS) == set(KNOWN_WAREHOUSE_IDS) | {
+        DEVICE_GRAVEYARD_ID
+    }
+
+
+def test_b9_jord_is_id_4():
+    """The primary GPS warehouse must remain id_entity=4 (B9 - Kjallari - Jörð).
+    Audit module and existing tooling depend on this constant."""
+    assert 4 in KNOWN_WAREHOUSE_IDS
+
+
+def test_graveyard_is_id_14():
+    """The 'Hent' device graveyard must remain id_entity=14. Discovered
+    2026-05-12 via probe of vi-api.vedur.is."""
+    assert DEVICE_GRAVEYARD_ID == 14
+
+
+def test_station_subtypes_includes_core_types():
+    """Smoke: the subtype set must contain the canonical GNSS-host types."""
+    assert "geophysical" in STATION_SUBTYPES
+    assert "meteorological" in STATION_SUBTYPES
+    assert "general_station" in STATION_SUBTYPES
+
+
+# ---------------------------------------------------------------------------
+# ParentEntity
+# ---------------------------------------------------------------------------
+
+
+def test_parent_entity_from_history_station():
+    h = _history(50, subtype="geophysical", name="RHOF")
+    p = ParentEntity.from_history(50, h)
+    assert p.id_entity == 50
+    assert p.name == "RHOF"
+    assert p.code_subtype == "geophysical"
+    assert p.role == "station"
+
+
+def test_parent_entity_from_history_warehouse():
+    h = _history(4, subtype="area", name="B9 - Kjallari - Jörð")
+    p = ParentEntity.from_history(4, h)
+    assert p.code_subtype == "area"
+    assert p.role == "warehouse"
+
+
+def test_parent_entity_from_history_stock_is_warehouse():
+    """Subtype ``stock`` is used for parent warehouses that group multiple
+    ``area`` sub-warehouses (e.g. id=8 Vagnhöfði). Treated as warehouse,
+    not "other" — discovered in live probe 2026-05-12."""
+    h = _history(8, subtype="stock", name="Vagnhöfði")
+    p = ParentEntity.from_history(8, h)
+    assert p.code_subtype == "stock"
+    assert p.role == "warehouse"
+
+
+def test_parent_entity_from_history_graveyard():
+    h = _history(14, subtype="discarded", name="Hent")
+    p = ParentEntity.from_history(14, h)
+    assert p.role == "graveyard"
+
+
+def test_parent_entity_from_history_unknown_subtype_is_other():
+    h = _history(99, subtype="some_future_subtype", name="?")
+    p = ParentEntity.from_history(99, h)
+    assert p.role == "other"
+
+
+def test_parent_entity_from_history_no_name_attribute():
+    """Mirrors the live-data quirk: some legacy parents have no ``name``
+    attribute in their own ``attributes`` payload (their display name is
+    only available via basic_search's lvl_two chain)."""
+    h = _history(18409, subtype="geophysical")  # no name
+    p = ParentEntity.from_history(18409, h)
+    assert p.name is None
+    assert p.role == "station"  # still a station, just unnamed in attrs
+
+
+def test_parent_entity_skips_closed_name_attribute():
+    """An attribute with ``time_to`` set is closed; we want the open name only."""
+    h = {
+        "id_entity": 50,
+        "code_entity_subtype": "geophysical",
+        "attributes": [
+            {"code": "name", "value_varchar": "old", "time_to": "2024-01-01"},
+            {"code": "name", "value_varchar": "current", "time_to": None},
+        ],
+    }
+    p = ParentEntity.from_history(50, h)
+    assert p.name == "current"
+
+
+# ---------------------------------------------------------------------------
+# read_station_markers
+# ---------------------------------------------------------------------------
+
+
+def test_read_station_markers_returns_upper_section_names(tmp_path: Path):
+    cfg = tmp_path / "stations.cfg"
+    cfg.write_text(
+        "[RHOF]\n"
+        "marker = RHOF\n"
+        "router_ip = 10.0.0.1\n"
+        "\n"
+        "[REYK]\n"
+        "router_ip = 10.0.0.2\n"
+        "\n"
+        "[lowercase_section]\n"
+        "ignored = true\n"
+    )
+    markers = read_station_markers(str(cfg))
+    assert "RHOF" in markers
+    assert "REYK" in markers
+    assert "lowercase_section" not in markers
+
+
+def test_read_station_markers_skips_default_section(tmp_path: Path):
+    """ConfigParser's special DEFAULT section must not leak into the list."""
+    cfg = tmp_path / "stations.cfg"
+    cfg.write_text("[DEFAULT]\nfoo = bar\n[RHOF]\nbaz = qux\n")
+    markers = read_station_markers(str(cfg))
+    # DEFAULT is omitted by configparser.sections()
+    assert markers == ["RHOF"]
+
+
+# ---------------------------------------------------------------------------
+# resolve_marker_to_entity_id
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_marker_returns_id_on_exact_match():
+    client = _client(
+        histories={},
+        search_hits=[_marker_hit("RHOF", id_entity=4521)],
+    )
+    assert resolve_marker_to_entity_id(client, "RHOF") == 4521
+
+
+def test_resolve_marker_is_case_insensitive():
+    """The cfg may use any case; markers in TOS are stored lowercase. We
+    match case-insensitively so the natural workflow works."""
+    client = _client(
+        histories={},
+        search_hits=[_marker_hit("rhof", id_entity=4521)],
+    )
+    assert resolve_marker_to_entity_id(client, "RHOF") == 4521
+
+
+def test_resolve_marker_rejects_distance_non_zero():
+    """basic_search returns fuzzy matches; only exact (distance=0) wins."""
+    client = _client(
+        histories={},
+        search_hits=[_marker_hit("RHOF", id_entity=4521, distance=8)],
+    )
+    assert resolve_marker_to_entity_id(client, "RHOF") is None
+
+
+def test_resolve_marker_rejects_wrong_code():
+    """Only ``code='marker'`` hits count — value matches in other
+    attributes (name, description, etc.) are noise."""
+    client = _client(
+        histories={},
+        search_hits=[
+            {
+                "code": "name",
+                "distance": 0,
+                "value_varchar": "RHOF",
+                "id_entity": 9999,
+            }
+        ],
+    )
+    assert resolve_marker_to_entity_id(client, "RHOF") is None
+
+
+def test_resolve_marker_returns_none_when_no_hit():
+    client = _client(histories={}, search_hits=[])
+    assert resolve_marker_to_entity_id(client, "UNKNOWN") is None
+
+
+def test_resolve_marker_falls_back_to_id_lvl_three():
+    """Some hits carry ``id_lvl_three`` but no top-level ``id_entity``;
+    accept either to mirror :func:`tostools.audit._find_device_by_serial`."""
+    client = _client(
+        histories={},
+        search_hits=[
+            {
+                "code": "marker",
+                "distance": 0,
+                "value_varchar": "RHOF",
+                "id_lvl_three": 4521,
+            }
+        ],
+    )
+    assert resolve_marker_to_entity_id(client, "RHOF") == 4521
+
+
+# ---------------------------------------------------------------------------
+# enumerate_known_parents
+# ---------------------------------------------------------------------------
+
+
+def test_enumerate_known_parents_returns_infrastructure_when_no_cfg():
+    """With no stations.cfg and no extras, only the 7 hardcoded
+    infrastructure entities should appear."""
+    histories = {
+        eid: _history(eid, subtype="area", name=f"warehouse-{eid}")
+        for eid in KNOWN_WAREHOUSE_IDS
+    }
+    histories[DEVICE_GRAVEYARD_ID] = _history(
+        DEVICE_GRAVEYARD_ID, subtype="discarded", name="Hent"
+    )
+    client = _client(histories=histories)
+
+    result = enumerate_known_parents(client, station_cfg_path=None)
+
+    assert {p.id_entity for p in result} == set(KNOWN_INFRASTRUCTURE_IDS)
+    # One graveyard, the rest warehouses
+    graveyards = [p for p in result if p.role == "graveyard"]
+    warehouses = [p for p in result if p.role == "warehouse"]
+    assert len(graveyards) == 1
+    assert len(warehouses) == len(KNOWN_WAREHOUSE_IDS)
+
+
+def test_enumerate_known_parents_skips_unreadable_infrastructure(caplog):
+    """When TOS cannot return history for a hardcoded ID (deleted entity,
+    transient error), the function logs a warning and skips it rather
+    than failing the whole bootstrap."""
+    # Only the graveyard returns history; all warehouses return None.
+    histories = {
+        DEVICE_GRAVEYARD_ID: _history(
+            DEVICE_GRAVEYARD_ID, subtype="discarded", name="Hent"
+        )
+    }
+    client = _client(histories=histories)
+
+    with caplog.at_level("WARNING"):
+        result = enumerate_known_parents(client, station_cfg_path=None)
+
+    assert {p.id_entity for p in result} == {DEVICE_GRAVEYARD_ID}
+    # One warning per missing warehouse.
+    skip_warnings = [r for r in caplog.records if "no history" in r.getMessage()]
+    assert len(skip_warnings) == len(KNOWN_WAREHOUSE_IDS)
+
+
+def test_enumerate_known_parents_resolves_stations_from_cfg(tmp_path: Path):
+    """Markers in stations.cfg get resolved to entity IDs and added."""
+    cfg = tmp_path / "stations.cfg"
+    cfg.write_text("[RHOF]\n[REYK]\n")
+
+    histories = {
+        eid: _history(eid, subtype="area", name=f"warehouse-{eid}")
+        for eid in KNOWN_WAREHOUSE_IDS
+    }
+    histories[DEVICE_GRAVEYARD_ID] = _history(
+        DEVICE_GRAVEYARD_ID, subtype="discarded", name="Hent"
+    )
+    # Two stations
+    histories[4521] = _history(4521, subtype="geophysical", name="Raufarhöfn")
+    histories[4530] = _history(4530, subtype="geophysical", name="Reykjavík")
+    # basic_search returns the marker hits — same payload for any search
+    # call because the test client doesn't differentiate by search term.
+    client = _client(
+        histories=histories,
+        search_hits=[
+            _marker_hit("RHOF", id_entity=4521),
+            _marker_hit("REYK", id_entity=4530),
+        ],
+    )
+
+    result = enumerate_known_parents(client, station_cfg_path=str(cfg))
+    ids = {p.id_entity for p in result}
+
+    assert ids == set(KNOWN_INFRASTRUCTURE_IDS) | {4521, 4530}
+    # The stations are tagged correctly
+    stations = [p for p in result if p.role == "station"]
+    assert {p.id_entity for p in stations} == {4521, 4530}
+
+
+def test_enumerate_known_parents_silently_skips_unresolvable_marker(
+    tmp_path: Path,
+):
+    """Markers that have no exact match in TOS are silently skipped; the
+    rest of the bootstrap is unaffected."""
+    cfg = tmp_path / "stations.cfg"
+    cfg.write_text("[RHOF]\n[NOPE]\n")
+
+    histories = {eid: _history(eid, subtype="area") for eid in KNOWN_WAREHOUSE_IDS}
+    histories[DEVICE_GRAVEYARD_ID] = _history(DEVICE_GRAVEYARD_ID, subtype="discarded")
+    histories[4521] = _history(4521, subtype="geophysical", name="Raufarhöfn")
+    # Only RHOF resolves; NOPE has no hit.
+    client = _client(
+        histories=histories,
+        search_hits=[_marker_hit("RHOF", id_entity=4521)],
+    )
+
+    result = enumerate_known_parents(client, station_cfg_path=str(cfg))
+    ids = {p.id_entity for p in result}
+
+    # Infrastructure + RHOF only; NOPE is dropped without error.
+    assert ids == set(KNOWN_INFRASTRUCTURE_IDS) | {4521}
+
+
+def test_enumerate_known_parents_accepts_extra_ids():
+    """`extra_parent_ids` injects known-missing parents (the
+    Fagradalsfjall / Bláfjöll / Bárðabunga / Hestalda gap)."""
+    histories = {eid: _history(eid, subtype="area") for eid in KNOWN_WAREHOUSE_IDS}
+    histories[DEVICE_GRAVEYARD_ID] = _history(DEVICE_GRAVEYARD_ID, subtype="discarded")
+    # Simulate the 4 stations missing from stations.cfg
+    for eid in (18409, 4243, 4239, 5444):
+        histories[eid] = _history(eid, subtype="geophysical", name=None)
+    client = _client(histories=histories)
+
+    result = enumerate_known_parents(
+        client,
+        station_cfg_path=None,
+        extra_parent_ids=(18409, 4243, 4239, 5444),
+    )
+    ids = {p.id_entity for p in result}
+
+    assert {18409, 4243, 4239, 5444}.issubset(ids)
+    # The extras are stations even though their name is None.
+    extras = [p for p in result if p.id_entity in {18409, 4243, 4239, 5444}]
+    assert all(p.role == "station" and p.name is None for p in extras)
+
+
+def test_enumerate_known_parents_dedupes_overlaps(tmp_path: Path):
+    """If a caller-supplied extra_parent_id overlaps with stations.cfg or
+    the hardcoded infrastructure, the returned list still contains each
+    entity exactly once."""
+    cfg = tmp_path / "stations.cfg"
+    cfg.write_text("[RHOF]\n")
+
+    histories = {eid: _history(eid, subtype="area") for eid in KNOWN_WAREHOUSE_IDS}
+    histories[DEVICE_GRAVEYARD_ID] = _history(DEVICE_GRAVEYARD_ID, subtype="discarded")
+    histories[4521] = _history(4521, subtype="geophysical", name="Raufarhöfn")
+    client = _client(
+        histories=histories,
+        search_hits=[_marker_hit("RHOF", id_entity=4521)],
+    )
+
+    # Supply 4521 again as an extra + 4 (already in infrastructure)
+    result = enumerate_known_parents(
+        client,
+        station_cfg_path=str(cfg),
+        extra_parent_ids=(4521, 4),
+    )
+    ids = [p.id_entity for p in result]
+
+    # No id appears twice
+    assert len(ids) == len(set(ids))
+    # All expected ids are present
+    assert set(ids) == set(KNOWN_INFRASTRUCTURE_IDS) | {4521}
+
+
+# ---------------------------------------------------------------------------
+# default_station_cfg_path
+# ---------------------------------------------------------------------------
+
+
+def test_default_station_cfg_path_uses_env_var(tmp_path: Path, monkeypatch):
+    """``GPS_CONFIG_PATH`` env var wins when set and the file exists."""
+    cfg = tmp_path / "stations.cfg"
+    cfg.write_text("[RHOF]\n")
+    monkeypatch.setenv("GPS_CONFIG_PATH", str(tmp_path))
+    assert default_station_cfg_path() == str(cfg)
+
+
+def test_default_station_cfg_path_falls_back_to_xdg(monkeypatch, tmp_path: Path):
+    """When the env var is unset, fall back to
+    ``~/.config/gpsconfig/stations.cfg``."""
+    monkeypatch.delenv("GPS_CONFIG_PATH", raising=False)
+    # Redirect HOME so we don't hit the developer's real cfg.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg_dir = tmp_path / ".config" / "gpsconfig"
+    cfg_dir.mkdir(parents=True)
+    cfg_path = cfg_dir / "stations.cfg"
+    cfg_path.write_text("[RHOF]\n")
+    assert default_station_cfg_path() == str(cfg_path)
+
+
+def test_default_station_cfg_path_returns_none_when_missing(
+    monkeypatch, tmp_path: Path
+):
+    """When neither candidate exists, return None (caller decides what to do)."""
+    monkeypatch.delenv("GPS_CONFIG_PATH", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))  # no .config/gpsconfig under here
+    assert default_station_cfg_path() is None


### PR DESCRIPTION
## Summary

Adds a new `tostools.history` module — the read-only side of device-history reconstruction. First deliverable is `enumerate_known_parents`: the **bootstrap parent list** needed by the upcoming join-index work (§5 step 3 of the synthesis note).

**Pure addition.** No existing module changes. `tosGPS`, `legacy/*`, and `audit` are untouched — the memory-note guardrail ("preserve current functionality during gradual refactor") is met.

## Why a new module

TOS exposes `children_connections` only from the parent side; a device's own `id_entity_parent` attribute is unreliable (see #17 / PR #18). To reconstruct a device's full timeline, every parent it could have touched must be walked. That walk needs a starting set — this PR ships it.

## What the module ships

| | |
|---|---|
| `ParentEntity` | Frozen dataclass: `(id_entity, name, code_subtype, role)` |
| `KNOWN_INFRASTRUCTURE_IDS` | 6 warehouses + 1 graveyard (hardcoded; discovered via 2026-05-12 live probe) |
| `STATION_SUBTYPES` / `WAREHOUSE_SUBTYPES` | Parent-relevant taxonomy from `/entity_subtypes` |
| `read_station_markers` | Read section names from a `stations.cfg` |
| `resolve_marker_to_entity_id` | Lookup marker → `id_entity` via `basic_search` |
| `default_station_cfg_path` | `GPS_CONFIG_PATH` env → `~/.config/gpsconfig/stations.cfg` |
| `enumerate_known_parents` | Top-level: infrastructure + stations.cfg + caller extras |

### Hardcoded infrastructure IDs

| id | role | name | subtype |
|---|---|---|---|
| 4 | warehouse | B9 - Kjallari - Jörð | `area` |
| 5 | warehouse | B9 - Kjallari - Vatn | `area` |
| 8 | warehouse | Vagnhöfði | `stock` |
| 10 | warehouse | Vagnhöfði - Kjallari - Jörð | `area` |
| 13 | warehouse | Vagnhöfði - Rafgeymaskúr | `area` |
| 16920 | warehouse | B9 - Verkstæði - Veður | `area` |
| 14 | graveyard | Hent | `discarded` (~1989 children_connections) |

The graveyard entity (`id=14 'Hent'`) was the surprise find — it's where decommissioned devices live. Without it in the bootstrap, ~1989 retired receivers' final state would show as fake gaps.

## Empirical correctness

Against `vi-api.vedur.is` on 2026-05-12, called with the deployed `stations.cfg` + 4 known-missing extras (Fagradalsfjall, Bláfjöll, Bárðabunga, Hestalda):

```
Total parents: 203
  station       196
  warehouse     6
  graveyard     1
```

Zero entries fall into the `"other"` bucket — every parent is correctly classified.

Initial probe surfaced one taxonomy gap: `id=8 Vagnhöfði` has `subtype='stock'` (not `'area'`), so `WAREHOUSE_SUBTYPES` covers both.

## Acknowledged caveat

`stations.cfg` is incomplete: at least 4 stations have current GNSS receivers but aren't in cfg. `extra_parent_ids` is the seam for callers to inject them by id. The fleet-sweep enumeration planned for §5 step 3 (this module's next addition) will close this gap automatically by collecting parents from every device's `basic_search` lvl_two.

## Tests

- 28 new tests in `tests/test_history.py` — every helper, every `role` branch (station/warehouse/graveyard/other plus `stock`-as-warehouse), unreadable infrastructure, unresolvable markers, dedup, env var + XDG cfg-path discovery
- [x] `pytest tests/` → 190 passed, 2 skipped (was 162 + 28 new = 190)
- [x] `ruff check src/` → clean
- [x] `black --check` → clean
- [x] Live smoke (above) — 203 parents in the expected breakdown

## Scope

This is §5 step 2 from the synthesis note `1778612553-tostools-history-reconstruction-leverage.md` — the bootstrap list. Step 3 is the `build_join_index` + `DeviceTimeline` work, which will live in this same `tostools.history` module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)