### PR TITLE
feat(history): build_join_index + DeviceTimeline + gap detection (step 3)

### DIFF
--- a/src/tostools/history.py
+++ b/src/tostools/history.py
@@ -1,22 +1,21 @@
-"""Device-history-reconstruction primitives (step 2 of the synthesis plan).
+"""Device-history-reconstruction primitives (synthesis plan §5 steps 2 & 3).
 
 This module owns the read-only primitives used to walk and reconstruct the
-full join history of GNSS devices in TOS. The first deliverable here is
-:func:`enumerate_known_parents` — the "bootstrap parent list" needed by the
-forthcoming :func:`build_join_index` (step 3 of the synthesis).
+full join history of GNSS devices in TOS.
 
 Why a separate module
 ---------------------
 TOS exposes ``children_connections`` only from the parent side; a device's
 own ``id_entity_parent`` attribute can be stale (see GitHub issue #17, fixed
-in PR #18). So to reconstruct a device's complete timeline we have to walk
-every parent the device might have touched. That requires knowing the parent
-set up front.
+in PR #18). To reconstruct a device's complete timeline we have to walk
+every parent it might have touched — :func:`build_join_index` does that
+once and gives us O(1) per-device lookup afterwards via
+:meth:`JoinIndex.timeline`. Gap detection on the timeline surfaces the
+"device was somewhere unrecorded" cases the user cares about.
 
 The synthesis note
 ``~/notes/bgovault/2.Areas/VI_GPS_Library/1778612553-tostools-history-reconstruction-leverage.md``
-captures the full design (§2.3 for the join index, §5 step 2 for this
-enumeration).
+captures the full design.
 
 What this module is NOT
 -----------------------
@@ -28,12 +27,24 @@ What this module is NOT
 
 API surface
 -----------
+Parent enumeration (§5 step 2):
+
 * :class:`ParentEntity` — frozen dataclass describing one parent.
 * :data:`KNOWN_INFRASTRUCTURE_IDS` — hardcoded entity IDs for the warehouse
   network + graveyard. Stable across deployments.
-* :func:`enumerate_known_parents` — top-level entry point. Returns the
-  bootstrap parent list (infrastructure + stations from ``stations.cfg``,
-  optionally augmented).
+* :func:`enumerate_known_parents` — returns the bootstrap parent list
+  (infrastructure + stations from ``stations.cfg``, optionally augmented).
+
+Join index + device timeline (§5 step 3):
+
+* :class:`Join` — one parent→child join from a parent's children_connections.
+* :class:`JoinIndex` — global child→[joins] map, dict-backed.
+* :class:`DeviceTimeline` — one device's full chronologically-sorted joins,
+  with ``open_joins``, ``closed_joins``, ``is_currently_attached``,
+  ``is_truly_orphan`` properties and ``gaps(min_days=…)`` detection.
+* :class:`Gap` — one unrecorded period between two adjacent closed→any joins.
+* :func:`build_join_index` — walk parents, return JoinIndex (~10s for the
+  IMO fleet).
 """
 
 from __future__ import annotations
@@ -41,8 +52,9 @@ from __future__ import annotations
 import configparser
 import logging
 import os
-from dataclasses import dataclass
-from typing import Any, Dict, Iterable, List, Optional
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence
 
 from .api.tos_client import TOSClient
 
@@ -351,3 +363,295 @@ def enumerate_known_parents(
         _add(int(eid))
 
     return list(seen.values())
+
+
+# ---------------------------------------------------------------------------
+# Join records, indexed by child
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Join:
+    """One parent→child join, sourced from a parent's ``children_connections``.
+
+    The shape mirrors the raw TOS payload directly — we don't enrich with
+    parent_name or child_subtype here (audit.JoinRecord does that). Keeping
+    Join lean lets the index stay cheap to build.
+    """
+
+    id_entity_connection: int
+    id_entity_parent: int
+    id_entity_child: int
+    time_from: str  # ISO 8601 datetime string from TOS
+    time_to: Optional[str]  # None = currently open
+
+    @property
+    def is_open(self) -> bool:
+        return self.time_to is None
+
+
+@dataclass(frozen=True)
+class Gap:
+    """A period during which the device has no recorded parent.
+
+    Bounded by the close of ``after`` (the preceding closed join) and the
+    open of ``before`` (the next join, open or closed). The user's
+    "device was at B9 but the move was never recorded" case shows up here.
+    """
+
+    id_entity: int
+    after: Join  # the closed join that ends the previous coverage
+    before: Join  # the next join that starts a new coverage period
+    duration_days: float  # decimal days between after.time_to and before.time_from
+
+    @property
+    def time_from(self) -> Optional[str]:
+        """The start of the gap (when the previous join closed)."""
+        return self.after.time_to
+
+    @property
+    def time_to(self) -> str:
+        """The end of the gap (when the next join opens)."""
+        return self.before.time_from
+
+
+class DeviceTimeline:
+    """The complete join history of one device, sorted chronologically.
+
+    Constructed by :meth:`JoinIndex.timeline`. Provides gap detection and
+    "is this device currently attached?" queries.
+    """
+
+    __slots__ = ("id_entity", "joins")
+
+    def __init__(self, id_entity: int, joins: Sequence[Join]):
+        self.id_entity = int(id_entity)
+        # Stable order: by time_from, with open joins after closed ones at
+        # the same time_from (so the chronological narrative reads
+        # "closed-then-opened" not "opened-then-closed").
+        self.joins: List[Join] = sorted(
+            joins,
+            key=lambda j: (j.time_from or "", 0 if not j.is_open else 1),
+        )
+
+    def __repr__(self) -> str:
+        return f"DeviceTimeline(id_entity={self.id_entity}, n_joins={len(self.joins)})"
+
+    @property
+    def open_joins(self) -> List[Join]:
+        return [j for j in self.joins if j.is_open]
+
+    @property
+    def closed_joins(self) -> List[Join]:
+        return [j for j in self.joins if not j.is_open]
+
+    @property
+    def is_currently_attached(self) -> bool:
+        """True if at least one open join exists."""
+        return any(j.is_open for j in self.joins)
+
+    @property
+    def is_truly_orphan(self) -> bool:
+        """True if the device has joins (so we know about it) but none open
+        (no current parent in TOS — the audit's I1-orphan signal, but
+        derived from the full index rather than ``id_entity_parent``).
+        """
+        return bool(self.joins) and not self.is_currently_attached
+
+    def gaps(self, *, min_days: float = 0.0) -> List[Gap]:
+        """Surface periods where no parent is recorded.
+
+        A gap is the time between the close of one join and the open of
+        the next adjacent (sorted) join, when the previous one is closed
+        and its ``time_to`` precedes the next one's ``time_from``.
+
+        ``min_days`` filters short gaps (typically date-rounding artifacts;
+        see synthesis note §2.3). Default 0 returns every gap; production
+        callers will want a threshold (start with 30 and calibrate).
+        """
+        if len(self.joins) < 2:
+            return []
+        out: List[Gap] = []
+        for prev, curr in zip(self.joins, self.joins[1:]):
+            if prev.is_open:
+                # Two opens or open-then-closed — that's overlap territory,
+                # not a gap. The audit's I1-multi-open / I2 checks deal
+                # with that case; we skip here.
+                continue
+            prev_end = _parse_iso(prev.time_to)
+            curr_start = _parse_iso(curr.time_from)
+            if prev_end is None or curr_start is None:
+                continue
+            delta_days = (curr_start - prev_end).total_seconds() / 86400.0
+            if delta_days <= 0:
+                # Overlap, not a gap.
+                continue
+            if delta_days < min_days:
+                continue
+            out.append(
+                Gap(
+                    id_entity=self.id_entity,
+                    after=prev,
+                    before=curr,
+                    duration_days=delta_days,
+                )
+            )
+        return out
+
+
+def _parse_iso(s: Optional[str]) -> Optional[datetime]:
+    """Best-effort ISO 8601 → datetime; returns None on failure.
+
+    TOS returns dates like ``'2025-11-05T00:00:00'`` (no timezone). We
+    accept the trailing ``Z`` form too for safety. Date-only fallback
+    handles malformed entries.
+    """
+    if not s:
+        return None
+    try:
+        return datetime.fromisoformat(s.replace("Z", "+00:00"))
+    except ValueError:
+        head = s.split("T")[0]
+        try:
+            return datetime.fromisoformat(head)
+        except ValueError:
+            return None
+
+
+@dataclass
+class JoinIndex:
+    """Global child→[joins] map, the cheap foundation of device-timeline lookup.
+
+    Built by :func:`build_join_index`. Lookup is O(1) per device.
+
+    Internal storage is a plain dict; the dataclass wrapper exists so we
+    can attach metadata (build time, parents visited) without making the
+    API surface large.
+    """
+
+    by_child: Dict[int, List[Join]] = field(default_factory=dict)
+    parents_walked: int = 0
+    parents_failed: int = 0
+
+    def timeline(self, id_entity: int) -> DeviceTimeline:
+        """Return the :class:`DeviceTimeline` for one device.
+
+        If no joins are indexed for that id, returns an empty timeline
+        (useful: ``timeline.is_currently_attached`` will be False).
+        """
+        joins = self.by_child.get(int(id_entity), [])
+        return DeviceTimeline(id_entity, joins)
+
+    @property
+    def total_joins(self) -> int:
+        return sum(len(v) for v in self.by_child.values())
+
+    @property
+    def device_ids(self) -> List[int]:
+        """All distinct child ids appearing in the index, sorted."""
+        return sorted(self.by_child.keys())
+
+
+# ---------------------------------------------------------------------------
+# Index builder
+# ---------------------------------------------------------------------------
+
+
+def _connection_to_join(
+    conn: Dict[str, Any], fallback_parent_id: int
+) -> Optional[Join]:
+    """Convert one ``children_connections[i]`` entry into a :class:`Join`.
+
+    Returns None for malformed entries (missing child id). The parent id
+    in the connection record is preferred; we fall back to the walked
+    parent's id when TOS omits it (rare but possible for some legacy
+    rows).
+    """
+    cid_raw = conn.get("id_entity_child")
+    if cid_raw is None:
+        return None
+    try:
+        cid = int(cid_raw)
+    except (TypeError, ValueError):
+        return None
+    pid_raw = conn.get("id_entity_parent")
+    try:
+        pid = int(pid_raw) if pid_raw is not None else int(fallback_parent_id)
+    except (TypeError, ValueError):
+        pid = int(fallback_parent_id)
+    return Join(
+        id_entity_connection=int(conn.get("id_entity_connection") or 0),
+        id_entity_parent=pid,
+        id_entity_child=cid,
+        time_from=str(conn.get("time_from") or ""),
+        time_to=conn.get("time_to"),
+    )
+
+
+def build_join_index(
+    client: TOSClient,
+    parents: Optional[Iterable[ParentEntity]] = None,
+    *,
+    progress: Optional[Callable[[int, int], None]] = None,
+) -> JoinIndex:
+    """Walk every parent's ``children_connections`` and aggregate joins by child.
+
+    This is the cheap O(P) primitive that makes per-device timeline lookup
+    O(1). For the live IMO TOS state (~200 parents, ~5000 joins total),
+    a fresh build takes ~10 seconds; subsequent ``.timeline(id)`` calls
+    are dict lookups.
+
+    Args:
+        client: An unauthenticated :class:`TOSClient`.
+        parents: An iterable of :class:`ParentEntity` to walk. If ``None``,
+            calls :func:`enumerate_known_parents` to use the bootstrap list.
+            Pass a custom iterable when you know exactly which parents
+            matter (e.g. only the warehouses, for a fast spot check).
+        progress: Optional ``(current, total)`` callback fired after each
+            parent fetch. Useful for CLI progress bars.
+
+    Returns:
+        A :class:`JoinIndex`. ``parents_walked`` / ``parents_failed`` on the
+        returned index reveal whether any parent failed to read (transient
+        TOS errors); the index is still usable, just missing those joins.
+    """
+    if parents is None:
+        parents = enumerate_known_parents(client)
+    parent_list = list(parents)
+
+    index = JoinIndex()
+    total = len(parent_list)
+    for i, parent in enumerate(parent_list, 1):
+        try:
+            h = client.get_entity_history(parent.id_entity)
+        except Exception as exc:
+            logger.warning(
+                "build_join_index: parent %d (%s) raised: %s; skipping",
+                parent.id_entity,
+                parent.name,
+                exc,
+            )
+            index.parents_failed += 1
+            if progress:
+                progress(i, total)
+            continue
+        if not h:
+            logger.warning(
+                "build_join_index: parent %d (%s) returned no history; skipping",
+                parent.id_entity,
+                parent.name,
+            )
+            index.parents_failed += 1
+            if progress:
+                progress(i, total)
+            continue
+        index.parents_walked += 1
+        for conn in h.get("children_connections") or []:
+            join = _connection_to_join(conn, parent.id_entity)
+            if join is None:
+                continue
+            index.by_child.setdefault(join.id_entity_child, []).append(join)
+        if progress:
+            progress(i, total)
+
+    return index

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -465,3 +465,541 @@ def test_default_station_cfg_path_returns_none_when_missing(
     monkeypatch.delenv("GPS_CONFIG_PATH", raising=False)
     monkeypatch.setenv("HOME", str(tmp_path))  # no .config/gpsconfig under here
     assert default_station_cfg_path() is None
+
+
+# ===========================================================================
+# Step 3 — Join, JoinIndex, DeviceTimeline, Gap, build_join_index
+# ===========================================================================
+
+
+from tostools.history import (  # noqa: E402  re-import to keep step-3 block self-contained
+    DeviceTimeline,
+    Gap,
+    Join,
+    JoinIndex,
+    _connection_to_join,
+    _parse_iso,
+    build_join_index,
+)
+
+
+def _join(
+    child: int,
+    parent: int,
+    time_from: str,
+    time_to: Optional[str] = None,
+    *,
+    connection_id: int = 0,
+) -> Join:
+    return Join(
+        id_entity_connection=connection_id,
+        id_entity_parent=parent,
+        id_entity_child=child,
+        time_from=time_from,
+        time_to=time_to,
+    )
+
+
+def _parent(
+    id_entity: int,
+    *,
+    role: str = "station",
+    subtype: str = "geophysical",
+    name: Optional[str] = None,
+) -> ParentEntity:
+    return ParentEntity(
+        id_entity=id_entity,
+        name=name,
+        code_subtype=subtype,
+        role=role,
+    )
+
+
+def _parent_history_with_conns(
+    id_entity: int,
+    conns: List[Dict[str, Any]],
+    subtype: str = "geophysical",
+) -> Dict[str, Any]:
+    return {
+        "id_entity": id_entity,
+        "code_entity_subtype": subtype,
+        "attributes": [],
+        "children_connections": conns,
+    }
+
+
+def _conn(
+    *,
+    id_entity_connection: int,
+    parent: int,
+    child: int,
+    time_from: str,
+    time_to: Optional[str] = None,
+) -> Dict[str, Any]:
+    return {
+        "id_entity_connection": id_entity_connection,
+        "id_entity_parent": parent,
+        "id_entity_child": child,
+        "time_from": time_from,
+        "time_to": time_to,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Join
+# ---------------------------------------------------------------------------
+
+
+def test_join_is_open_when_time_to_is_none():
+    j = _join(100, 50, "2025-03-15")
+    assert j.is_open is True
+
+
+def test_join_is_closed_when_time_to_is_set():
+    j = _join(100, 50, "2025-03-15", "2025-06-30")
+    assert j.is_open is False
+
+
+# ---------------------------------------------------------------------------
+# _parse_iso
+# ---------------------------------------------------------------------------
+
+
+def test_parse_iso_standard_datetime():
+    dt = _parse_iso("2025-11-05T00:00:00")
+    assert dt is not None
+    assert dt.year == 2025 and dt.month == 11 and dt.day == 5
+
+
+def test_parse_iso_with_z_suffix():
+    dt = _parse_iso("2025-11-05T00:00:00Z")
+    assert dt is not None
+    assert dt.year == 2025
+
+
+def test_parse_iso_date_only_fallback():
+    """If TOS ever returns a date without time, we still parse."""
+    dt = _parse_iso("2025-11-05")
+    assert dt is not None
+    assert dt.year == 2025
+
+
+def test_parse_iso_returns_none_for_garbage():
+    assert _parse_iso("not-a-date") is None
+    assert _parse_iso(None) is None
+    assert _parse_iso("") is None
+
+
+# ---------------------------------------------------------------------------
+# _connection_to_join
+# ---------------------------------------------------------------------------
+
+
+def test_connection_to_join_uses_connection_parent_id():
+    """When the conn has id_entity_parent, that's what we use (not the
+    fallback). Real TOS data always carries this."""
+    conn = _conn(
+        id_entity_connection=42,
+        parent=50,
+        child=100,
+        time_from="2025-03-15",
+    )
+    j = _connection_to_join(conn, fallback_parent_id=999)
+    assert j is not None
+    assert j.id_entity_parent == 50  # from conn, not fallback
+    assert j.id_entity_child == 100
+    assert j.id_entity_connection == 42
+
+
+def test_connection_to_join_falls_back_to_walked_parent_id_when_missing():
+    """Some legacy connection rows omit id_entity_parent; we fall back to
+    the parent we're currently walking."""
+    conn = {
+        "id_entity_connection": 42,
+        "id_entity_child": 100,
+        "time_from": "2025-03-15",
+        "time_to": None,
+    }
+    j = _connection_to_join(conn, fallback_parent_id=999)
+    assert j is not None
+    assert j.id_entity_parent == 999
+
+
+def test_connection_to_join_returns_none_for_missing_child_id():
+    conn = {
+        "id_entity_parent": 50,
+        "time_from": "2025-03-15",
+        "time_to": None,
+    }
+    j = _connection_to_join(conn, fallback_parent_id=999)
+    assert j is None
+
+
+# ---------------------------------------------------------------------------
+# DeviceTimeline — sorting and properties
+# ---------------------------------------------------------------------------
+
+
+def test_timeline_sorts_joins_by_time_from():
+    """Joins arrive from arbitrary parents in any order; the timeline
+    must sort them chronologically for gap detection to work."""
+    tl = DeviceTimeline(
+        100,
+        [
+            _join(100, 60, "2025-06-30", None),
+            _join(100, 50, "2020-01-01", "2025-05-15"),
+            _join(100, 70, "2018-04-01", "2019-12-31"),
+        ],
+    )
+    times = [j.time_from for j in tl.joins]
+    assert times == sorted(times)
+
+
+def test_timeline_open_and_closed_partition():
+    tl = DeviceTimeline(
+        100,
+        [
+            _join(100, 50, "2020-01-01", "2025-05-15"),
+            _join(100, 60, "2025-06-30", None),
+        ],
+    )
+    assert len(tl.open_joins) == 1
+    assert tl.open_joins[0].id_entity_parent == 60
+    assert len(tl.closed_joins) == 1
+    assert tl.closed_joins[0].id_entity_parent == 50
+
+
+def test_timeline_is_currently_attached_when_any_open_join():
+    tl = DeviceTimeline(100, [_join(100, 60, "2025-06-30", None)])
+    assert tl.is_currently_attached is True
+
+
+def test_timeline_is_truly_orphan_when_joins_but_none_open():
+    """The audit's I1-orphan signal, but derived from full index."""
+    tl = DeviceTimeline(
+        100,
+        [_join(100, 50, "2020-01-01", "2025-05-15")],
+    )
+    assert tl.is_truly_orphan is True
+    assert tl.is_currently_attached is False
+
+
+def test_timeline_empty_is_not_orphan():
+    """A device with NO joins anywhere isn't 'orphan' — it's not in the
+    index at all. is_truly_orphan requires joins-but-none-open."""
+    tl = DeviceTimeline(100, [])
+    assert tl.is_truly_orphan is False
+    assert tl.is_currently_attached is False
+
+
+# ---------------------------------------------------------------------------
+# DeviceTimeline.gaps
+# ---------------------------------------------------------------------------
+
+
+def test_gaps_empty_when_fewer_than_two_joins():
+    tl = DeviceTimeline(100, [_join(100, 50, "2025-03-15")])
+    assert tl.gaps() == []
+
+
+def test_gaps_detects_simple_gap():
+    """Models device 19969 (Grindavík vestur close 2025-05-05 → Grindavík
+    miðja open 2025-11-05 = ~184-day gap)."""
+    tl = DeviceTimeline(
+        19969,
+        [
+            _join(19969, 19968, "2023-11-15T00:00:00", "2025-05-05T00:00:00"),
+            _join(19969, 19964, "2025-11-05T00:00:00", None),
+        ],
+    )
+    gaps = tl.gaps()
+    assert len(gaps) == 1
+    g = gaps[0]
+    assert g.id_entity == 19969
+    assert g.after.id_entity_parent == 19968
+    assert g.before.id_entity_parent == 19964
+    assert 180 < g.duration_days < 190
+    assert g.time_from == "2025-05-05T00:00:00"
+    assert g.time_to == "2025-11-05T00:00:00"
+
+
+def test_gaps_min_days_threshold_filters_short_artifacts():
+    """1–30 day "gaps" are typically date-rounding artifacts (per advisor
+    caveat). The threshold drops them."""
+    tl = DeviceTimeline(
+        100,
+        [
+            _join(100, 50, "2020-01-01", "2020-06-01"),
+            _join(100, 60, "2020-06-05", None),  # 4-day gap
+        ],
+    )
+    assert len(tl.gaps(min_days=0)) == 1
+    assert tl.gaps(min_days=30) == []
+
+
+def test_gaps_ignores_overlap_as_gap():
+    """When the next join starts BEFORE the previous one closes, that's
+    overlap (an I2-style anomaly), not a gap."""
+    tl = DeviceTimeline(
+        100,
+        [
+            _join(100, 50, "2020-01-01", "2025-12-31"),
+            _join(100, 60, "2024-06-15", None),  # starts inside join-1
+        ],
+    )
+    assert tl.gaps() == []
+
+
+def test_gaps_ignores_pair_starting_with_open_join():
+    """Two opens (or open-then-closed) is multi-open territory, not a gap."""
+    tl = DeviceTimeline(
+        100,
+        [
+            _join(100, 50, "2020-01-01", None),  # open
+            _join(100, 60, "2025-06-30", None),  # open
+        ],
+    )
+    assert tl.gaps() == []
+
+
+def test_gaps_handles_unparseable_dates():
+    """If TOS ever returns malformed dates, skip the affected gap rather
+    than crashing."""
+    tl = DeviceTimeline(
+        100,
+        [
+            _join(100, 50, "2020-01-01", "garbage"),
+            _join(100, 60, "2025-06-30", None),
+        ],
+    )
+    # Bad close date → no gap surfaced, no exception.
+    assert tl.gaps() == []
+
+
+def test_gaps_multiple_gaps_in_one_timeline():
+    """A device that bounced through several stations with gaps between."""
+    tl = DeviceTimeline(
+        100,
+        [
+            _join(100, 50, "2018-01-01", "2019-06-30"),
+            _join(100, 60, "2020-01-15", "2022-08-15"),  # gap 1: ~6.5 months
+            _join(100, 70, "2024-03-01", None),  # gap 2: ~18.5 months
+        ],
+    )
+    gaps = tl.gaps(min_days=30)
+    assert len(gaps) == 2
+    # First gap is between 50-close and 60-open
+    assert gaps[0].after.id_entity_parent == 50
+    assert gaps[0].before.id_entity_parent == 60
+    # Second between 60-close and 70-open
+    assert gaps[1].after.id_entity_parent == 60
+    assert gaps[1].before.id_entity_parent == 70
+
+
+# ---------------------------------------------------------------------------
+# JoinIndex
+# ---------------------------------------------------------------------------
+
+
+def test_join_index_timeline_for_known_device():
+    idx = JoinIndex(
+        by_child={
+            100: [
+                _join(100, 50, "2020-01-01", "2025-05-15"),
+                _join(100, 60, "2025-06-30", None),
+            ]
+        }
+    )
+    tl = idx.timeline(100)
+    assert isinstance(tl, DeviceTimeline)
+    assert len(tl.joins) == 2
+
+
+def test_join_index_timeline_for_unknown_device_returns_empty():
+    idx = JoinIndex()
+    tl = idx.timeline(999)
+    assert tl.joins == []
+    assert tl.is_currently_attached is False
+
+
+def test_join_index_total_joins_counts_across_all_devices():
+    idx = JoinIndex(
+        by_child={
+            100: [_join(100, 50, "2020-01-01")],
+            200: [
+                _join(200, 50, "2020-01-01", "2022-01-01"),
+                _join(200, 60, "2022-02-01", None),
+            ],
+        }
+    )
+    assert idx.total_joins == 3
+
+
+def test_join_index_device_ids_returns_sorted_unique():
+    idx = JoinIndex(
+        by_child={
+            200: [_join(200, 50, "2020-01-01")],
+            100: [_join(100, 50, "2020-01-01")],
+        }
+    )
+    assert idx.device_ids == [100, 200]
+
+
+# ---------------------------------------------------------------------------
+# build_join_index
+# ---------------------------------------------------------------------------
+
+
+def test_build_join_index_aggregates_across_parents():
+    """A device joined to parent A then to parent B shows both joins in
+    its timeline after one full index build."""
+    h_a = _parent_history_with_conns(
+        50,
+        conns=[
+            _conn(
+                id_entity_connection=1,
+                parent=50,
+                child=100,
+                time_from="2020-01-01",
+                time_to="2022-05-15",
+            )
+        ],
+    )
+    h_b = _parent_history_with_conns(
+        60,
+        conns=[
+            _conn(
+                id_entity_connection=2,
+                parent=60,
+                child=100,
+                time_from="2023-03-15",
+                time_to=None,
+            )
+        ],
+    )
+    client = MagicMock()
+    client.get_entity_history.side_effect = lambda i: {50: h_a, 60: h_b}.get(int(i))
+
+    idx = build_join_index(client, parents=[_parent(50), _parent(60)])
+
+    assert idx.parents_walked == 2
+    assert idx.parents_failed == 0
+    tl = idx.timeline(100)
+    assert len(tl.joins) == 2
+    # Sorted chronologically
+    assert tl.joins[0].id_entity_parent == 50
+    assert tl.joins[1].id_entity_parent == 60
+    # Closed → Open transition is a recoverable gap
+    gaps = tl.gaps()
+    assert len(gaps) == 1
+
+
+def test_build_join_index_skips_unreadable_parent():
+    """A parent whose history returns None (deleted? transient error?) is
+    counted as failed; the rest of the index is unaffected."""
+    h_b = _parent_history_with_conns(
+        60,
+        conns=[
+            _conn(
+                id_entity_connection=2,
+                parent=60,
+                child=100,
+                time_from="2023-03-15",
+            )
+        ],
+    )
+    client = MagicMock()
+    client.get_entity_history.side_effect = lambda i: {60: h_b}.get(int(i))
+
+    idx = build_join_index(client, parents=[_parent(50), _parent(60)])
+
+    assert idx.parents_walked == 1
+    assert idx.parents_failed == 1
+    assert idx.timeline(100).joins[0].id_entity_parent == 60
+
+
+def test_build_join_index_progress_callback_fires_per_parent():
+    h = _parent_history_with_conns(50, conns=[])
+    client = MagicMock()
+    client.get_entity_history.return_value = h
+
+    calls: List[tuple] = []
+    idx = build_join_index(
+        client,
+        parents=[_parent(50), _parent(60), _parent(70)],
+        progress=lambda i, total: calls.append((i, total)),
+    )
+    _ = idx  # unused
+    assert calls == [(1, 3), (2, 3), (3, 3)]
+
+
+def test_build_join_index_handles_get_entity_history_exception():
+    """A network error reading one parent should NOT abort the whole
+    index build."""
+    h_good = _parent_history_with_conns(60, conns=[])
+
+    def hist(i):
+        if int(i) == 50:
+            raise RuntimeError("transient TOS error")
+        return h_good if int(i) == 60 else None
+
+    client = MagicMock()
+    client.get_entity_history.side_effect = hist
+
+    idx = build_join_index(client, parents=[_parent(50), _parent(60)])
+
+    assert idx.parents_walked == 1
+    assert idx.parents_failed == 1
+
+
+def test_build_join_index_calls_enumerate_known_parents_when_none(monkeypatch):
+    """The convenience case ``parents=None`` calls enumerate_known_parents
+    so callers don't need to wire it up themselves."""
+    import tostools.history as histmod
+
+    sentinel = [_parent(4, role="warehouse", subtype="area")]
+    h = _parent_history_with_conns(4, conns=[], subtype="area")
+    client = MagicMock()
+    client.get_entity_history.return_value = h
+
+    monkeypatch.setattr(histmod, "enumerate_known_parents", lambda c: sentinel)
+    idx = build_join_index(client)
+
+    assert idx.parents_walked == 1
+
+
+def test_build_join_index_ignores_malformed_connection_rows():
+    """A row missing id_entity_child is dropped; index still built from
+    the well-formed rows."""
+    h = _parent_history_with_conns(
+        50,
+        conns=[
+            {"id_entity_connection": 1, "time_from": "2020-01-01"},  # no child
+            _conn(
+                id_entity_connection=2,
+                parent=50,
+                child=100,
+                time_from="2021-01-01",
+            ),
+        ],
+    )
+    client = MagicMock()
+    client.get_entity_history.return_value = h
+
+    idx = build_join_index(client, parents=[_parent(50)])
+
+    assert idx.total_joins == 1
+    assert 100 in idx.device_ids
+
+
+# ---------------------------------------------------------------------------
+# Gap dataclass
+# ---------------------------------------------------------------------------
+
+
+def test_gap_time_from_and_time_to_properties():
+    j_after = _join(100, 50, "2020-01-01", "2022-05-15")
+    j_before = _join(100, 60, "2023-03-15", None)
+    g = Gap(id_entity=100, after=j_after, before=j_before, duration_days=304.0)
+    assert g.time_from == "2022-05-15"
+    assert g.time_to == "2023-03-15"


### PR DESCRIPTION
## Summary

Extends `tostools.history` with the join-index foundation — the answer to your "can we reconstruct the device history of all receivers in a continuous manner, i.e. are there gaps where they are not accounted for?" question. Builds on the parent enumeration shipped in #19 (step 2). **Pure addition; no existing module touched.** `tosGPS`, `legacy/*`, `audit` all unaffected (memory-note guardrail).

## What's new

| | |
|---|---|
| `Join` (frozen) | One parent→child record from `children_connections` |
| `JoinIndex` | Dict-backed global child→[joins] map with `parents_walked` / `parents_failed` / `total_joins` / `device_ids` |
| `DeviceTimeline` | Per-device chronologically-sorted joins; `open_joins` / `closed_joins` / `is_currently_attached` / `is_truly_orphan` properties; **`gaps(min_days=…)`** |
| `Gap` (frozen) | One unrecorded period (closed→any pair) with `duration_days` and `time_from` / `time_to` props |
| `build_join_index(client, parents=None, progress=…)` | Walks every parent's `children_connections`; defaults to `enumerate_known_parents` for ergonomics |

## Usage

```python
from tostools.api.tos_client import TOSClient
from tostools.history import build_join_index

c = TOSClient()
idx = build_join_index(c)               # ~10s for the IMO fleet
tl = idx.timeline(19969)                # O(1) dict lookup
for g in tl.gaps(min_days=30):          # filter date-rounding artifacts
    print(g.time_from, "→", g.time_to, f"({g.duration_days:.0f} days)")
```

## Design highlights

- **Gap detection only counts CLOSED→ANY adjacent pairs** where `curr.time_from > prev.time_to`. Two-opens, open-then-closed, and overlapping joins are NOT gaps (those are `audit`'s I1/I2 territory).
- **`min_days` threshold** for noise filtering. The user's "device sat at B9 but the move was never recorded" cases are months/years; date-rounding artifacts are days. Advisor caveat from synthesis §2.3 baked into the API.
- **ISO 8601 parsing** accepts the standard form, trailing-`Z` form, and date-only fallback. Garbage dates yield no gap rather than raising — partial timelines are useful.
- **One-time O(P) build, O(1) lookups**. ~200 parents × ~50ms = ~10s rebuild; subsequent queries are dict lookups.
- **Per-parent failure tolerance**: a single unreadable parent (deleted, transient TOS error) is logged + counted in `parents_failed`; the rest of the index is still usable.

## Tests

32 new tests covering every public class + helper:

- **Join** — open/closed semantics
- **`_parse_iso`** — standard form, Z suffix, date-only fallback, garbage rejection
- **`_connection_to_join`** — primary parent id, fallback when missing, drop on missing child
- **DeviceTimeline** — chronological sort, open/closed partition, `is_currently_attached`, `is_truly_orphan`, empty case
- **Gap detection** — simple gap, `min_days` threshold, overlap-is-not-gap, open-then-anything ignored, malformed dates, multi-gap timeline
- **JoinIndex** — lookup, unknown device returns empty, `total_joins`, `device_ids` sort
- **build_join_index** — cross-parent aggregation, skip unreadable parent, progress callback, exception tolerance, default to `enumerate_known_parents`, malformed-connection drop
- **Gap dataclass** — `time_from` / `time_to` props

- [x] Full suite: **222 passed, 2 skipped** (was 190; +32 new)
- [x] `ruff check src/` — clean
- [x] `black --check` — clean

## Live smoke status

**Deferred.** VPN to `vi-api.vedur.is` was down at commit time. All network-error paths verified locally (graceful degradation: empty index returned, warnings logged, no exceptions). Once VPN's back, the canonical smoke is:

```python
idx = build_join_index(c)
tl = idx.timeline(19969)        # known case: Grindavík vestur → Grindavík miðja
[g for g in tl.gaps(min_days=30)]
# expected: one ~184-day gap (2025-05-05 close → 2025-11-05 open)
```

## Scope

This is §5 step 3 from the synthesis note `1778612553-tostools-history-reconstruction-leverage.md`. Next steps in the plan:

- **Step 4** — run the gap-detection report fleet-wide with `--min-gap-days=30` (calibrate after first run).
- **Step 5** — re-design `cfg move` around the PATCH-close-then-POST ordering (no rollback verb needed).
- **Step 7** — `cfg fix` triage workflow that uses both the join index and RINEX-based gap evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)