### PR TITLE
feat: rinex tools + station export (carries forward #8, #9, #10, #11)

### DIFF
--- a/scripts/export_station_equipment.py
+++ b/scripts/export_station_equipment.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""
+Export all GNSS stations with coordinates and current equipment information.
+
+This script queries the TOS API for all stations and extracts:
+- Station identifier (marker)
+- Station name
+- Coordinates (lat, lon)
+- Current receiver type
+- Current antenna type
+
+Output formats: CSV, JSON, or Excel
+"""
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+# Add src to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from tostools.legacy import gps_metadata_qc as gpsqc
+from tostools.legacy.gps_metadata_functions import getStationList
+
+
+def get_current_equipment(station_marker, url_rest_tos, loglevel=logging.WARNING):
+    """
+    Get current equipment for a station.
+
+    Returns dict with current receiver, antenna, and radome info.
+    """
+    try:
+        station, devices_history = gpsqc.get_station_metadata(
+            station_marker, url_rest_tos, loglevel=loglevel
+        )
+        device_sessions = gpsqc.get_device_sessions(
+            devices_history, url_rest_tos, loglevel=loglevel
+        )
+
+        # Find current equipment (time_to is None)
+        current_receiver = None
+        current_antenna = None
+        current_radome = None
+
+        for session in device_sessions:
+            if session.get("time_to") is None:  # Current equipment
+                device_type = session["device"]["code_entity_subtype"]
+
+                if device_type == "gnss_receiver":
+                    current_receiver = {
+                        "model": session["device"].get("model", ""),
+                        "serial_number": session["device"].get("serial_number", ""),
+                        "firmware": session["device"].get("firmware_version", ""),
+                    }
+                elif device_type == "antenna":
+                    current_antenna = {
+                        "model": session["device"].get("model", ""),
+                        "serial_number": session["device"].get("serial_number", ""),
+                        "height": session["device"].get("antenna_height", 0.0),
+                    }
+                elif device_type == "radome":
+                    current_radome = {
+                        "model": session["device"].get("model", "NONE"),
+                    }
+
+        return {
+            "receiver": current_receiver,
+            "antenna": current_antenna,
+            "radome": current_radome,
+        }
+    except Exception as e:
+        logging.warning(f"Failed to get equipment for {station_marker}: {e}")
+        return {
+            "receiver": None,
+            "antenna": None,
+            "radome": None,
+        }
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Export GNSS station coordinates and current equipment"
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        required=True,
+        help="Output file path (extension determines format: .csv, .json, .xlsx)",
+    )
+    parser.add_argument(
+        "--log-level",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        default="WARNING",
+        help="Logging level",
+    )
+    parser.add_argument(
+        "--include-inactive",
+        action="store_true",
+        help="Include stations with no current equipment",
+    )
+    parser.add_argument(
+        "--url",
+        default="https://vi-api.vedur.is/tos/v1",
+        help="TOS API base URL (default: https://vi-api.vedur.is/tos/v1)",
+    )
+
+    args = parser.parse_args()
+
+    # Configure logging
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="[%(levelname)s] %(message)s",
+        stream=sys.stderr,
+    )
+
+    print("Fetching station list from TOS API...", file=sys.stderr)
+    station_list = getStationList()
+
+    print(
+        f"Found {len(station_list)} stations. Querying equipment information...",
+        file=sys.stderr,
+    )
+
+    results = []
+    url_rest_tos = args.url
+
+    for i, station in enumerate(station_list, 1):
+        marker = station["marker"]
+        print(f"[{i}/{len(station_list)}] Processing {marker}...", file=sys.stderr)
+
+        equipment = get_current_equipment(marker, url_rest_tos, loglevel=logging.ERROR)
+
+        # Skip stations with no current equipment if not including inactive
+        if not args.include_inactive:
+            if equipment["receiver"] is None and equipment["antenna"] is None:
+                print(f"  Skipping {marker} (no current equipment)", file=sys.stderr)
+                continue
+
+        result = {
+            "marker": marker,
+            "name": station.get("name", ""),
+            "latitude": station.get("lat"),
+            "longitude": station.get("lon"),
+            "receiver_type": (
+                equipment["receiver"]["model"] if equipment["receiver"] else ""
+            ),
+            "antenna_type": (
+                equipment["antenna"]["model"] if equipment["antenna"] else ""
+            ),
+        }
+
+        results.append(result)
+
+    # Create DataFrame
+    df = pd.DataFrame(results)
+
+    # Determine output format from extension
+    output_path = Path(args.output)
+    output_format = output_path.suffix.lower()
+
+    print(f"\nWriting {len(results)} stations to {output_path}...", file=sys.stderr)
+
+    if output_format == ".csv":
+        df.to_csv(output_path, index=False)
+    elif output_format == ".json":
+        df.to_json(output_path, orient="records", indent=2)
+    elif output_format in [".xlsx", ".xls"]:
+        df.to_excel(output_path, index=False, engine="openpyxl")
+    else:
+        print(f"Error: Unsupported output format '{output_format}'", file=sys.stderr)
+        print("Supported formats: .csv, .json, .xlsx", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Done! Exported {len(results)} stations.", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tostools/rinex/reader.py
+++ b/src/tostools/rinex/reader.py
@@ -6,11 +6,120 @@ including support for various compression formats.
 """
 
 import logging
+import re
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Union
 
 from ..io.file_utils import read_gzip_file, read_text_file, read_zzipped_file
 from ..utils.logging import get_logger
+
+# Lowercase month names — match the on-disk archive layout
+# ``<base>/<YYYY>/<mon>/<STA>/...`` used by the IMO GPS pipeline.
+MONTHS = [
+    "jan",
+    "feb",
+    "mar",
+    "apr",
+    "may",
+    "jun",
+    "jul",
+    "aug",
+    "sep",
+    "oct",
+    "nov",
+    "dec",
+]
+
+
+def _parse_daily_rinex_date(name: str, station: str) -> Optional[datetime]:
+    """
+    Parse the observation date from a daily Hatanaka RINEX filename.
+
+    Expected pattern: ``STA<DDD>0.<YY>[DO][.Z|.gz]`` where DDD is day of year
+    and YY is two-digit year (pivot 80: <80 → 2000+YY, otherwise 1900+YY).
+
+    Args:
+        name: Bare filename (no directory)
+        station: Four-character station code
+
+    Returns:
+        ``datetime`` at 00:00 on the parsed date, or ``None`` if the name
+        does not match the daily pattern
+    """
+    m = re.match(
+        rf"^{re.escape(station)}(\d{{3}})\d\.(\d{{2}})[DO](?:\.Z|\.gz)?$",
+        name,
+        re.IGNORECASE,
+    )
+    if not m:
+        return None
+    doy = int(m.group(1))
+    yy = int(m.group(2))
+    year = 2000 + yy if yy < 80 else 1900 + yy
+    return datetime(year, 1, 1) + timedelta(days=doy - 1)
+
+
+def _scan_dir_dates(
+    directory: Path,
+    parser,
+    station: str,
+) -> List[Tuple[datetime, Path]]:
+    """Return ``(date, path)`` pairs for every file in ``directory`` whose
+    name is recognised by ``parser``. Returns an empty list if the directory
+    does not exist.
+    """
+    if not directory.is_dir():
+        return []
+    dates: List[Tuple[datetime, Path]] = []
+    for f in directory.iterdir():
+        dt = parser(f.name, station)
+        if dt is not None:
+            dates.append((dt, f))
+    return dates
+
+
+def find_most_recent_rinex(
+    station: str,
+    base_dir: Union[str, Path] = "/mnt_data/rawgpsdata",
+    rate_dir: str = "15s_24hr",
+) -> Optional[Path]:
+    """
+    Return the most recent daily RINEX file for a station.
+
+    Archive layout:
+    ``<base_dir>/<YYYY>/<mon>/<STATION>/<rate_dir>/rinex/<STA><DDD>0.<YY>[DO][.Z|.gz]``
+
+    Walks years and months descending and, within the first populated month
+    found, returns the file with the highest ``(year, DOY)``.
+
+    Args:
+        station: Four-character station code (case-insensitive)
+        base_dir: Archive root directory
+        rate_dir: Sampling-rate subdirectory (default ``"15s_24hr"``)
+
+    Returns:
+        Path to the most recent daily RINEX file, or ``None`` if no
+        matching file is found under ``base_dir``.
+    """
+    base = Path(base_dir)
+    if not base.is_dir():
+        return None
+
+    sta = station.upper()
+    years = sorted(
+        (p for p in base.iterdir() if p.is_dir() and p.name.isdigit()),
+        reverse=True,
+    )
+    for year_dir in years:
+        months_present = [m for m in MONTHS if (year_dir / m).is_dir()]
+        for mon in reversed(months_present):
+            rinex_dir = year_dir / mon / sta / rate_dir / "rinex"
+            dates = _scan_dir_dates(rinex_dir, _parse_daily_rinex_date, sta)
+            if dates:
+                dates.sort()
+                return dates[-1][1]
+    return None
 
 
 def get_rinex_labels() -> Tuple[List[str], List[str]]:

--- a/src/tostools/rinex/reader.py
+++ b/src/tostools/rinex/reader.py
@@ -9,7 +9,7 @@ import logging
 import re
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from ..io.file_utils import read_gzip_file, read_text_file, read_zzipped_file
 from ..utils.logging import get_logger
@@ -60,6 +60,39 @@ def _parse_daily_rinex_date(name: str, station: str) -> Optional[datetime]:
     return datetime(year, 1, 1) + timedelta(days=doy - 1)
 
 
+def _parse_hourly_raw_date(name: str, station: str) -> Optional[datetime]:
+    """
+    Parse the observation timestamp from a 1 Hz raw filename.
+
+    Expected prefix: ``STA<YYYY><MM><DD><HHMM>`` (followed by any suffix/extension).
+
+    Args:
+        name: Bare filename (no directory)
+        station: Four-character station code
+
+    Returns:
+        ``datetime`` at the parsed timestamp, or ``None`` if the name does
+        not match the hourly pattern
+    """
+    m = re.match(
+        rf"^{re.escape(station)}(\d{{4}})(\d{{2}})(\d{{2}})(\d{{2}})(\d{{2}})",
+        name,
+        re.IGNORECASE,
+    )
+    if not m:
+        return None
+    try:
+        return datetime(
+            int(m.group(1)),
+            int(m.group(2)),
+            int(m.group(3)),
+            int(m.group(4)),
+            int(m.group(5)),
+        )
+    except ValueError:
+        return None
+
+
 def _scan_dir_dates(
     directory: Path,
     parser,
@@ -77,6 +110,87 @@ def _scan_dir_dates(
         if dt is not None:
             dates.append((dt, f))
     return dates
+
+
+def find_station_archive_range(
+    station: str,
+    base_dir: Union[str, Path] = "/mnt_data/rawgpsdata",
+) -> Dict[str, Any]:
+    """
+    Find the first and last archived file for a station.
+
+    Scans the archive layout
+    ``<base_dir>/<YYYY>/<mon>/<STATION>/<rate>/<leaf>/`` for two rate kinds:
+
+    * ``15s_24hr/rinex`` — daily Hatanaka RINEX (``STA<DDD>0.<YY>D[.Z|.gz]``)
+    * ``1Hz_1hr/raw``   — hourly raw (``STA<YYYY><MM><DD><HHMM>...``)
+
+    For each kind, walks years ascending to find the earliest month that
+    contains matching files (and picks the earliest file in that month),
+    then mirrors the walk descending for the latest.
+
+    Args:
+        station: Four-character station code (case-insensitive)
+        base_dir: Archive root directory
+
+    Returns:
+        Dict with per-kind results under keys ``"15s_24hr"`` and ``"1Hz_1hr"``
+        (each containing ``first``, ``last``, ``first_file``, ``last_file``)
+        plus the overall ``first`` and ``last`` across kinds.
+    """
+    base = Path(base_dir)
+    sta = station.upper()
+    kinds = [
+        ("15s_24hr", "15s_24hr", "rinex", _parse_daily_rinex_date),
+        ("1Hz_1hr", "1Hz_1hr", "raw", _parse_hourly_raw_date),
+    ]
+
+    if not base.is_dir():
+        return {"first": None, "last": None, "15s_24hr": {}, "1Hz_1hr": {}}
+
+    years = sorted([p.name for p in base.iterdir() if p.is_dir() and p.name.isdigit()])
+
+    result: Dict[str, Any] = {}
+    for kind, rate, leaf, parser in kinds:
+        first_dt = last_dt = None
+        first_file = last_file = None
+
+        for y in years:
+            found = False
+            for mon in MONTHS:
+                dates = _scan_dir_dates(base / y / mon / sta / rate / leaf, parser, sta)
+                if dates:
+                    dates.sort()
+                    first_dt, first_file = dates[0]
+                    found = True
+                    break
+            if found:
+                break
+
+        for y in reversed(years):
+            found = False
+            for mon in reversed(MONTHS):
+                dates = _scan_dir_dates(base / y / mon / sta / rate / leaf, parser, sta)
+                if dates:
+                    dates.sort()
+                    last_dt, last_file = dates[-1]
+                    found = True
+                    break
+            if found:
+                break
+
+        result[kind] = {
+            "first": first_dt,
+            "last": last_dt,
+            "first_file": first_file,
+            "last_file": last_file,
+        }
+
+    firsts = [result[k]["first"] for k in ("15s_24hr", "1Hz_1hr") if result[k]["first"]]
+    lasts = [result[k]["last"] for k in ("15s_24hr", "1Hz_1hr") if result[k]["last"]]
+    result["first"] = min(firsts) if firsts else None
+    result["last"] = max(lasts) if lasts else None
+    return result
 
 
 def find_most_recent_rinex(

--- a/src/tostools/rinex/validator.py
+++ b/src/tostools/rinex/validator.py
@@ -6,9 +6,11 @@ information and performing quality control checks.
 """
 
 import logging
+import math
 from datetime import datetime
 from typing import Any, Dict, List
 
+from .. import gps_metadata_qc as gpsqc
 from ..utils.logging import get_logger
 
 
@@ -16,6 +18,7 @@ def compare_rinex_to_tos(
     rinex_info: Dict[str, str],
     tos_session: Dict[str, Any],
     loglevel: int = logging.WARNING,
+    coord_tolerance: float = 10.0,
 ) -> Dict[str, Any]:
     """
     Compare RINEX header information with TOS database session.
@@ -24,6 +27,9 @@ def compare_rinex_to_tos(
         rinex_info: Extracted RINEX header information
         tos_session: TOS session data with device information
         loglevel: Logging level
+        coord_tolerance: Maximum distance in meters between the RINEX
+            APPROX POSITION XYZ and the TOS coordinates (transformed to
+            ECEF) before the coordinate check is flagged as a discrepancy
 
     Returns:
         Dictionary containing comparison results and corrections
@@ -120,6 +126,47 @@ def compare_rinex_to_tos(
                         comparison_result["matches"]["antenna_height"] = rinex_h
                 except (ValueError, IndexError) as e:
                     logger.warning(f"Error parsing antenna height: {e}")
+
+    # Compare approximate position (XYZ) against TOS coordinates
+    rinex_xyz_str = rinex_info.get("APPROX POSITION XYZ", "").strip()
+    tos_lat = tos_session.get("lat")
+    tos_lon = tos_session.get("lon")
+    tos_alt = tos_session.get("altitude")
+
+    have_tos_coords = (
+        tos_lat is not None and tos_lon is not None and tos_alt is not None
+    )
+    if rinex_xyz_str and have_tos_coords:
+        try:
+            rinex_xyz = [float(v) for v in rinex_xyz_str.split()[:3]]
+            tos_xyz = list(
+                gpsqc.wgs84toitrf08.transform(
+                    float(tos_lat), float(tos_lon), float(tos_alt)
+                )
+            )
+            diff = [r - t for r, t in zip(rinex_xyz, tos_xyz)]
+            distance = math.sqrt(sum(d * d for d in diff))
+
+            comparison_result["coord_check"] = {
+                "rinex_xyz": rinex_xyz,
+                "tos_xyz": tos_xyz,
+                "diff_xyz": diff,
+                "distance_m": distance,
+                "tolerance_m": coord_tolerance,
+                "exceeds_tolerance": distance > coord_tolerance,
+            }
+
+            if distance > coord_tolerance:
+                comparison_result["discrepancies"]["coordinates"] = {
+                    "rinex": rinex_xyz,
+                    "tos": tos_xyz,
+                    "distance_m": distance,
+                    "tolerance_m": coord_tolerance,
+                }
+            else:
+                comparison_result["matches"]["coordinates"] = distance
+        except (ValueError, TypeError) as e:
+            logger.warning(f"Error comparing coordinates: {e}")
 
     # Compare observer/agency
     observer_info = tos_session.get("contact", {})

--- a/src/tostools/tosGPS.py
+++ b/src/tostools/tosGPS.py
@@ -596,6 +596,13 @@ Examples:
     )
     rinex_parser.add_argument("rinex_files", nargs="+", help="RINEX files to validate")
     rinex_parser.add_argument(
+        "--coord-tolerance",
+        type=float,
+        default=10.0,
+        help="Max allowed distance (m) between RINEX APPROX POSITION XYZ "
+        "and TOS coordinates (default: 10.0)",
+    )
+    rinex_parser.add_argument(
         "--fix", action="store_true", help="Apply corrections to RINEX headers"
     )
     rinex_parser.add_argument(
@@ -1177,10 +1184,30 @@ def _handle_rinex_subcommand(args, stations, url, log_level):
             rinex_info = extract_header_info(header_data, log_level.value)
 
             # Compare with TOS metadata
-            comparison = compare_rinex_to_tos(rinex_info, station_data, log_level.value)
+            comparison = compare_rinex_to_tos(
+                rinex_info,
+                station_data,
+                log_level.value,
+                coord_tolerance=args.coord_tolerance,
+            )
             all_comparisons.append(
                 {"station": station, "file": rinex_file, "comparison": comparison}
             )
+
+            # Always report the coordinate check if available
+            coord_check = comparison.get("coord_check")
+            if coord_check:
+                dx, dy, dz = coord_check["diff_xyz"]
+                print(
+                    "Coordinates: ΔX={:+.3f} ΔY={:+.3f} ΔZ={:+.3f} → "
+                    "distance={:.3f} m (tolerance {:.1f} m)".format(
+                        dx,
+                        dy,
+                        dz,
+                        coord_check["distance_m"],
+                        coord_check["tolerance_m"],
+                    )
+                )
 
             # Report discrepancies
             if comparison.get("discrepancies"):

--- a/src/tostools/tosGPS.py
+++ b/src/tostools/tosGPS.py
@@ -21,7 +21,11 @@ from .legacy import gps_metadata_functions as gpsf
 # Use the comprehensive legacy site log generator
 # from .core.site_log import generate_igs_site_log
 from .rinex.editor import update_rinex_files
-from .rinex.reader import extract_header_info, read_rinex_header
+from .rinex.reader import (
+    extract_header_info,
+    find_most_recent_rinex,
+    read_rinex_header,
+)
 from .rinex.validator import compare_rinex_to_tos
 from .utils.data_quality import data_quality_manager
 
@@ -594,7 +598,19 @@ Examples:
     rinex_parser.add_argument(
         "stations", nargs="+", help="GPS stations to validate against"
     )
-    rinex_parser.add_argument("rinex_files", nargs="+", help="RINEX files to validate")
+    rinex_parser.add_argument(
+        "rinex_files",
+        nargs="*",
+        help="RINEX files to validate (if omitted, the most recent daily "
+        "file per station is resolved from --rinex-base-dir)",
+    )
+    rinex_parser.add_argument(
+        "--rinex-base-dir",
+        type=str,
+        default="/mnt_data/rawgpsdata",
+        help="Archive root when rinex_files is omitted "
+        "(default: /mnt_data/rawgpsdata)",
+    )
     rinex_parser.add_argument(
         "--coord-tolerance",
         type=float,
@@ -1165,8 +1181,24 @@ def _handle_rinex_subcommand(args, stations, url, log_level):
             print(f"Error retrieving station data: {e}", file=sys.stderr)
             continue
 
+        # Resolve the list of RINEX files: explicit args, or
+        # most-recent-from-archive when none provided.
+        if args.rinex_files:
+            files_for_station = list(args.rinex_files)
+        else:
+            resolved = find_most_recent_rinex(station, base_dir=args.rinex_base_dir)
+            if resolved is None:
+                print(
+                    f"Warning: No RINEX file found for {station} under "
+                    f"{args.rinex_base_dir}",
+                    file=sys.stderr,
+                )
+                continue
+            print(f"Using most recent RINEX file: {resolved}", file=sys.stderr)
+            files_for_station = [str(resolved)]
+
         # Validate each RINEX file
-        for rinex_file in args.rinex_files:
+        for rinex_file in files_for_station:
             rinex_path = Path(rinex_file)
             if not rinex_path.exists():
                 print(f"Warning: RINEX file {rinex_file} not found", file=sys.stderr)

--- a/src/tostools/tosGPS.py
+++ b/src/tostools/tosGPS.py
@@ -24,6 +24,7 @@ from .rinex.editor import update_rinex_files
 from .rinex.reader import (
     extract_header_info,
     find_most_recent_rinex,
+    find_station_archive_range,
     read_rinex_header,
 )
 from .rinex.validator import compare_rinex_to_tos
@@ -641,6 +642,39 @@ Examples:
         help="Save human-readable data quality report to file (e.g., tos_quality_report.txt)",
     )
 
+    # Station timespan subcommand: TOS start/end vs archive first/last file dates
+    timespan_parser = subparsers.add_parser(
+        "timespan",
+        help="Compare TOS station start/end dates with first/last files in the archive",
+        epilog="""
+Examples:
+  tosGPS timespan HAUC
+  tosGPS timespan HAUC REYK HOFN
+  tosGPS timespan HAUC --rinex-base-dir /mnt_data/rawgpsdata
+        """,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    timespan_parser.add_argument("stations", nargs="+", help="List of stations")
+    timespan_parser.add_argument(
+        "--rinex-base-dir",
+        type=str,
+        default="/mnt_data/rawgpsdata",
+        help="Archive root (default: /mnt_data/rawgpsdata)",
+    )
+    timespan_parser.add_argument(
+        "--start-tolerance-days",
+        type=int,
+        default=1,
+        help="Max |TOS start - archive first| in days before flagging " "(default: 1)",
+    )
+    timespan_parser.add_argument(
+        "--end-tolerance-days",
+        type=int,
+        default=7,
+        help="Max |TOS end - archive last| in days before flagging when "
+        "station is closed in TOS (default: 7)",
+    )
+
     # Site log generation subcommand
     sitelog_parser = subparsers.add_parser(
         "sitelog",
@@ -928,6 +962,9 @@ Examples:
         )
 
     # Handle different subcommands
+    if args.subcommand == "timespan":
+        _handle_timespan_subcommand(args, stations, url, log_level)
+        return
     if args.subcommand == "rinex":
         _handle_rinex_subcommand(args, stations, url, log_level)
     elif args.subcommand == "sitelog":
@@ -1288,6 +1325,111 @@ def _handle_rinex_subcommand(args, stations, url, log_level):
             print(f"\n✓ QC report saved to {args.report}", file=sys.stderr)
         except Exception as e:
             print(f"Error writing report: {e}", file=sys.stderr)
+
+
+def _fmt_date(dt):
+    """Format a ``datetime`` as ``YYYY-MM-DD``, or ``"—"`` when ``None``."""
+    return dt.strftime("%Y-%m-%d") if dt else "—"
+
+
+def _delta_days(a, b):
+    """Return ``|a - b|`` in whole days, or ``None`` if either date is missing."""
+    if a is None or b is None:
+        return None
+    return abs((a.date() - b.date()).days)
+
+
+def _coerce_to_datetime(value):
+    """Best-effort coercion of a TOS date field to a ``datetime``.
+
+    Accepts ``datetime`` instances, ISO-8601 strings, and bare ``YYYY-MM-DD``
+    strings. Returns ``None`` for missing or unparseable values.
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    try:
+        return datetime.fromisoformat(str(value))
+    except ValueError:
+        try:
+            return datetime.strptime(str(value)[:10], "%Y-%m-%d")
+        except ValueError:
+            return None
+
+
+def _handle_timespan_subcommand(args, stations, url, log_level):
+    """Compare TOS station start/end dates with first/last files in the archive."""
+    for station in stations:
+        print(f"\n=== {station} ===")
+
+        try:
+            station_data = gpsqc.gps_metadata(station, url, loglevel=log_level.value)
+        except Exception as e:
+            print(f"  TOS error: {e}", file=sys.stderr)
+            continue
+        if not station_data:
+            print(f"  No TOS metadata for {station}", file=sys.stderr)
+            continue
+
+        sessions = station_data.get("device_history", []) or []
+        tos_end_raw = sessions[-1].get("time_to") if sessions else None
+        tos_active = tos_end_raw is None and bool(sessions)
+
+        tos_start = _coerce_to_datetime(station_data.get("date_start"))
+        tos_end = _coerce_to_datetime(tos_end_raw)
+
+        archive = find_station_archive_range(station, base_dir=args.rinex_base_dir)
+        arch_first = archive.get("first")
+        arch_last = archive.get("last")
+
+        # Start comparison
+        start_delta = _delta_days(tos_start, arch_first)
+        if tos_start is None:
+            start_flag = "✗ no TOS start"
+        elif arch_first is None:
+            start_flag = "✗ no archive files"
+        elif start_delta <= args.start_tolerance_days:
+            start_flag = f"✓ (Δ {start_delta} d)"
+        else:
+            start_flag = f"⚠ (Δ {start_delta} d)"
+        print(
+            f"  TOS start:  {_fmt_date(tos_start):<12} "
+            f"Archive first: {_fmt_date(arch_first):<12} {start_flag}"
+        )
+
+        # End comparison
+        if tos_active:
+            print(
+                f"  TOS end:    {'active':<12} "
+                f"Archive last:  {_fmt_date(arch_last):<12} "
+                "active in TOS; latest file reported"
+            )
+        else:
+            end_delta = _delta_days(tos_end, arch_last)
+            if tos_end is None:
+                end_flag = "✗ no TOS end"
+            elif arch_last is None:
+                end_flag = "✗ no archive files"
+            elif end_delta <= args.end_tolerance_days:
+                end_flag = f"✓ (Δ {end_delta} d)"
+            else:
+                end_flag = f"⚠ (Δ {end_delta} d)"
+            print(
+                f"  TOS end:    {_fmt_date(tos_end):<12} "
+                f"Archive last:  {_fmt_date(arch_last):<12} {end_flag}"
+            )
+
+        # Per-kind breakdown
+        for kind in ("15s_24hr", "1Hz_1hr"):
+            k = archive.get(kind, {})
+            if k.get("first") or k.get("last"):
+                print(
+                    f"    {kind:<9} {_fmt_date(k.get('first'))} "
+                    f"→ {_fmt_date(k.get('last'))}"
+                )
+            else:
+                print(f"    {kind:<9} (no files)")
 
 
 def _handle_sitelog_subcommand(args, stations, url, log_level):

--- a/tests/test_rinex_reader.py
+++ b/tests/test_rinex_reader.py
@@ -14,8 +14,10 @@ from pathlib import Path
 from tostools.rinex.reader import (
     MONTHS,
     _parse_daily_rinex_date,
+    _parse_hourly_raw_date,
     _scan_dir_dates,
     find_most_recent_rinex,
+    find_station_archive_range,
 )
 
 # ---------------------------------------------------------------------------
@@ -178,3 +180,119 @@ def test_months_constant_is_lowercase_calendar_order():
     assert MONTHS[0] == "jan"
     assert MONTHS[-1] == "dec"
     assert len(MONTHS) == 12
+
+
+# ---------------------------------------------------------------------------
+# _parse_hourly_raw_date — PR #10
+# ---------------------------------------------------------------------------
+
+
+def test_parse_hourly_raw_date_extracts_timestamp():
+    """``STA<YYYY><MM><DD><HHMM>...`` → full datetime including HH:MM."""
+    assert _parse_hourly_raw_date("HAUC202604211530.T02", "HAUC") == datetime(
+        2026, 4, 21, 15, 30
+    )
+
+
+def test_parse_hourly_raw_date_accepts_any_suffix():
+    """The hourly parser only anchors on the prefix — any extension /
+    suffix after the 12-digit timestamp is ignored."""
+    assert _parse_hourly_raw_date("HAUC202604211530.tar.gz", "HAUC") == datetime(
+        2026, 4, 21, 15, 30
+    )
+
+
+def test_parse_hourly_raw_date_rejects_wrong_station():
+    assert _parse_hourly_raw_date("RHOF202604211530.T02", "HAUC") is None
+
+
+def test_parse_hourly_raw_date_rejects_invalid_calendar():
+    """Month 13 → ValueError inside the datetime constructor → return None
+    instead of raising."""
+    assert _parse_hourly_raw_date("HAUC202613211530.T02", "HAUC") is None
+
+
+def test_parse_hourly_raw_date_rejects_non_timestamp_prefix():
+    assert _parse_hourly_raw_date("HAUCnotastamp.T02", "HAUC") is None
+
+
+# ---------------------------------------------------------------------------
+# find_station_archive_range — PR #10
+# ---------------------------------------------------------------------------
+
+
+def _make_daily_layout(
+    base: Path, station: str, year: int, month_name: str, files: list[str]
+) -> Path:
+    d = base / str(year) / month_name / station / "15s_24hr" / "rinex"
+    d.mkdir(parents=True, exist_ok=True)
+    for f in files:
+        (d / f).touch()
+    return d
+
+
+def _make_hourly_layout(
+    base: Path, station: str, year: int, month_name: str, files: list[str]
+) -> Path:
+    d = base / str(year) / month_name / station / "1Hz_1hr" / "raw"
+    d.mkdir(parents=True, exist_ok=True)
+    for f in files:
+        (d / f).touch()
+    return d
+
+
+def test_find_station_archive_range_daily_only(tmp_path: Path):
+    """Daily files in two years — first is earliest in earliest year,
+    last is latest in latest year."""
+    _make_daily_layout(tmp_path, "HAUC", 2024, "mar", ["HAUC0750.24D"])
+    _make_daily_layout(tmp_path, "HAUC", 2026, "sep", ["HAUC2660.26D"])
+    r = find_station_archive_range("HAUC", base_dir=tmp_path)
+    assert r["first"] == datetime(2024, 3, 15)
+    assert r["last"] == datetime(2026, 9, 23)
+    assert r["15s_24hr"]["first"] == datetime(2024, 3, 15)
+    assert r["15s_24hr"]["last"] == datetime(2026, 9, 23)
+    assert r["1Hz_1hr"]["first"] is None
+    assert r["1Hz_1hr"]["last"] is None
+
+
+def test_find_station_archive_range_hourly_only(tmp_path: Path):
+    _make_hourly_layout(tmp_path, "HAUC", 2025, "feb", ["HAUC202502010800.T02"])
+    _make_hourly_layout(tmp_path, "HAUC", 2025, "dec", ["HAUC202512311959.T02"])
+    r = find_station_archive_range("HAUC", base_dir=tmp_path)
+    assert r["first"] == datetime(2025, 2, 1, 8, 0)
+    assert r["last"] == datetime(2025, 12, 31, 19, 59)
+
+
+def test_find_station_archive_range_combines_kinds(tmp_path: Path):
+    """When both kinds exist, the overall first/last spans both
+    layouts. Hildur's worked example pattern: 1 Hz raw often captures
+    the true first/last minute of service."""
+    _make_daily_layout(tmp_path, "HAUC", 2007, "sep", ["HAUC2450.07D"])
+    _make_daily_layout(tmp_path, "HAUC", 2026, "apr", ["HAUC1110.26D"])
+    _make_hourly_layout(tmp_path, "HAUC", 2009, "jan", ["HAUC200901010001.T02"])
+    _make_hourly_layout(tmp_path, "HAUC", 2018, "feb", ["HAUC201802231230.T02"])
+
+    r = find_station_archive_range("HAUC", base_dir=tmp_path)
+    # Overall first = earliest of (2007-09-02 daily, 2009-01-01 hourly)
+    assert r["first"] == datetime(2007, 9, 2)
+    # Overall last = latest of (2026-04-21 daily, 2018-02-23 hourly)
+    assert r["last"] == datetime(2026, 4, 21)
+    # Per-kind details preserved.
+    assert r["15s_24hr"]["last"] == datetime(2026, 4, 21)
+    assert r["1Hz_1hr"]["last"] == datetime(2018, 2, 23, 12, 30)
+
+
+def test_find_station_archive_range_missing_base_returns_empty(tmp_path: Path):
+    r = find_station_archive_range("HAUC", base_dir=tmp_path / "missing")
+    assert r["first"] is None
+    assert r["last"] is None
+    assert r["15s_24hr"] == {}
+    assert r["1Hz_1hr"] == {}
+
+
+def test_find_station_archive_range_empty_layout_returns_nones(tmp_path: Path):
+    """Layout dirs exist but no recognised files → all None."""
+    _make_daily_layout(tmp_path, "HAUC", 2026, "sep", [])
+    r = find_station_archive_range("HAUC", base_dir=tmp_path)
+    assert r["first"] is None
+    assert r["last"] is None

--- a/tests/test_rinex_reader.py
+++ b/tests/test_rinex_reader.py
@@ -1,0 +1,180 @@
+"""Unit tests for :mod:`tostools.rinex.reader`.
+
+Covers the auto-resolve helpers added with PR #9 — the daily Hatanaka
+filename parser, the directory scanner, and the most-recent-walker.
+Filesystem fixtures are built under ``tmp_path``; no network, no
+side effects.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+from tostools.rinex.reader import (
+    MONTHS,
+    _parse_daily_rinex_date,
+    _scan_dir_dates,
+    find_most_recent_rinex,
+)
+
+# ---------------------------------------------------------------------------
+# _parse_daily_rinex_date — the regex contract is the load-bearing piece
+# ---------------------------------------------------------------------------
+
+
+def test_parse_daily_rinex_date_yy_pivot_post_2000():
+    """YY < 80 should resolve to 2000+YY (modern era)."""
+    assert _parse_daily_rinex_date("HAUC2660.26D", "HAUC") == datetime(2026, 9, 23)
+
+
+def test_parse_daily_rinex_date_yy_pivot_pre_2000():
+    """YY >= 80 should resolve to 1900+YY (legacy era)."""
+    assert _parse_daily_rinex_date("HAUC0010.98D", "HAUC") == datetime(1998, 1, 1)
+
+
+def test_parse_daily_rinex_date_doy_to_calendar():
+    """DOY 100 in 2026 is April 10."""
+    assert _parse_daily_rinex_date("HAUC1000.26D", "HAUC") == datetime(2026, 4, 10)
+
+
+def test_parse_daily_rinex_date_accepts_observation_o_extension():
+    """``[DO]`` in the regex — both D (Hatanaka compressed) and O (raw
+    RINEX) should parse."""
+    assert _parse_daily_rinex_date("HAUC2660.26O", "HAUC") == datetime(2026, 9, 23)
+
+
+def test_parse_daily_rinex_date_accepts_compression_suffix():
+    """``.Z`` and ``.gz`` should both be tolerated."""
+    assert _parse_daily_rinex_date("HAUC2660.26D.Z", "HAUC") == datetime(2026, 9, 23)
+    assert _parse_daily_rinex_date("HAUC2660.26D.gz", "HAUC") == datetime(2026, 9, 23)
+
+
+def test_parse_daily_rinex_date_rejects_wrong_station():
+    """Station code is fixed by the caller — a file from a different
+    station mustn't match (or auto-resolve would return cross-station files)."""
+    assert _parse_daily_rinex_date("RHOF2660.26D", "HAUC") is None
+
+
+def test_parse_daily_rinex_date_rejects_non_rinex_filename():
+    assert _parse_daily_rinex_date("not_a_rinex_file.txt", "HAUC") is None
+
+
+def test_parse_daily_rinex_date_is_case_insensitive():
+    """re.IGNORECASE on the pattern — operators sometimes paste lowercase
+    station codes."""
+    assert _parse_daily_rinex_date("hauc2660.26d", "HAUC") == datetime(2026, 9, 23)
+
+
+# ---------------------------------------------------------------------------
+# _scan_dir_dates
+# ---------------------------------------------------------------------------
+
+
+def test_scan_dir_dates_skips_unrecognised_filenames(tmp_path: Path):
+    (tmp_path / "HAUC1000.26D").touch()
+    (tmp_path / "README.txt").touch()
+    (tmp_path / "HAUC2000.26D").touch()
+    out = _scan_dir_dates(tmp_path, _parse_daily_rinex_date, "HAUC")
+    assert len(out) == 2
+    dates = sorted(d for d, _ in out)
+    assert dates == [datetime(2026, 4, 10), datetime(2026, 7, 19)]
+
+
+def test_scan_dir_dates_missing_directory_returns_empty(tmp_path: Path):
+    """Non-existent directory is a normal state (sparse archive) — must
+    not raise."""
+    missing = tmp_path / "does-not-exist"
+    assert _scan_dir_dates(missing, _parse_daily_rinex_date, "HAUC") == []
+
+
+def test_scan_dir_dates_empty_directory_returns_empty(tmp_path: Path):
+    assert _scan_dir_dates(tmp_path, _parse_daily_rinex_date, "HAUC") == []
+
+
+# ---------------------------------------------------------------------------
+# find_most_recent_rinex — the integration walker
+# ---------------------------------------------------------------------------
+
+
+def _make_layout(
+    base: Path, station: str, year: int, month_name: str, files: list[str]
+) -> Path:
+    """Build ``<base>/<YYYY>/<mon>/<STA>/15s_24hr/rinex/<file>`` for tests."""
+    d = base / str(year) / month_name / station / "15s_24hr" / "rinex"
+    d.mkdir(parents=True, exist_ok=True)
+    for f in files:
+        (d / f).touch()
+    return d
+
+
+def test_find_most_recent_rinex_returns_latest_doy_in_latest_month(
+    tmp_path: Path,
+):
+    """When multiple files exist in the latest populated month, the one
+    with the highest DOY wins."""
+    _make_layout(
+        tmp_path,
+        "HAUC",
+        2026,
+        "sep",
+        ["HAUC2540.26D", "HAUC2600.26D", "HAUC2660.26D"],
+    )
+    result = find_most_recent_rinex("HAUC", base_dir=tmp_path)
+    assert result is not None
+    assert result.name == "HAUC2660.26D"
+
+
+def test_find_most_recent_rinex_picks_latest_month_in_latest_year(
+    tmp_path: Path,
+):
+    """Two months populated in the same year — the later month wins."""
+    _make_layout(tmp_path, "HAUC", 2026, "jan", ["HAUC0050.26D"])
+    _make_layout(tmp_path, "HAUC", 2026, "oct", ["HAUC2750.26D"])
+    result = find_most_recent_rinex("HAUC", base_dir=tmp_path)
+    assert result is not None
+    assert result.parent.name == "rinex"
+    assert result.name == "HAUC2750.26D"
+
+
+def test_find_most_recent_rinex_picks_latest_year(tmp_path: Path):
+    """A 2026 file should beat any 2025 file."""
+    _make_layout(tmp_path, "HAUC", 2025, "dec", ["HAUC3650.25D"])
+    _make_layout(tmp_path, "HAUC", 2026, "jan", ["HAUC0010.26D"])
+    result = find_most_recent_rinex("HAUC", base_dir=tmp_path)
+    assert result is not None
+    # Year 2026 (later) trumps month 'dec' in 2025.
+    assert "2026" in str(result)
+    assert result.name == "HAUC0010.26D"
+
+
+def test_find_most_recent_rinex_missing_base_returns_none(tmp_path: Path):
+    """Operator points --rinex-base-dir at a path that doesn't exist
+    (typo, wrong host) → return None, not crash."""
+    assert find_most_recent_rinex("HAUC", base_dir=tmp_path / "missing") is None
+
+
+def test_find_most_recent_rinex_no_files_returns_none(tmp_path: Path):
+    """Layout structure exists but the rinex/ dir is empty."""
+    _make_layout(tmp_path, "HAUC", 2026, "sep", [])
+    assert find_most_recent_rinex("HAUC", base_dir=tmp_path) is None
+
+
+def test_find_most_recent_rinex_falls_through_to_earlier_month(tmp_path: Path):
+    """Newer month directory exists but is empty (e.g. nothing arrived
+    yet this month) → walker steps backward to the earlier populated
+    month."""
+    _make_layout(tmp_path, "HAUC", 2026, "sep", ["HAUC2660.26D"])
+    _make_layout(tmp_path, "HAUC", 2026, "oct", [])  # exists but empty
+    result = find_most_recent_rinex("HAUC", base_dir=tmp_path)
+    assert result is not None
+    assert result.name == "HAUC2660.26D"
+
+
+def test_months_constant_is_lowercase_calendar_order():
+    """Smoke check on the constant — used to walk archive dirs in
+    chronological order. Order matters for the descending-walk in
+    find_most_recent_rinex."""
+    assert MONTHS[0] == "jan"
+    assert MONTHS[-1] == "dec"
+    assert len(MONTHS) == 12

--- a/tests/test_rinex_validator.py
+++ b/tests/test_rinex_validator.py
@@ -1,0 +1,159 @@
+"""Unit tests for :mod:`tostools.rinex.validator`.
+
+Focused on the Layer-5 ``coord_tolerance`` flow added with PR #8 — the
+RINEX ``APPROX POSITION XYZ`` vs TOS lat/lon/altitude ECEF distance
+check. Mirrors Hildur's test plan from PR #8 (in-tolerance vs
+exceeds-tolerance vs missing TOS coords). No network — the WGS84↔ITRF08
+transformer is real (pyproj) but only fed deterministic inputs.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from tostools import gps_metadata_qc as gpsqc
+from tostools.rinex.validator import compare_rinex_to_tos
+
+# ---------------------------------------------------------------------------
+# Helpers — build the minimal inputs compare_rinex_to_tos needs.
+# ---------------------------------------------------------------------------
+
+
+def _tos_session_with_coords(lat: float, lon: float, alt: float) -> Dict[str, Any]:
+    """Minimal TOS-session dict carrying lat/lon/altitude.
+
+    All other comparison branches (antenna height, observer/agency, etc.)
+    are inactive because the dict has no devices.
+    """
+    return {
+        "lat": lat,
+        "lon": lon,
+        "altitude": alt,
+        "devices": {},
+        "contact": {},
+    }
+
+
+def _rinex_info_with_xyz(x: float, y: float, z: float) -> Dict[str, str]:
+    return {
+        "MARKER NAME": "TEST",
+        "APPROX POSITION XYZ": f"{x:.4f} {y:.4f} {z:.4f}",
+    }
+
+
+def _expected_xyz(lat: float, lon: float, alt: float) -> tuple:
+    """Re-run the same transform compare_rinex_to_tos uses, so we can
+    construct synthetic 'matching' inputs without hard-coding ECEF values
+    that drift with pyproj versions."""
+    return tuple(gpsqc.wgs84toitrf08.transform(lat, lon, alt))
+
+
+# ---------------------------------------------------------------------------
+# Hildur's test plan, mirrored
+# ---------------------------------------------------------------------------
+
+
+def test_coord_check_in_tolerance_records_match():
+    """RINEX XYZ that exactly matches the TOS-derived ECEF coordinate
+    should land in ``matches['coordinates']`` and ``coord_check.distance_m``
+    should be ~0."""
+    lat, lon, alt = 64.13, -21.93, 50.0
+    x, y, z = _expected_xyz(lat, lon, alt)
+
+    result = compare_rinex_to_tos(
+        _rinex_info_with_xyz(x, y, z),
+        _tos_session_with_coords(lat, lon, alt),
+    )
+
+    assert "coord_check" in result
+    cc = result["coord_check"]
+    assert cc["exceeds_tolerance"] is False
+    assert cc["distance_m"] < 1e-3
+    assert "coordinates" in result["matches"]
+    assert "coordinates" not in result["discrepancies"]
+
+
+def test_coord_check_exceeds_tolerance_flags_discrepancy():
+    """A 20m offset on Z with the default 10m tolerance should trip the
+    discrepancy branch — populates ``discrepancies['coordinates']`` and
+    records ``exceeds_tolerance=True``."""
+    lat, lon, alt = 64.13, -21.93, 50.0
+    x, y, z = _expected_xyz(lat, lon, alt)
+
+    result = compare_rinex_to_tos(
+        _rinex_info_with_xyz(x, y, z + 20.0),  # 20m offset in Z
+        _tos_session_with_coords(lat, lon, alt),
+    )
+
+    cc = result["coord_check"]
+    assert cc["exceeds_tolerance"] is True
+    assert cc["distance_m"] > 10.0
+    assert "coordinates" in result["discrepancies"]
+
+
+def test_coord_check_custom_tolerance_passes_a_known_offset():
+    """A 5m offset should pass with tolerance=10m but fail with
+    tolerance=1m. Same input, different threshold — proves the kwarg
+    actually reaches the check."""
+    lat, lon, alt = 64.13, -21.93, 50.0
+    x, y, z = _expected_xyz(lat, lon, alt)
+    rinex_info = _rinex_info_with_xyz(x, y, z + 5.0)
+    tos_session = _tos_session_with_coords(lat, lon, alt)
+
+    lenient = compare_rinex_to_tos(rinex_info, tos_session, coord_tolerance=10.0)
+    assert lenient["coord_check"]["exceeds_tolerance"] is False
+
+    strict = compare_rinex_to_tos(rinex_info, tos_session, coord_tolerance=1.0)
+    assert strict["coord_check"]["exceeds_tolerance"] is True
+
+
+def test_coord_check_missing_tos_coords_skips_silently():
+    """When TOS has no lat/lon/alt (a station with incomplete metadata),
+    the check should not crash — just leave ``coord_check`` out of the
+    result. Other comparison branches still run."""
+    rinex_info = _rinex_info_with_xyz(2587000.0, -1043000.0, 5755000.0)
+    tos_session: Dict[str, Any] = {"devices": {}, "contact": {}}
+
+    result = compare_rinex_to_tos(rinex_info, tos_session)
+
+    assert "coord_check" not in result
+    # And the function still returned its normal structure.
+    assert "discrepancies" in result
+    assert "matches" in result
+
+
+def test_coord_check_missing_rinex_xyz_skips_silently():
+    """When the RINEX header has no APPROX POSITION XYZ line, the check
+    is skipped without affecting the rest of the comparison."""
+    rinex_info: Dict[str, str] = {"MARKER NAME": "TEST"}
+    tos_session = _tos_session_with_coords(64.13, -21.93, 50.0)
+
+    result = compare_rinex_to_tos(rinex_info, tos_session)
+
+    assert "coord_check" not in result
+
+
+def test_coord_check_payload_shape():
+    """The ``coord_check`` dict should carry the operator-visible fields
+    used by the tosGPS CLI print line (diff_xyz, distance_m, tolerance_m,
+    exceeds_tolerance)."""
+    lat, lon, alt = 64.13, -21.93, 50.0
+    x, y, z = _expected_xyz(lat, lon, alt)
+
+    result = compare_rinex_to_tos(
+        _rinex_info_with_xyz(x, y, z),
+        _tos_session_with_coords(lat, lon, alt),
+        coord_tolerance=10.0,
+    )
+
+    cc = result["coord_check"]
+    assert set(cc.keys()) >= {
+        "rinex_xyz",
+        "tos_xyz",
+        "diff_xyz",
+        "distance_m",
+        "tolerance_m",
+        "exceeds_tolerance",
+    }
+    assert cc["tolerance_m"] == 10.0
+    assert len(cc["diff_xyz"]) == 3


### PR DESCRIPTION
## Summary

This PR carries the work of @HildurMaria's #8, #9, #10, #11 forward onto current master. Master moved ~32 commits since those PRs were opened (devices §3 refactor + the attribute-dates audit), and her PRs had stale CI from before the lint config was relaxed. Re-implementing on top of current master is cleaner than chained rebases through 30+ commits.

Each commit corresponds 1:1 with one of @HildurMaria's PRs, ordered to match dependencies (#11 isolated; #9 helpers precede #10 timespan), with `Co-Authored-By: HildurMaria` so the authorship trail is preserved.

| Commit | Carries | Surface |
|---|---|---|
| `71c78e3` | #11 | `scripts/export_station_equipment.py` — TOS → CSV/JSON/Excel |
| `1e68207` | #8  | RINEX `APPROX POSITION XYZ` vs TOS ECEF coord check, `--coord-tolerance` |
| `aee56a6` | #9  | `find_most_recent_rinex` + `tosGPS rinex` auto-resolve (`nargs="*"`) |
| `4d0f18b` | #10 | `tosGPS timespan STATIONS...` subcommand on top of #9's helpers |

## Carried verbatim from Hildur's PRs

* Default coord tolerance **10.0m** (#8) — Hildur's empirical pick from 176-station 2026 survey, 90th percentile ~8m
* Archive root **`/mnt_data/rawgpsdata`** (#9, #10) — physical layout on `rek-d01`
* Archive layouts **`15s_24hr/rinex`** (daily Hatanaka) and **`1Hz_1hr/raw`** (hourly raw) (#10)
* Output-format-by-extension dispatch — `.csv` / `.json` / `.xlsx` (#11)
* CLI flag names — `--coord-tolerance`, `--rinex-base-dir`, `--start-tolerance-days`, `--end-tolerance-days`, `--include-inactive`
* Subcommand name — `timespan`
* For #11: kept the `tostools.legacy.gps_metadata_qc` + `gps_metadata_functions.getStationList` imports as-is. Migration to the new `tostools.devices` / `audit` primitives is a separate concern once the new synthesis chain fully supersedes the legacy path.

## Departures from Hildur's PRs

The only departures are **black 24.x reformatting** (each PR was originally drafted on a black version that line-wraps slightly differently — applied to match CI) and one **bug fix on the dispatch**: `args.subcommand == "timespan"` is checked with an early `return` rather than `elif` because the surrounding control flow had moved to a series of `if` statements during the devices §3 work.

No behaviour changes from Hildur's design.

## Tests

+34 new unit tests:

* `tests/test_rinex_validator.py` (6) — Hildur's #8 test plan: in-tolerance, exceeds-tolerance, custom tolerance, missing TOS coords, missing RINEX XYZ, payload shape
* `tests/test_rinex_reader.py` (28) — #9 + #10 helpers: daily/hourly filename parsers (YY pivot, DOY, case, suffix tolerance, wrong-station rejection), `_scan_dir_dates`, `find_most_recent_rinex` (multiple ordering scenarios, missing base, empty layout), `find_station_archive_range` (daily-only, hourly-only, both-kinds combine, missing base, empty layout)

Total suite: **484 passed, 2 skipped** (was 450/2 before this PR). ruff + black 24.x clean.

## For @HildurMaria

If you have a moment, would you mind testing the features against your stations? Specifically:

* `tosGPS rinex HAUC` (no file arg) — auto-resolves the latest daily file from `/mnt_data/rawgpsdata`
* `tosGPS rinex HAUC <file>.D --coord-tolerance 5.0` — the new coord check
* `tosGPS timespan HAUC REYK HOFN` — your worked example
* `python scripts/export_station_equipment.py -o stations.csv`

Your original PRs (#8, #9, #10, #11) can stay open until you've confirmed parity — once you've tested, feel free to close them yourself. If you find anything missing or different from what your PRs intended, please leave a review here and I'll fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)