### PR TITLE
feat(audit): Layer 6 — `tos audit missing-attributes`

### DIFF
--- a/data/attribute_codes.yaml
+++ b/data/attribute_codes.yaml
@@ -1633,9 +1633,12 @@ stations:
     walked: false
     why: ""
 
-  station_subtype:
+  subtype:
     icelandic_label: Undirtegund
     description: Station sub-type — describes composition / measurement purpose
+    # NOTE: TOS uses the same `subtype` code on both stations and devices.
+    # This is the stations-scope entry (value e.g. "GPS stöð"); see devices.subtype
+    # for the device-scope entry (value e.g. "4G LTE" on a router).
     classification: inherent
     tos_required_for: [geophysical]
     gps_required_for: [geophysical] # USER FILLS IN — strict superset of tos

--- a/src/tostools/audit_attribute_dates.py
+++ b/src/tostools/audit_attribute_dates.py
@@ -179,31 +179,69 @@ class StationAttributeDateReport:
 # ---------------------------------------------------------------------------
 
 
+SCOPES: Tuple[str, ...] = ("devices", "locations", "stations")
+
+
+def _resolve_catalog_path(path: Optional[Path]) -> Path:
+    if path is not None:
+        return path
+    env_path = os.environ.get(CATALOG_ENV_VAR)
+    return Path(env_path) if env_path else DEFAULT_CATALOG_PATH
+
+
+def load_catalog_scoped(
+    path: Optional[Path] = None,
+) -> Dict[str, Dict[str, Dict[str, Any]]]:
+    """Load ``attribute_codes.yaml`` preserving the three scopes.
+
+    Returns ``{scope: {code: entry}}`` with ``_scope`` attached to each
+    entry for parity with :func:`load_catalog`. Use this when iterating
+    rules per-entity-type — the station entity walks ``catalog['stations']``
+    and each device walks ``catalog['devices']``, so cross-scope code
+    collisions (``subtype``, ``date_start``, ``lat``, …) stay distinct.
+
+    Path resolution: explicit ``path`` arg → env
+    ``TOSTOOLS_ATTRIBUTE_CODES_PATH`` → :data:`DEFAULT_CATALOG_PATH`.
+
+    Raises :class:`FileNotFoundError` if no catalog is reachable.
+    """
+    resolved = _resolve_catalog_path(path)
+    with open(resolved, encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    scoped: Dict[str, Dict[str, Dict[str, Any]]] = {}
+    for scope in SCOPES:
+        scoped[scope] = {}
+        for code, entry in (data.get(scope) or {}).items():
+            merged = dict(entry)
+            merged["_scope"] = scope
+            scoped[scope][code] = merged
+    return scoped
+
+
 def load_catalog(path: Optional[Path] = None) -> Dict[str, Dict[str, Any]]:
     """Load ``attribute_codes.yaml`` and flatten the three scopes into a
     single ``{code: entry}`` map.
 
     Path resolution: explicit ``path`` arg → env ``TOSTOOLS_ATTRIBUTE_CODES_PATH``
     → :data:`DEFAULT_CATALOG_PATH`. The devices/locations/stations scopes
-    are merged with devices winning on the rare collision; each entry
-    carries a ``_scope`` key so callers can disambiguate when relevant.
+    are merged with devices winning on collision; each entry carries a
+    ``_scope`` key so callers can disambiguate when relevant.
+
+    Use :func:`load_catalog_scoped` when the caller must distinguish
+    cross-scope collisions (e.g. ``subtype`` exists on both stations and
+    devices); the flat view is suitable for Layers 2-5 which only iterate
+    device-scope rules.
 
     Raises :class:`FileNotFoundError` if no catalog is reachable —
     audit cannot run without it.
     """
-    if path is None:
-        env_path = os.environ.get(CATALOG_ENV_VAR)
-        path = Path(env_path) if env_path else DEFAULT_CATALOG_PATH
-    with open(path, encoding="utf-8") as f:
-        data = yaml.safe_load(f) or {}
+    scoped = load_catalog_scoped(path)
     flat: Dict[str, Dict[str, Any]] = {}
-    for scope in ("devices", "locations", "stations"):
-        for code, entry in (data.get(scope) or {}).items():
+    for scope in SCOPES:
+        for code, entry in scoped[scope].items():
             if code in flat:
                 continue
-            merged = dict(entry)
-            merged["_scope"] = scope
-            flat[code] = merged
+            flat[code] = entry  # already carries _scope
     return flat
 
 

--- a/src/tostools/audit_missing_attributes.py
+++ b/src/tostools/audit_missing_attributes.py
@@ -32,6 +32,7 @@ task #10); this module exposes the walker + data model only.
 
 from __future__ import annotations
 
+import shlex
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple
@@ -50,6 +51,18 @@ from .audit_attribute_dates import (
 # (id_entity, code) — "missing" has no date anchor, so the suppression key
 # is shorter than the attribute-dates audit's 3-tuple.
 MissingSuppressionKey = Tuple[int, str]
+
+# Layer 3 — committed-in-repo suppression file for missing-attributes.
+# Format: one ``SUPPRESS <id_entity> <code>`` per known-good gap.
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+DEFAULT_MISSING_SUPPRESSIONS_PATH = (
+    _REPO_ROOT / "data" / "audit_suppressions" / "missing_attributes.txt"
+)
+
+# Placeholders rendered in triage output for codes without catalog defaults
+# or when a sensible date_from anchor isn't available.
+FILL_VALUE_PLACEHOLDER = "<FILL_VALUE>"
+FILL_DATE_PLACEHOLDER = "<FILL_DATE>"
 
 
 # ---------------------------------------------------------------------------
@@ -108,6 +121,95 @@ class StationMissingAttributesReport:
     @property
     def suppressed_count(self) -> int:
         return len(self.suppressed)
+
+
+# ---------------------------------------------------------------------------
+# Suppression file parsing (Layer 3 — 2-tuple key)
+# ---------------------------------------------------------------------------
+
+
+def load_missing_suppressions(
+    path: Optional[Path] = None,
+) -> Tuple[Dict[MissingSuppressionKey, int], List[SuppressionParseError], Path]:
+    """Parse a SUPPRESS-style file for the missing-attributes audit.
+
+    Format: one ``SUPPRESS <id_entity> <code>`` per line. Comments start
+    with ``#`` and run to end-of-line; blank lines are ignored. The key
+    is a 2-tuple — there's no ``date_from`` anchor since "missing" has
+    no date. Mirrors :func:`tostools.audit_attribute_dates.load_suppressions`
+    in spirit; the shorter shape is the only material difference.
+
+    Returns ``(suppressions, errors, resolved_path)``:
+
+    * ``suppressions`` — ``{(id_entity, code): line_no}`` mapping. Line
+      numbers are kept so verbose output can show which file line
+      silenced each entry.
+    * ``errors`` — collected malformed lines; the caller decides whether
+      to abort or continue with the parsed entries.
+    * ``resolved_path`` — the path actually tried.
+
+    File-not-found is NOT an error. Returns an empty mapping. The
+    suppression file is opt-in.
+    """
+    if path is None:
+        path = DEFAULT_MISSING_SUPPRESSIONS_PATH
+
+    suppressions: Dict[MissingSuppressionKey, int] = {}
+    errors: List[SuppressionParseError] = []
+
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return suppressions, errors, path
+
+    for i, line in enumerate(text.splitlines(), 1):
+        raw = line
+        if "#" in line:
+            line = line.split("#", 1)[0]
+        line = line.strip()
+        if not line:
+            continue
+
+        tokens = line.split()
+        if tokens[0] != "SUPPRESS":
+            errors.append(
+                SuppressionParseError(
+                    line_no=i,
+                    message=(
+                        f"expected line to start with 'SUPPRESS' "
+                        f"(got {tokens[0]!r})"
+                    ),
+                    raw=raw,
+                )
+            )
+            continue
+        if len(tokens) < 3:
+            errors.append(
+                SuppressionParseError(
+                    line_no=i,
+                    message=(
+                        "SUPPRESS line requires 2 arguments: "
+                        f"<id_entity> <code> (got {len(tokens) - 1})"
+                    ),
+                    raw=raw,
+                )
+            )
+            continue
+        try:
+            id_entity = int(tokens[1])
+        except ValueError:
+            errors.append(
+                SuppressionParseError(
+                    line_no=i,
+                    message=f"id_entity must be int, got {tokens[1]!r}",
+                    raw=raw,
+                )
+            )
+            continue
+        code = tokens[2]
+        suppressions[(id_entity, code)] = i
+
+    return suppressions, errors, path
 
 
 # ---------------------------------------------------------------------------
@@ -195,6 +297,8 @@ def audit_station_missing_attributes(
     id_entity: Optional[int] = None,
     subtypes: Optional[Sequence[str]] = None,
     catalog_path: Optional[Path] = None,
+    suppressions_path: Optional[Path] = None,
+    use_suppressions: bool = True,
 ) -> StationMissingAttributesReport:
     """Walk a station + its open child devices and flag missing required
     attributes.
@@ -215,12 +319,19 @@ def audit_station_missing_attributes(
     catalog_path
         Override the catalog file location. Defaults to the canonical
         repo path / ``TOSTOOLS_ATTRIBUTE_CODES_PATH`` env var.
+    suppressions_path
+        Override the suppression file location. Defaults to
+        :data:`DEFAULT_MISSING_SUPPRESSIONS_PATH`. File-not-found is silent.
+    use_suppressions
+        When False, skip the suppression file entirely — every missing
+        hit lands in ``violations``. Equivalent to ``--no-suppressions``.
 
     Returns
     -------
     StationMissingAttributesReport
-        ``has_violations`` is True when at least one required attribute is
-        missing from an audited entity.
+        ``has_violations`` reflects the **filtered** violations list —
+        suppressed entries are preserved on ``report.suppressed`` so
+        verbose output can show what was silenced.
 
     Raises
     ------
@@ -229,13 +340,22 @@ def audit_station_missing_attributes(
     ValueError
         Neither ``name`` nor ``id_entity`` set.
     FileNotFoundError
-        Catalog file missing.
+        Catalog file missing (suppression file missing is not an error).
     """
     scoped = load_catalog_scoped(catalog_path)
     stations_rules = scoped.get("stations") or {}
     devices_rules = scoped.get("devices") or {}
 
     wanted = tuple(subtypes) if subtypes else GPS_DEVICE_SUBTYPES
+
+    if use_suppressions:
+        suppressions, supp_errors, supp_path = load_missing_suppressions(
+            suppressions_path
+        )
+    else:
+        suppressions = {}
+        supp_errors = []
+        supp_path = suppressions_path or DEFAULT_MISSING_SUPPRESSIONS_PATH
 
     station_history = _resolve_station_entity(client, name=name, id_entity=id_entity)
     station_id = int(station_history["id_entity"])
@@ -245,6 +365,9 @@ def audit_station_missing_attributes(
     report = StationMissingAttributesReport(
         station_id=station_id,
         station_name=station_name,
+        suppressions_path=supp_path,
+        suppressions_errors=supp_errors,
+        suppressions_disabled=not use_suppressions,
     )
 
     # 1. Station entity itself — iterate stations scope.
@@ -296,4 +419,163 @@ def audit_station_missing_attributes(
             suggested_date_from=suggested_date,
         )
 
+    # Apply suppressions — partition violations into kept vs suppressed.
+    if suppressions:
+        kept: List[MissingAttributeViolation] = []
+        for v in report.violations:
+            key = (v.id_entity, v.code)
+            line_no = suppressions.get(key)
+            if line_no is not None:
+                report.suppressed.append(
+                    SuppressedMissing(
+                        violation=v,
+                        suppressions_path=supp_path,
+                        line_no=line_no,
+                    )
+                )
+            else:
+                kept.append(v)
+        report.violations = kept
+
     return report
+
+
+# ---------------------------------------------------------------------------
+# Triage file emission (Layer 4)
+# ---------------------------------------------------------------------------
+
+
+def _quote_value(value: Optional[str]) -> str:
+    """Render a value for the ACTION line — shlex-quote when needed.
+
+    ``None`` becomes the ``<FILL_VALUE>`` placeholder so the operator
+    has to fill it in before applying. Values with spaces or shell
+    metacharacters get single-quoted (e.g. ``GPS stöð`` → ``'GPS stöð'``),
+    matching the shlex-split parsing the apply verb (task #11) will use.
+    """
+    if value is None:
+        return FILL_VALUE_PLACEHOLDER
+    return shlex.quote(value)
+
+
+def format_triage_file(
+    report: StationMissingAttributesReport,
+    *,
+    audit_command: Optional[str] = None,
+    generated_at: Optional[str] = None,
+) -> str:
+    """Render a missing-attributes report as an operator-editable
+    action file.
+
+    Each violation becomes a commented ``#ACTION <id> add-attribute
+    <code> <value> <date_from>`` line. The operator reviews, fills in
+    ``<FILL_VALUE>`` / ``<FILL_DATE>`` placeholders where present,
+    uncomments the lines they want to apply, then feeds the file into
+    ``tos audit apply`` (which dispatches to the ``add-attribute`` verb
+    once Layer 6 task #11 lands).
+
+    Parameters
+    ----------
+    report
+        The audit report. Only ``report.violations`` is consulted —
+        suppressed entries are intentionally NOT emitted.
+    audit_command
+        Optional command-line string captured at audit time; rendered
+        in the header so the file is self-documenting.
+    generated_at
+        Optional ISO timestamp. Defaults to ``datetime.utcnow()`` at
+        call time. Pass an explicit value in tests to keep output
+        byte-deterministic.
+
+    Returns
+    -------
+    str
+        Newline-terminated file contents, safe to write directly with
+        :meth:`pathlib.Path.write_text`.
+
+    Notes
+    -----
+    Violations are grouped by entity (station first, then devices) so
+    the operator can read the file linearly and decide per-entity what
+    to fill in.
+    """
+    from datetime import datetime, timezone
+
+    if generated_at is None:
+        generated_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+    lines: List[str] = []
+    station_label = report.station_name or "<unknown>"
+    lines.append("# === tos audit missing-attributes — triage action file ===")
+    lines.append(f"# Generated:  {generated_at}")
+    lines.append(f"# Station:    {station_label!r} (id_entity={report.station_id})")
+    if audit_command:
+        lines.append(f"# Audit cmd:  {audit_command}")
+    lines.append(f"# Violations: {len(report.violations)}")
+    lines.append("#")
+    lines.append("# Format: one ACTION per line, '#' for comments.")
+    lines.append("#")
+    lines.append("#   ACTION <id_entity> add-attribute \\")
+    lines.append("#          <code> <value> <date_from>")
+    lines.append("#")
+    lines.append("# Workflow:")
+    lines.append("#   1. Review each block below. Replace any")
+    lines.append(
+        f"#      {FILL_VALUE_PLACEHOLDER} / {FILL_DATE_PLACEHOLDER}"
+        " placeholders with the value/date you"
+    )
+    lines.append("#      know is correct for the entity.")
+    lines.append("#   2. Uncomment the ACTION line(s) you want to fire.")
+    lines.append("#   3. tos audit apply <file>          # dry-run preview")
+    lines.append("#   4. tos audit apply <file> --apply  # commit writes")
+    lines.append("#")
+    lines.append("# Alternative for known-good gaps: copy the SUPPRESS hint into")
+    lines.append("# data/audit_suppressions/missing_attributes.txt instead.")
+    lines.append("")
+
+    if not report.violations:
+        lines.append("# (no violations — nothing to triage)")
+        lines.append("")
+        return "\n".join(lines)
+
+    # Group by entity for readability. Station entity always comes first
+    # if present; devices follow in id_entity order.
+    station_vios: List[MissingAttributeViolation] = []
+    by_device: Dict[int, List[MissingAttributeViolation]] = {}
+    entity_meta: Dict[int, Tuple[str, Optional[str]]] = {}
+    for v in report.violations:
+        if v.id_entity == report.station_id:
+            station_vios.append(v)
+        else:
+            by_device.setdefault(v.id_entity, []).append(v)
+        entity_meta[v.id_entity] = (v.subtype, v.name)
+
+    def _emit_entity_block(
+        entity_id: int, entity_vios: List[MissingAttributeViolation]
+    ) -> None:
+        subtype, label = entity_meta[entity_id]
+        label_part = f" {label!r}" if label else ""
+        lines.append(f"# --- {subtype} id_entity={entity_id}{label_part} ---")
+        for v in entity_vios:
+            value_token = _quote_value(v.suggested_value)
+            date_token = v.suggested_date_from or FILL_DATE_PLACEHOLDER
+            suggested_note = ""
+            if v.suggested_value is not None:
+                suggested_note = f"  (default: {v.suggested_value!r})"
+            elif v.suggested_date_from is not None:
+                suggested_note = f"  (date hint: {v.suggested_date_from})"
+            lines.append(f"# missing: {v.code}{suggested_note}")
+            lines.append(
+                f"#ACTION {v.id_entity} add-attribute "
+                f"{v.code} {value_token} {date_token}"
+            )
+            lines.append(f"# (or suppress: SUPPRESS {v.id_entity} {v.code})")
+            lines.append("")
+
+    if station_vios:
+        _emit_entity_block(report.station_id, station_vios)
+
+    for did in sorted(by_device):
+        _emit_entity_block(did, by_device[did])
+
+    return "\n".join(lines)

--- a/src/tostools/audit_missing_attributes.py
+++ b/src/tostools/audit_missing_attributes.py
@@ -1,0 +1,299 @@
+"""Detect missing required TOS attributes (Layer 6 of the audit work).
+
+The Layers 2-5 audit (``audit_attribute_dates``) checks the dates of attributes
+that *exist*. This module checks the *presence* of attributes that *should*
+exist — surfacing REYK-style gaps where the station entity is missing its
+``date_start``, or where a device is missing a required ``serial_number``.
+
+Rule — per ``.interrogate-tos-audit-missing-attributes.md``::
+
+    For each entity in scope (the station + its open child devices), iterate
+    the catalog rules for that entity's scope. Flag every code where
+    ``entity.code_entity_subtype ∈ entry['gps_required_for']`` AND the entity
+    has no open attribute period for that code.
+
+The walker fans out from one station:
+
+* The station entity itself is audited against ``catalog['stations']`` —
+  station subtype is always ``geophysical`` for real GPS sites.
+* Each open child device (``time_to`` is None) is audited against
+  ``catalog['devices']`` — restricted to the GPS quartet
+  (gnss_receiver, antenna, radome, monument). Monument-specific catalog
+  entries are reached naturally via ``applies_to: [monument]``.
+
+Iterating *only* the entity's natural catalog scope prevents the cross-scope
+collision pattern (``subtype``, ``date_start``, ``lat``, …) from shadowing
+station-level rules behind device-level ones. See
+:func:`tostools.audit_attribute_dates.load_catalog_scoped`.
+
+Suppression-file integration and CLI wiring land in the next step (Layer 6
+task #10); this module exposes the walker + data model only.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from .api.tos_client import TOSClient
+from .audit import GPS_DEVICE_SUBTYPES, _resolve_station_entity
+from .audit_attribute_dates import (
+    SuppressionParseError,
+    _date_only,
+    _open_attribute_value,
+    _station_display_name,
+    _station_joins_by_device,
+    load_catalog_scoped,
+)
+
+# (id_entity, code) — "missing" has no date anchor, so the suppression key
+# is shorter than the attribute-dates audit's 3-tuple.
+MissingSuppressionKey = Tuple[int, str]
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MissingAttributeViolation:
+    """One catalog code an entity is required to have but doesn't.
+
+    Carries enough context for triage emission:
+    ``suggested_value`` pre-fills the ACTION line when the catalog has a
+    ``default_value`` (e.g. ``subtype`` → ``"GPS stöð"``); ``suggested_date_from``
+    pre-fills the date when the entity is a device (we use its earliest open
+    join's ``time_from``). Stations don't carry a sensible date hint — the
+    operator picks the value when they uncomment the line.
+    """
+
+    id_entity: int
+    subtype: str
+    name: Optional[str]
+    code: str
+    scope: str  # "stations" or "devices" — which catalog scope the rule came from
+    suggested_value: Optional[str]
+    suggested_date_from: Optional[str]
+
+
+@dataclass(frozen=True)
+class SuppressedMissing:
+    """A missing-attributes hit that was filtered by the suppression file."""
+
+    violation: MissingAttributeViolation
+    suppressions_path: Path
+    line_no: int
+
+
+@dataclass
+class StationMissingAttributesReport:
+    """Result of :func:`audit_station_missing_attributes`."""
+
+    station_id: int
+    station_name: Optional[str]
+    audited_entities: int = 0
+    devices_skipped: int = 0
+    violations: List[MissingAttributeViolation] = field(default_factory=list)
+    suppressed: List[SuppressedMissing] = field(default_factory=list)
+    suppressions_path: Optional[Path] = None
+    suppressions_errors: List[SuppressionParseError] = field(default_factory=list)
+    suppressions_disabled: bool = False
+
+    @property
+    def has_violations(self) -> bool:
+        return bool(self.violations)
+
+    @property
+    def suppressed_count(self) -> int:
+        return len(self.suppressed)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _device_display_label(history: Dict[str, Any]) -> Optional[str]:
+    """Pull a human label for a device — open serial_number, then open model."""
+    for code in ("serial_number", "model"):
+        v = _open_attribute_value(history, code)
+        if v:
+            return v
+    return None
+
+
+def _required_codes_in_scope(
+    scope_rules: Dict[str, Dict[str, Any]],
+    entity_subtype: str,
+) -> List[Tuple[str, Dict[str, Any]]]:
+    """Return ``[(code, entry)]`` for rules where ``entity_subtype`` is
+    required AND ``gps_relevance == 'yes'``.
+
+    Filtering on ``gps_relevance`` keeps "no" entries (clearly seismic /
+    meteorological) and "maybe" entries (operator review still pending)
+    out of the audit until they're explicitly classified.
+    """
+    out: List[Tuple[str, Dict[str, Any]]] = []
+    for code, entry in scope_rules.items():
+        if entry.get("gps_relevance") != "yes":
+            continue
+        required = entry.get("gps_required_for") or []
+        if entity_subtype not in required:
+            continue
+        out.append((code, entry))
+    return out
+
+
+def _audit_entity(
+    *,
+    report: StationMissingAttributesReport,
+    scope_rules: Dict[str, Dict[str, Any]],
+    history: Dict[str, Any],
+    entity_id: int,
+    entity_subtype: str,
+    entity_label: Optional[str],
+    scope_name: str,
+    suggested_date_from: Optional[str] = None,
+) -> None:
+    """Walk one entity (station, device, or monument).
+
+    Increments ``report.audited_entities``, appends to ``report.violations``.
+    The caller passes the correct catalog scope (``catalog['stations']`` for
+    a station entity, ``catalog['devices']`` for a device/monument) so
+    cross-scope code collisions stay distinct.
+    """
+    report.audited_entities += 1
+    for code, entry in _required_codes_in_scope(scope_rules, entity_subtype):
+        if _open_attribute_value(history, code) is not None:
+            continue
+        default = entry.get("default_value")
+        suggested_value = str(default) if default is not None else None
+        report.violations.append(
+            MissingAttributeViolation(
+                id_entity=entity_id,
+                subtype=entity_subtype,
+                name=entity_label,
+                code=code,
+                scope=scope_name,
+                suggested_value=suggested_value,
+                suggested_date_from=suggested_date_from,
+            )
+        )
+
+
+# ---------------------------------------------------------------------------
+# Main audit entry point
+# ---------------------------------------------------------------------------
+
+
+def audit_station_missing_attributes(
+    client: TOSClient,
+    *,
+    name: Optional[str] = None,
+    id_entity: Optional[int] = None,
+    subtypes: Optional[Sequence[str]] = None,
+    catalog_path: Optional[Path] = None,
+) -> StationMissingAttributesReport:
+    """Walk a station + its open child devices and flag missing required
+    attributes.
+
+    Parameters
+    ----------
+    client
+        Unauthenticated :class:`TOSClient`. No writes; ``basic_search`` +
+        ``get_entity_history`` only.
+    name / id_entity
+        Station identifier — pass one or the other. Resolution delegates
+        to :func:`tostools.audit._resolve_station_entity`, which prefers
+        markers and disambiguates ``geophysical`` station collisions.
+    subtypes
+        Device subtypes to audit. Defaults to
+        :data:`tostools.audit.GPS_DEVICE_SUBTYPES`
+        (gnss_receiver, antenna, radome, monument).
+    catalog_path
+        Override the catalog file location. Defaults to the canonical
+        repo path / ``TOSTOOLS_ATTRIBUTE_CODES_PATH`` env var.
+
+    Returns
+    -------
+    StationMissingAttributesReport
+        ``has_violations`` is True when at least one required attribute is
+        missing from an audited entity.
+
+    Raises
+    ------
+    LookupError
+        Station not found.
+    ValueError
+        Neither ``name`` nor ``id_entity`` set.
+    FileNotFoundError
+        Catalog file missing.
+    """
+    scoped = load_catalog_scoped(catalog_path)
+    stations_rules = scoped.get("stations") or {}
+    devices_rules = scoped.get("devices") or {}
+
+    wanted = tuple(subtypes) if subtypes else GPS_DEVICE_SUBTYPES
+
+    station_history = _resolve_station_entity(client, name=name, id_entity=id_entity)
+    station_id = int(station_history["id_entity"])
+    station_subtype = station_history.get("code_entity_subtype") or "geophysical"
+    station_name = _station_display_name(station_history, name)
+
+    report = StationMissingAttributesReport(
+        station_id=station_id,
+        station_name=station_name,
+    )
+
+    # 1. Station entity itself — iterate stations scope.
+    _audit_entity(
+        report=report,
+        scope_rules=stations_rules,
+        history=station_history,
+        entity_id=station_id,
+        entity_subtype=station_subtype,
+        entity_label=station_name,
+        scope_name="stations",
+        suggested_date_from=None,
+    )
+
+    # 2. Each open child device — iterate devices scope. Closed joins
+    #    (time_to set) are skipped: a removed device's missing attributes
+    #    aren't a current operational gap.
+    joins_by_device = _station_joins_by_device(station_history)
+    for device_id, joins in joins_by_device.items():
+        open_joins = [j for j in joins if j.get("time_to") is None]
+        if not open_joins:
+            continue
+
+        history = client.get_entity_history(device_id)
+        if not history:
+            continue
+
+        dev_subtype = history.get("code_entity_subtype") or ""
+        if dev_subtype not in wanted:
+            report.devices_skipped += 1
+            continue
+
+        device_label = _device_display_label(history)
+        join_dates = [
+            _date_only(str(j["time_from"]))
+            for j in open_joins
+            if j.get("time_from")
+        ]
+        suggested_date = min(join_dates) if join_dates else None
+
+        _audit_entity(
+            report=report,
+            scope_rules=devices_rules,
+            history=history,
+            entity_id=device_id,
+            entity_subtype=dev_subtype,
+            entity_label=device_label,
+            scope_name="devices",
+            suggested_date_from=suggested_date,
+        )
+
+    return report

--- a/src/tostools/tos.py
+++ b/src/tostools/tos.py
@@ -2063,6 +2063,13 @@ def _audit_main(argv):
             "  tos audit attribute-dates RHOF --no-suppressions     # bypass committed SUPPRESSes\n"
             "  tos audit attribute-dates RHOF --json                # machine-readable\n"
             "\n"
+            "  # ---- Missing required attributes (Layer 6) ---------------\n"
+            "  tos audit missing-attributes HAUC                    # station + open devices + monument\n"
+            "  tos audit missing-attributes HAUC --verbose          # show SUPPRESS hints + silenced entries\n"
+            "  tos audit missing-attributes HAUC --triage trial.txt # emit ACTION file (add-attribute lines)\n"
+            "  tos audit missing-attributes HAUC --no-suppressions  # bypass committed SUPPRESSes\n"
+            "  tos audit missing-attributes HAUC --json             # machine-readable\n"
+            "\n"
             "  # ---- Apply triage files (writes; needs credentials) -----\n"
             "  tos audit apply trial.txt                            # dry-run preview (default)\n"
             "  tos audit apply trial.txt --apply                    # commit writes\n"
@@ -2604,6 +2611,101 @@ def _audit_main(argv):
     )
     p_attr.add_argument("--port", type=int, default=443)
 
+    p_missing = sub.add_parser(
+        "missing-attributes",
+        help="Flag required TOS attributes that have no open period.",
+        description=(
+            "Walk a station + its open child devices + monument and flag "
+            "every catalog code where the entity's subtype is listed in "
+            "``gps_required_for`` but the entity has no open attribute "
+            "period for it. Complements `attribute-dates` (which checks "
+            "the dates of attributes that *exist*); this verb checks the "
+            "presence of attributes that *should* exist.\n\n"
+            "Rule: for each entity in scope (station + open GPS-quartet "
+            "children — gnss_receiver, antenna, radome, monument), iterate "
+            "the catalog rules for that entity's scope. Flag every code "
+            "where ``entity.code_entity_subtype ∈ entry['gps_required_for']`` "
+            "AND the entity has no open attribute period for that code. "
+            "Filters: ``gps_relevance == 'yes'`` gates above "
+            "``gps_required_for`` — TODO / maybe / no entries are silently "
+            "skipped until the operator classifies them.\n\n"
+            "Exits 0 when no violations found (or all were suppressed), "
+            "1 when at least one violation survives, 2 on lookup / usage "
+            "error. The ``(id_entity, code)`` 2-tuple in each violation "
+            "is the natural suppression key for Layer 3 "
+            "(data/audit_suppressions/missing_attributes.txt)."
+        ),
+        epilog=(
+            "Examples:\n"
+            "  tos audit missing-attributes HAUC\n"
+            "  tos audit missing-attributes HAUC --verbose\n"
+            "  tos audit missing-attributes HAUC --triage hauc_missing.txt\n"
+            "  tos audit missing-attributes --id 1234 --subtypes antenna monument\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p_missing.add_argument(
+        "name", nargs="?", help="Station marker (e.g. HAUC) or display name."
+    )
+    p_missing.add_argument(
+        "--id", dest="id_entity", type=int, help="Station id_entity."
+    )
+    p_missing.add_argument(
+        "--subtypes",
+        nargs="+",
+        help=(
+            "Device subtypes to audit (short or canonical). Default: "
+            "gnss_receiver, antenna, radome, monument."
+        ),
+    )
+    p_missing.add_argument(
+        "--catalog",
+        type=Path,
+        default=None,
+        help="Override the catalog YAML path. Defaults to repo "
+        "data/attribute_codes.yaml or $TOSTOOLS_ATTRIBUTE_CODES_PATH.",
+    )
+    p_missing.add_argument(
+        "--suppressions",
+        type=Path,
+        default=None,
+        help="Override the suppression file path. Defaults to "
+        "data/audit_suppressions/missing_attributes.txt. File-not-found "
+        "is silent (the file is opt-in).",
+    )
+    p_missing.add_argument(
+        "--no-suppressions",
+        action="store_true",
+        help="Bypass the suppression file entirely; every missing-attribute "
+        "hit is reported. Useful to verify what a stale SUPPRESS line is hiding.",
+    )
+    p_missing.add_argument(
+        "--triage",
+        dest="triage_path",
+        type=Path,
+        default=None,
+        help="Emit a draft ACTION file at this path. One commented "
+        "`ACTION ... add-attribute ...` line per violation, with the "
+        "catalog's default_value pre-filled when present (otherwise "
+        "<FILL_VALUE>) and the device's earliest open-join time_from "
+        "as the date hint (otherwise <FILL_DATE>).",
+    )
+    p_missing.add_argument(
+        "--json", action="store_true", help="Emit JSON instead of plain text."
+    )
+    p_missing.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Show extra context: SUPPRESS hint per violation and any "
+        "entries that were silenced by the suppression file.",
+    )
+    p_missing.add_argument(
+        "--server",
+        default="vi-api.vedur.is",
+        help="TOS API host (default: vi-api.vedur.is).",
+    )
+    p_missing.add_argument("--port", type=int, default=443)
+
     args = p.parse_args(argv)
 
     scheme = "https" if args.port == 443 else "http"
@@ -2840,6 +2942,51 @@ def _audit_main(argv):
             )
         else:
             _print_attribute_date_report(report, verbose=args.verbose)
+        return 1 if report.has_violations else 0
+
+    if args.kind == "missing-attributes":
+        from . import audit_missing_attributes as ama_mod
+
+        try:
+            report = ama_mod.audit_station_missing_attributes(
+                client,
+                name=args.name,
+                id_entity=args.id_entity,
+                subtypes=args.subtypes,
+                catalog_path=args.catalog,
+                suppressions_path=args.suppressions,
+                use_suppressions=not args.no_suppressions,
+            )
+        except (LookupError, ValueError, FileNotFoundError) as e:
+            print(str(e), file=sys.stderr)
+            return 2
+        if report.suppressions_errors:
+            print(
+                f"warning: {len(report.suppressions_errors)} malformed line(s) "
+                f"in {report.suppressions_path}:",
+                file=sys.stderr,
+            )
+            for err in report.suppressions_errors:
+                print(f"  line {err.line_no}: {err.message}", file=sys.stderr)
+        if args.triage_path:
+            audit_cmd = "tos audit " + " ".join(argv) if argv else "tos audit"
+            content = ama_mod.format_triage_file(report, audit_command=audit_cmd)
+            args.triage_path.write_text(content, encoding="utf-8")
+            print(
+                f"wrote triage file: {args.triage_path} "
+                f"({len(report.violations)} violation(s))",
+                file=sys.stderr,
+            )
+        if args.json:
+            print(
+                _json.dumps(
+                    _missing_attributes_report_to_dict(report),
+                    ensure_ascii=False,
+                    indent=2,
+                )
+            )
+        else:
+            _print_missing_attributes_report(report, verbose=args.verbose)
         return 1 if report.has_violations else 0
 
     p.error(f"unknown kind: {args.kind}")
@@ -3892,6 +4039,129 @@ def _print_attribute_date_report(report, *, verbose: bool = False):
             f"  ({len(report.unknown_codes)} unknown attribute code(s); "
             f"re-run with --verbose to list them)"
         )
+
+
+def _missing_attributes_report_to_dict(report):
+    """Convert a :class:`StationMissingAttributesReport` to a JSON-serialisable dict."""
+
+    def _violation_dict(v):
+        return {
+            "id_entity": v.id_entity,
+            "subtype": v.subtype,
+            "name": v.name,
+            "code": v.code,
+            "scope": v.scope,
+            "suggested_value": v.suggested_value,
+            "suggested_date_from": v.suggested_date_from,
+        }
+
+    return {
+        "kind": "missing-attributes",
+        "station_id": report.station_id,
+        "station_name": report.station_name,
+        "audited_entities": report.audited_entities,
+        "devices_skipped": report.devices_skipped,
+        "violations": [_violation_dict(v) for v in report.violations],
+        "suppressed": [
+            {
+                **_violation_dict(s.violation),
+                "suppressions_path": str(s.suppressions_path),
+                "line_no": s.line_no,
+            }
+            for s in report.suppressed
+        ],
+        "suppressions_path": (
+            str(report.suppressions_path) if report.suppressions_path else None
+        ),
+        "suppressions_disabled": report.suppressions_disabled,
+        "suppressions_errors": [
+            {"line_no": e.line_no, "message": e.message, "raw": e.raw}
+            for e in report.suppressions_errors
+        ],
+    }
+
+
+def _print_missing_attributes_report(report, *, verbose: bool = False):
+    """Render a missing-attributes audit report as plain text on stdout.
+
+    Groups violations by entity (station first, then devices) for a
+    compact, human-readable layout. ``verbose=True`` shows:
+
+    * a copy-pasteable ``SUPPRESS`` hint per violation
+    * the suppressed entries that the file silenced, with file:lineno
+      references — the only audit trail of silenced violations
+    """
+    status = "CLEAN" if not report.has_violations else "VIOLATIONS"
+    marker = "✓" if not report.has_violations else "✗"
+    name = report.station_name or "?"
+    print(f"{marker} Station {name!r} (id_entity={report.station_id}) — {status}")
+    print(
+        f"  audited entities: {report.audited_entities}  "
+        f"(skipped {report.devices_skipped} non-GPS device(s))"
+    )
+    if report.suppressed_count:
+        print(
+            f"  suppressed: {report.suppressed_count} entry(ies) via "
+            f"{report.suppressions_path}"
+        )
+    elif report.suppressions_disabled:
+        print("  suppressions: disabled (--no-suppressions)")
+
+    if report.violations:
+        # Group by entity for the same shape as the triage file.
+        station_vios: List = []
+        by_device: Dict[int, List] = {}
+        entity_meta: Dict[int, tuple] = {}
+        for v in report.violations:
+            if v.id_entity == report.station_id:
+                station_vios.append(v)
+            else:
+                by_device.setdefault(v.id_entity, []).append(v)
+            entity_meta[v.id_entity] = (v.subtype, v.name, v.scope)
+        print()
+        print(f"  flagged ({len(report.violations)} attribute(s)):")
+
+        def _emit_entity(eid: int, vios: List) -> None:
+            subtype, label, _scope = entity_meta[eid]
+            label_part = f" {label!r}" if label else ""
+            print(f"    {subtype} id_entity={eid}{label_part}")
+            for v in vios:
+                hint_parts = []
+                if v.suggested_value is not None:
+                    hint_parts.append(f"suggested: {v.suggested_value!r}")
+                else:
+                    hint_parts.append("suggested: <FILL_VALUE>")
+                if v.suggested_date_from is not None:
+                    hint_parts.append(f"date hint: {v.suggested_date_from}")
+                hint_str = ", ".join(hint_parts)
+                print(f"      · {v.code:24s} ({hint_str})")
+                if verbose:
+                    print(f"        suppress: SUPPRESS {v.id_entity} {v.code}")
+
+        if station_vios:
+            _emit_entity(report.station_id, station_vios)
+        for did in sorted(by_device):
+            _emit_entity(did, by_device[did])
+
+    if verbose and report.suppressed:
+        print()
+        print(f"  suppressed ({len(report.suppressed)} silenced entry(ies)):")
+        by_device_s: Dict[int, List] = {}
+        entity_meta_s: Dict[int, tuple] = {}
+        for s in report.suppressed:
+            v = s.violation
+            by_device_s.setdefault(v.id_entity, []).append(s)
+            entity_meta_s[v.id_entity] = (v.subtype, v.name)
+        for eid in sorted(by_device_s):
+            subtype, label = entity_meta_s[eid]
+            label_part = f" {label!r}" if label else ""
+            print(f"    {subtype} id_entity={eid}{label_part}")
+            for s in by_device_s[eid]:
+                v = s.violation
+                print(
+                    f"      · {v.code:24s} "
+                    f"(suppressed at {s.suppressions_path}:{s.line_no})"
+                )
 
 
 def _station_report_to_dict(report):

--- a/src/tostools/tos.py
+++ b/src/tostools/tos.py
@@ -2408,6 +2408,14 @@ def _audit_main(argv):
             "                            PATCH /attribute_value/<id> "
             "date_from — consumes triage files from\n"
             "                            `tos audit attribute-dates --triage`\n"
+            "  add-attribute <code> <value> <date_from>\n"
+            "                            POST /attribute_values — add a new open "
+            "period to fill\n"
+            "                            a required-attribute gap. Consumes triage "
+            "files from\n"
+            "                            `tos audit missing-attributes --triage`. "
+            "Quote values\n"
+            "                            with spaces, e.g. `'GPS stöð'`.\n"
             "  defer                      no-op placeholder (review next run)\n\n"
             "Validation: each ACTION line is parsed before any HTTP call. "
             "If any line is malformed, nothing is sent. Otherwise actions "
@@ -3019,6 +3027,7 @@ class ParseError:
 
 
 _SUPPORTED_VERBS = (
+    "add-attribute",
     "change-subtype",
     "decommission",
     "defer",
@@ -3036,9 +3045,16 @@ def _parse_action_file(text: str) -> tuple[List[ParsedAction], List[ParseError]]
 
         ACTION <id_entity> <verb> [args...]
 
+    Token splitting uses :func:`shlex.split` so values containing spaces
+    can be quoted (e.g. ``add-attribute subtype 'GPS stöð' 2010-01-01``).
+    For verbs that take bare tokens (patch-attribute-date, change-subtype,
+    …), shlex.split behaves identically to ``str.split()``.
+
     Returns both lists so the runner can report every malformed line at
     once instead of bailing on the first error.
     """
+    import shlex
+
     actions: List[ParsedAction] = []
     errors: List[ParseError] = []
     for i, line in enumerate(text.splitlines(), 1):
@@ -3049,7 +3065,17 @@ def _parse_action_file(text: str) -> tuple[List[ParsedAction], List[ParseError]]
         line = line.strip()
         if not line:
             continue
-        tokens = line.split()
+        try:
+            tokens = shlex.split(line)
+        except ValueError as exc:
+            errors.append(
+                ParseError(
+                    line_no=i,
+                    message=f"malformed quoting: {exc}",
+                    raw=raw,
+                )
+            )
+            continue
         if tokens[0] != "ACTION":
             errors.append(
                 ParseError(
@@ -3160,6 +3186,20 @@ def _parse_action_file(text: str) -> tuple[List[ParsedAction], List[ParseError]]
                     message=(
                         "patch-attribute-date requires exactly three "
                         "arguments: <code> <old_date_from> <new_date_from>"
+                    ),
+                    raw=raw,
+                )
+            )
+            continue
+        if verb == "add-attribute" and len(tokens) != 6:
+            errors.append(
+                ParseError(
+                    line_no=i,
+                    message=(
+                        "add-attribute requires exactly three arguments: "
+                        "<code> <value> <date_from> "
+                        "(quote the value if it contains spaces, e.g. "
+                        "'GPS stöð')"
                     ),
                     raw=raw,
                 )
@@ -3529,6 +3569,143 @@ def _dispatch_patch_attribute_date(writer, action: ParsedAction) -> ActionResult
     )
 
 
+def _dispatch_add_attribute(writer, action: ParsedAction) -> ActionResult:
+    """Add a new attribute period to an existing entity.
+
+    Action shape: ``ACTION <id_entity> add-attribute <code> <value>
+    <date_from>``. Fires the missing-attributes audit's ``add-attribute``
+    verb — used to fill the gap when an entity is required to carry a
+    code but has no open period for it.
+
+    Pre-flight checks before POSTing
+    --------------------------------
+    * **Placeholder rejection** — if ``value`` or ``date_from`` still
+      contains a ``<FILL_*>`` placeholder, the operator forgot to
+      replace it. Refuse rather than POST a literal placeholder string
+      to TOS.
+    * **Date format** — ``date_from`` must be ``YYYY-MM-DD``.
+    * **Conflict detection** — fetches existing periods via
+      :meth:`writer.get_attribute_values`; if an open period already
+      exists with the same value, the action is a no-op (idempotent).
+      If an open period exists with a *different* value, refuse —
+      silent overwrite is the failure mode we're explicitly guarding
+      against; the operator should use a transition verb if they want
+      history-preserving update.
+    * **Multiple open periods** — refuse; the entity is already in a
+      corrupt state and ``add-attribute`` would compound it.
+
+    Otherwise calls :meth:`writer.add_attribute_value` to POST a new
+    period with ``date_to=None``. The writer's ``dry_run`` flag
+    controls whether anything actually goes over the wire.
+    """
+    code = action.args[0]
+    value = action.args[1]
+    date_from_raw = action.args[2]
+
+    # Placeholder rejection — anything matching <...> shape is a
+    # triage marker the operator forgot to fill in. Cheaper to refuse
+    # here than to debug a literal "<FILL_VALUE>" string sitting in TOS.
+    if value.startswith("<") and value.endswith(">"):
+        return ActionResult(
+            action=action,
+            status="failed",
+            detail=(
+                f"add-attribute: value placeholder {value!r} not replaced — "
+                "fill in the value before applying"
+            ),
+        )
+    if date_from_raw.startswith("<") and date_from_raw.endswith(">"):
+        return ActionResult(
+            action=action,
+            status="failed",
+            detail=(
+                f"add-attribute: date placeholder {date_from_raw!r} not "
+                "replaced — fill in the date_from before applying"
+            ),
+        )
+
+    # Date format check — same YYYY-MM-DD contract as patch-attribute-date.
+    date_from = date_from_raw[:10]
+    if len(date_from) != 10 or date_from[4] != "-" or date_from[7] != "-":
+        return ActionResult(
+            action=action,
+            status="failed",
+            detail=(
+                f"add-attribute: date_from must be YYYY-MM-DD "
+                f"(got {date_from_raw!r})"
+            ),
+        )
+
+    try:
+        existing = writer.get_attribute_values(action.id_entity, code)
+    except Exception as exc:  # noqa: BLE001
+        return ActionResult(
+            action=action,
+            status="failed",
+            detail=f"get_attribute_values raised: {exc}",
+        )
+
+    open_values = [a for a in existing if a.get("date_to") is None]
+    if len(open_values) > 1:
+        ids = ", ".join(
+            str(a.get("id_attribute_value")) for a in open_values
+        )
+        return ActionResult(
+            action=action,
+            status="failed",
+            detail=(
+                f"add-attribute: {len(open_values)} open periods already "
+                f"exist for code {code!r} on id_entity={action.id_entity} "
+                f"(ids: {ids}) — refusing to add; clean up the existing "
+                "duplicates first"
+            ),
+        )
+    if len(open_values) == 1:
+        current = open_values[0]
+        current_value = current.get("value")
+        if str(current_value) == value:
+            return ActionResult(
+                action=action,
+                status="ok",
+                detail=(
+                    f"already present: open period for {code!r} on "
+                    f"id_entity={action.id_entity} already has value "
+                    f"{value!r} (no-op)"
+                ),
+            )
+        return ActionResult(
+            action=action,
+            status="failed",
+            detail=(
+                f"add-attribute: open period for {code!r} on "
+                f"id_entity={action.id_entity} already has value "
+                f"{current_value!r}; refuse to overwrite with {value!r}. "
+                "Use a transition verb (history-preserving) instead."
+            ),
+        )
+
+    try:
+        response = writer.add_attribute_value(
+            action.id_entity, code, value, date_from
+        )
+    except Exception as exc:  # noqa: BLE001
+        return ActionResult(
+            action=action,
+            status="failed",
+            detail=f"add_attribute_value raised: {exc}",
+        )
+
+    return ActionResult(
+        action=action,
+        status="ok",
+        detail=(
+            f"POST /attribute_values id_entity={action.id_entity} "
+            f"code={code!r} value={value!r} date_from={date_from} "
+            f"— {response!r}"
+        ),
+    )
+
+
 def _dispatch_action(
     writer,
     action: ParsedAction,
@@ -3566,6 +3743,8 @@ def _dispatch_action(
         return _dispatch_fill_gap(writer, action)
     if action.verb == "patch-attribute-date":
         return _dispatch_patch_attribute_date(writer, action)
+    if action.verb == "add-attribute":
+        return _dispatch_add_attribute(writer, action)
     if action.verb == "change-subtype":
         code = action.args[0]
         mapping = subtype_id_by_code or {}

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -916,3 +916,305 @@ def test_dispatch_patch_attribute_date_captures_read_exception():
     assert result.status == "failed"
     assert "get_attribute_values raised" in result.detail
     writer.patch_attribute_value.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _parse_action_file — add-attribute
+# ---------------------------------------------------------------------------
+
+
+def test_parse_action_file_add_attribute_three_args():
+    text = "ACTION 4257 add-attribute in_network_epos true 2021-11-01\n"
+    actions, errors = _parse_action_file(text)
+    assert errors == []
+    assert len(actions) == 1
+    assert actions[0].verb == "add-attribute"
+    assert actions[0].id_entity == 4257
+    assert actions[0].args == ["in_network_epos", "true", "2021-11-01"]
+
+
+def test_parse_action_file_add_attribute_quoted_value():
+    """Values with spaces must be quoted — shlex.split unquotes them
+    back to a single token. The `'GPS stöð'` case is the regression
+    target: the catalog's `subtype` default carries a space."""
+    text = "ACTION 4390 add-attribute subtype 'GPS stöð' 2001-07-19\n"
+    actions, errors = _parse_action_file(text)
+    assert errors == []
+    assert actions[0].args == ["subtype", "GPS stöð", "2001-07-19"]
+
+
+def test_parse_action_file_add_attribute_double_quoted_value():
+    """Double quotes also work — shlex accepts either form."""
+    text = 'ACTION 4390 add-attribute subtype "GPS stöð" 2001-07-19\n'
+    actions, errors = _parse_action_file(text)
+    assert errors == []
+    assert actions[0].args == ["subtype", "GPS stöð", "2001-07-19"]
+
+
+def test_parse_action_file_add_attribute_rejects_too_few_args():
+    text = "ACTION 4257 add-attribute date_start 2010-01-01\n"
+    actions, errors = _parse_action_file(text)
+    assert actions == []
+    assert "add-attribute requires exactly three arguments" in errors[0].message
+
+
+def test_parse_action_file_add_attribute_rejects_extra_args():
+    text = "ACTION 4257 add-attribute date_start 2010-01-01 2011-01-01 EXTRA\n"
+    actions, errors = _parse_action_file(text)
+    assert actions == []
+    assert "add-attribute requires exactly three arguments" in errors[0].message
+
+
+def test_parse_action_file_rejects_unbalanced_quoting():
+    """shlex raises on unbalanced quotes; the error is captured, not
+    propagated, so the rest of the file still parses."""
+    text = (
+        "ACTION 100 add-attribute marker 'unclosed quote 2020-01-01\n"
+        "ACTION 200 defer\n"
+    )
+    actions, errors = _parse_action_file(text)
+    assert len(actions) == 1
+    assert actions[0].id_entity == 200
+    assert "malformed quoting" in errors[0].message
+
+
+def test_parse_action_file_backward_compat_with_bare_tokens():
+    """shlex.split on lines with no quoting behaves identically to
+    str.split — verify existing verbs aren't disturbed."""
+    text = (
+        "ACTION 16321 change-subtype digitizer\n"
+        "ACTION 16321 patch-attribute-date serial_number "
+        "2014-10-17 2002-01-01\n"
+        "ACTION 16321 defer\n"
+    )
+    actions, errors = _parse_action_file(text)
+    assert errors == []
+    assert [a.verb for a in actions] == [
+        "change-subtype",
+        "patch-attribute-date",
+        "defer",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# _dispatch_action — add-attribute
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_add_attribute_happy_path():
+    """No existing open period → POST a new attribute value."""
+    writer = MagicMock()
+    writer.get_attribute_values.return_value = []  # entity has no values yet
+    writer.add_attribute_value.return_value = {"id_attribute_value": 99001}
+
+    result = _dispatch_action(
+        writer,
+        _make_action(
+            4257, "add-attribute", "date_start", "2010-06-15", "2010-06-15"
+        ),
+    )
+
+    assert result.status == "ok"
+    writer.get_attribute_values.assert_called_once_with(4257, "date_start")
+    writer.add_attribute_value.assert_called_once_with(
+        4257, "date_start", "2010-06-15", "2010-06-15"
+    )
+    assert "POST /attribute_values id_entity=4257" in result.detail
+
+
+def test_dispatch_add_attribute_quoted_value_passes_through():
+    """A value parsed from `'GPS stöð'` reaches the writer unchanged."""
+    writer = MagicMock()
+    writer.get_attribute_values.return_value = []
+    writer.add_attribute_value.return_value = {"id_attribute_value": 99002}
+
+    result = _dispatch_action(
+        writer,
+        _make_action(
+            4390, "add-attribute", "subtype", "GPS stöð", "2001-07-19"
+        ),
+    )
+
+    assert result.status == "ok"
+    writer.add_attribute_value.assert_called_once_with(
+        4390, "subtype", "GPS stöð", "2001-07-19"
+    )
+
+
+def test_dispatch_add_attribute_same_value_is_no_op():
+    """Open period with the same value → idempotent skip; never POSTs.
+    Guards against accidental duplicate periods when the apply runs
+    twice in a row."""
+    writer = MagicMock()
+    writer.get_attribute_values.return_value = [
+        _attr_value(50001, "date_start", "2010-06-15", "2010-06-15 00:00:00")
+    ]
+
+    result = _dispatch_action(
+        writer,
+        _make_action(
+            4257, "add-attribute", "date_start", "2010-06-15", "2010-06-15"
+        ),
+    )
+
+    assert result.status == "ok"
+    assert "already present" in result.detail
+    writer.add_attribute_value.assert_not_called()
+
+
+def test_dispatch_add_attribute_different_value_refuses():
+    """Open period exists with a different value → refuse rather than
+    silently overwrite. This is the safety contract the dispatcher
+    enforces; the operator should use a transition verb for
+    history-preserving updates."""
+    writer = MagicMock()
+    writer.get_attribute_values.return_value = [
+        _attr_value(50001, "subtype", "Annað", "2001-01-01 00:00:00")
+    ]
+
+    result = _dispatch_action(
+        writer,
+        _make_action(
+            4390, "add-attribute", "subtype", "GPS stöð", "2001-07-19"
+        ),
+    )
+
+    assert result.status == "failed"
+    assert "refuse to overwrite" in result.detail
+    assert "Annað" in result.detail
+    writer.add_attribute_value.assert_not_called()
+
+
+def test_dispatch_add_attribute_multiple_open_periods_refuses():
+    """Two open periods for the same code → data is already corrupt.
+    add-attribute refuses to compound the problem."""
+    writer = MagicMock()
+    writer.get_attribute_values.return_value = [
+        _attr_value(50001, "subtype", "X", "2001-01-01 00:00:00"),
+        _attr_value(50002, "subtype", "Y", "2005-01-01 00:00:00"),
+    ]
+
+    result = _dispatch_action(
+        writer,
+        _make_action(
+            4390, "add-attribute", "subtype", "GPS stöð", "2001-07-19"
+        ),
+    )
+
+    assert result.status == "failed"
+    assert "2 open periods" in result.detail
+    writer.add_attribute_value.assert_not_called()
+
+
+def test_dispatch_add_attribute_fill_value_placeholder_refuses():
+    """A literal <FILL_VALUE> in the action line means the operator
+    forgot to fill it in — refuse before any network call."""
+    writer = MagicMock()
+
+    result = _dispatch_action(
+        writer,
+        _make_action(
+            4257, "add-attribute", "note", "<FILL_VALUE>", "2010-01-01"
+        ),
+    )
+
+    assert result.status == "failed"
+    assert "placeholder" in result.detail
+    writer.get_attribute_values.assert_not_called()
+    writer.add_attribute_value.assert_not_called()
+
+
+def test_dispatch_add_attribute_fill_date_placeholder_refuses():
+    writer = MagicMock()
+
+    result = _dispatch_action(
+        writer,
+        _make_action(
+            4257, "add-attribute", "date_start", "2010-01-01", "<FILL_DATE>"
+        ),
+    )
+
+    assert result.status == "failed"
+    assert "date placeholder" in result.detail
+    writer.add_attribute_value.assert_not_called()
+
+
+def test_dispatch_add_attribute_invalid_date_format_refuses():
+    writer = MagicMock()
+
+    result = _dispatch_action(
+        writer,
+        _make_action(
+            4257, "add-attribute", "date_start", "2010-01-01", "not-a-date"
+        ),
+    )
+
+    assert result.status == "failed"
+    assert "YYYY-MM-DD" in result.detail
+    writer.add_attribute_value.assert_not_called()
+
+
+def test_dispatch_add_attribute_get_raises_returns_failed():
+    """Network/auth errors from get_attribute_values surface as failed
+    actions — never raise out of the dispatcher."""
+    writer = MagicMock()
+    writer.get_attribute_values.side_effect = RuntimeError("simulated 503")
+
+    result = _dispatch_action(
+        writer,
+        _make_action(
+            4257, "add-attribute", "date_start", "2010-06-15", "2010-06-15"
+        ),
+    )
+
+    assert result.status == "failed"
+    assert "get_attribute_values raised" in result.detail
+    writer.add_attribute_value.assert_not_called()
+
+
+def test_dispatch_add_attribute_writer_raises_returns_failed():
+    """Network/auth errors from add_attribute_value surface as failed
+    actions — never raise out of the dispatcher."""
+    writer = MagicMock()
+    writer.get_attribute_values.return_value = []
+    writer.add_attribute_value.side_effect = RuntimeError("simulated 500")
+
+    result = _dispatch_action(
+        writer,
+        _make_action(
+            4257, "add-attribute", "date_start", "2010-06-15", "2010-06-15"
+        ),
+    )
+
+    assert result.status == "failed"
+    assert "add_attribute_value raised" in result.detail
+
+
+def test_dispatch_add_attribute_skips_closed_periods_for_conflict_check():
+    """Closed periods (date_to set) don't count as open conflicts — only
+    open periods (date_to is None) gate the new POST."""
+    writer = MagicMock()
+    # All existing periods are closed → still allowed to add a new open one.
+    writer.get_attribute_values.return_value = [
+        _attr_value(
+            50001, "subtype", "Old", "2001-01-01 00:00:00",
+            date_to="2005-12-31 00:00:00",
+        ),
+        _attr_value(
+            50002, "subtype", "Older", "1995-01-01 00:00:00",
+            date_to="2000-12-31 00:00:00",
+        ),
+    ]
+    writer.add_attribute_value.return_value = {"id_attribute_value": 99003}
+
+    result = _dispatch_action(
+        writer,
+        _make_action(
+            4390, "add-attribute", "subtype", "GPS stöð", "2006-01-01"
+        ),
+    )
+
+    assert result.status == "ok"
+    writer.add_attribute_value.assert_called_once_with(
+        4390, "subtype", "GPS stöð", "2006-01-01"
+    )

--- a/tests/test_audit_attribute_dates.py
+++ b/tests/test_audit_attribute_dates.py
@@ -25,6 +25,7 @@ from tostools.audit_attribute_dates import (
     classification_for,
     format_triage_file,
     load_catalog,
+    load_catalog_scoped,
     load_suppressions,
     validate_codes_against_catalog,
 )
@@ -263,6 +264,74 @@ def test_load_catalog_devices_wins_on_collision(tmp_path: Path):
 def test_load_catalog_missing_file_raises(tmp_path: Path):
     with pytest.raises(FileNotFoundError):
         load_catalog(tmp_path / "does-not-exist.yaml")
+
+
+# ---------------------------------------------------------------------------
+# load_catalog_scoped
+# ---------------------------------------------------------------------------
+
+
+def test_load_catalog_scoped_preserves_scopes(catalog_path: Path):
+    """The scoped view keeps the three scopes separate — Layer 6 walker
+    iterates rules per-entity-type, so cross-scope code collisions must
+    stay distinct (unlike the flat view where devices wins)."""
+    scoped = load_catalog_scoped(catalog_path)
+    assert set(scoped.keys()) == {"devices", "locations", "stations"}
+    assert "serial_number" in scoped["devices"]
+    assert "address" in scoped["locations"]
+    assert "marker" in scoped["stations"]
+
+
+def test_load_catalog_scoped_keeps_cross_scope_collisions_distinct(tmp_path: Path):
+    """When the same code appears in two scopes, each entry survives under
+    its own scope key — the regression the rename + scoped view exists to
+    fix (TOS uses ``subtype`` on both stations and devices)."""
+    yaml_text = dedent("""
+        devices:
+          subtype:
+            classification: TODO
+            applies_to: [gnss_receiver, antenna, radome, monument]
+            gps_relevance: "no"
+            why: "from devices"
+        stations:
+          subtype:
+            classification: inherent
+            tos_required_for: [geophysical]
+            gps_required_for: [geophysical]
+            default_value: "GPS stöð"
+            applies_to: [geophysical]
+            gps_relevance: "yes"
+            why: "from stations"
+        """).strip()
+    p = tmp_path / "cat.yaml"
+    p.write_text(yaml_text, encoding="utf-8")
+    scoped = load_catalog_scoped(p)
+    assert scoped["devices"]["subtype"]["why"] == "from devices"
+    assert scoped["stations"]["subtype"]["why"] == "from stations"
+    assert scoped["stations"]["subtype"]["default_value"] == "GPS stöð"
+
+
+def test_load_catalog_scoped_attaches_scope_to_each_entry(catalog_path: Path):
+    """Parity with the flat view — every entry carries ``_scope``."""
+    scoped = load_catalog_scoped(catalog_path)
+    assert scoped["devices"]["serial_number"]["_scope"] == "devices"
+    assert scoped["locations"]["address"]["_scope"] == "locations"
+    assert scoped["stations"]["marker"]["_scope"] == "stations"
+
+
+def test_load_catalog_scoped_missing_file_raises(tmp_path: Path):
+    with pytest.raises(FileNotFoundError):
+        load_catalog_scoped(tmp_path / "does-not-exist.yaml")
+
+
+def test_load_catalog_derived_from_scoped(catalog_path: Path):
+    """The flat view is a flatten of the scoped view — they must agree on
+    every code the flat view exposes."""
+    scoped = load_catalog_scoped(catalog_path)
+    flat = load_catalog(catalog_path)
+    for code, entry in flat.items():
+        scope = entry["_scope"]
+        assert scoped[scope][code] == entry
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_audit_missing_attributes.py
+++ b/tests/test_audit_missing_attributes.py
@@ -1,0 +1,593 @@
+"""Unit tests for :mod:`tostools.audit_missing_attributes`.
+
+No network — :class:`tostools.api.tos_client.TOSClient` is mocked. Catalog
+fixtures are written to ``tmp_path`` as minimal in-memory YAML; the goal is
+focused per-rule coverage of the walker, not a full integration test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+from unittest.mock import MagicMock
+
+import pytest
+
+from tostools.audit_missing_attributes import audit_station_missing_attributes
+
+
+# ---------------------------------------------------------------------------
+# Fixtures + helpers
+# ---------------------------------------------------------------------------
+
+
+def _attr(code: str, value, date_from: str = "2010-01-01", date_to=None):
+    return {
+        "code": code,
+        "value": value,
+        "date_from": date_from,
+        "date_to": date_to,
+    }
+
+
+def _conn(id_child: int, time_from: str = "2010-01-01", time_to=None):
+    return {
+        "id_entity_child": id_child,
+        "time_from": time_from,
+        "time_to": time_to,
+    }
+
+
+def _device(id_entity: int, subtype: str, attributes):
+    return {
+        "id_entity": id_entity,
+        "code_entity_subtype": subtype,
+        "attributes": list(attributes),
+        "children_connections": [],
+    }
+
+
+def _station(id_entity: int, name: str, connections, *, extra_attrs=()):
+    return {
+        "id_entity": id_entity,
+        "code_entity_subtype": "geophysical",
+        "attributes": [_attr("name", name)] + list(extra_attrs),
+        "children_connections": list(connections),
+    }
+
+
+def _client_for(history_by_id):
+    """Mock client whose ``get_entity_history`` dispatches by id and whose
+    ``basic_search`` is unused (we resolve by id_entity directly)."""
+    client = MagicMock()
+    client.get_entity_history.side_effect = lambda i: history_by_id.get(int(i))
+    return client
+
+
+# Minimal catalog exercising the rule across both scopes. Mirrors the real
+# data/attribute_codes.yaml structure but trimmed to the cases the tests cover.
+_CATALOG_YAML = dedent("""
+    devices:
+      serial_number:
+        icelandic_label: Raðnúmer
+        description: Physical device identity
+        classification: inherent
+        gps_required_for: [gnss_receiver, antenna, monument]
+        applies_to: [gnss_receiver, antenna, radome, monument]
+        gps_relevance: "yes"
+
+      model:
+        icelandic_label: Tegund tækis
+        classification: inherent
+        gps_required_for: [gnss_receiver, antenna]
+        applies_to: [gnss_receiver, antenna, monument]
+        gps_relevance: "yes"
+
+      subtype:
+        # Cross-scope collision with stations.subtype — TOS uses the same
+        # code on both scopes. In the devices scope it's classified TODO
+        # / not GPS-relevant.
+        icelandic_label: Undirtegund
+        classification: TODO
+        gps_required_for: []
+        applies_to: [gnss_receiver, antenna, radome, monument]
+        gps_relevance: "no"
+
+      inscription:
+        # Monument-only — exercises monument-specific filtering.
+        icelandic_label: Áletrun
+        classification: inherent
+        gps_required_for: [monument]
+        applies_to: [monument]
+        gps_relevance: "yes"
+
+      not_relevant:
+        # gps_relevance: "no" — must be skipped even when required matches.
+        icelandic_label: Hiti
+        classification: inherent
+        gps_required_for: [gnss_receiver]
+        applies_to: [gnss_receiver]
+        gps_relevance: "no"
+
+    stations:
+      marker:
+        icelandic_label: Auðkenni
+        classification: inherent
+        gps_required_for: [geophysical]
+        applies_to: [geophysical]
+        gps_relevance: "yes"
+
+      name:
+        classification: inherent
+        gps_required_for: [geophysical]
+        applies_to: [geophysical]
+        gps_relevance: "yes"
+
+      date_start:
+        classification: inherent
+        gps_required_for: [geophysical]
+        applies_to: [geophysical]
+        gps_relevance: "yes"
+
+      subtype:
+        # Cross-scope collision — the regression the scoped loader fixes.
+        # In stations scope this is GPS-required with a default value.
+        icelandic_label: Undirtegund
+        classification: inherent
+        gps_required_for: [geophysical]
+        default_value: "GPS stöð"
+        applies_to: [geophysical]
+        gps_relevance: "yes"
+
+      altitude:
+        classification: inherent
+        gps_required_for: [geophysical]
+        applies_to: [geophysical]
+        gps_relevance: "yes"
+    """).strip()
+
+
+@pytest.fixture
+def catalog_path(tmp_path: Path) -> Path:
+    p = tmp_path / "attribute_codes.yaml"
+    p.write_text(_CATALOG_YAML, encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Walker — basic cases
+# ---------------------------------------------------------------------------
+
+
+def test_clean_station_emits_no_violations(catalog_path: Path):
+    """Station + one device, all required attributes present → no
+    violations, audited_entities == 2."""
+    station = _station(
+        100,
+        "Test Station",
+        connections=[_conn(200)],
+        extra_attrs=[
+            _attr("marker", "tst1"),
+            _attr("date_start", "2010-01-01"),
+            _attr("subtype", "GPS stöð"),
+            _attr("altitude", 12.3),
+        ],
+    )
+    device = _device(
+        200,
+        "gnss_receiver",
+        [_attr("serial_number", "SN001"), _attr("model", "POLARX5")],
+    )
+    client = _client_for({100: station, 200: device})
+
+    report = audit_station_missing_attributes(
+        client, id_entity=100, catalog_path=catalog_path
+    )
+
+    assert not report.has_violations
+    assert report.audited_entities == 2
+    assert report.devices_skipped == 0
+
+
+def test_station_missing_date_start_flagged(catalog_path: Path):
+    """The REYK gap: station entity has no ``date_start`` open period."""
+    station = _station(
+        100,
+        "Test Station",
+        connections=[],
+        extra_attrs=[
+            _attr("marker", "tst1"),
+            _attr("subtype", "GPS stöð"),
+            _attr("altitude", 12.3),
+            # date_start missing
+        ],
+    )
+    client = _client_for({100: station})
+    report = audit_station_missing_attributes(
+        client, id_entity=100, catalog_path=catalog_path
+    )
+
+    assert report.has_violations
+    codes = {v.code for v in report.violations}
+    assert "date_start" in codes
+    assert report.audited_entities == 1
+
+
+def test_station_subtype_pre_filled_from_default(catalog_path: Path):
+    """When the catalog has a ``default_value``, the violation carries it
+    in ``suggested_value`` for triage pre-fill."""
+    station = _station(
+        100,
+        "Test Station",
+        connections=[],
+        extra_attrs=[
+            _attr("marker", "tst1"),
+            _attr("date_start", "2010-01-01"),
+            _attr("altitude", 12.3),
+            # subtype missing
+        ],
+    )
+    client = _client_for({100: station})
+    report = audit_station_missing_attributes(
+        client, id_entity=100, catalog_path=catalog_path
+    )
+
+    subtype_vio = next(v for v in report.violations if v.code == "subtype")
+    assert subtype_vio.suggested_value == "GPS stöð"
+    assert subtype_vio.scope == "stations"
+
+
+def test_violation_without_default_has_no_suggested_value(catalog_path: Path):
+    """Codes without a catalog ``default_value`` get ``suggested_value=None``
+    — the triage emitter renders ``<FILL_VALUE>``."""
+    station = _station(
+        100,
+        "Test Station",
+        connections=[],
+        extra_attrs=[
+            _attr("marker", "tst1"),
+            _attr("subtype", "GPS stöð"),
+            _attr("altitude", 12.3),
+            # date_start missing — no default in catalog
+        ],
+    )
+    client = _client_for({100: station})
+    report = audit_station_missing_attributes(
+        client, id_entity=100, catalog_path=catalog_path
+    )
+
+    date_vio = next(v for v in report.violations if v.code == "date_start")
+    assert date_vio.suggested_value is None
+
+
+# ---------------------------------------------------------------------------
+# Walker — device handling
+# ---------------------------------------------------------------------------
+
+
+def test_device_missing_serial_number_flagged(catalog_path: Path):
+    """Open device missing required attribute on devices scope."""
+    station = _station(
+        100,
+        "Test Station",
+        connections=[_conn(200, time_from="2015-06-01")],
+        extra_attrs=[
+            _attr("marker", "tst1"),
+            _attr("date_start", "2010-01-01"),
+            _attr("subtype", "GPS stöð"),
+            _attr("altitude", 12.3),
+        ],
+    )
+    device = _device(
+        200,
+        "gnss_receiver",
+        [_attr("model", "POLARX5")],
+        # serial_number missing
+    )
+    client = _client_for({100: station, 200: device})
+    report = audit_station_missing_attributes(
+        client, id_entity=100, catalog_path=catalog_path
+    )
+
+    serial_vios = [v for v in report.violations if v.code == "serial_number"]
+    assert len(serial_vios) == 1
+    v = serial_vios[0]
+    assert v.id_entity == 200
+    assert v.subtype == "gnss_receiver"
+    assert v.scope == "devices"
+    # Earliest open-join time_from used as date hint for the triage line.
+    assert v.suggested_date_from == "2015-06-01"
+
+
+def test_closed_device_join_is_skipped(catalog_path: Path):
+    """Devices whose join is closed (``time_to`` set) are removed from the
+    station; their missing attributes are not a current violation."""
+    station = _station(
+        100,
+        "Test Station",
+        connections=[_conn(200, time_from="2010-01-01", time_to="2015-01-01")],
+        extra_attrs=[
+            _attr("marker", "tst1"),
+            _attr("date_start", "2010-01-01"),
+            _attr("subtype", "GPS stöð"),
+            _attr("altitude", 12.3),
+        ],
+    )
+    # Device exists but its missing attrs should NOT be flagged because
+    # the join is closed.
+    device = _device(200, "gnss_receiver", [])
+    client = _client_for({100: station, 200: device})
+    report = audit_station_missing_attributes(
+        client, id_entity=100, catalog_path=catalog_path
+    )
+
+    assert all(v.id_entity != 200 for v in report.violations)
+    # Station-side audit still ran:
+    assert report.audited_entities == 1
+
+
+def test_non_gps_device_subtype_is_skipped(catalog_path: Path):
+    """A router (subtype outside the GPS quartet) bumps devices_skipped
+    and contributes no violations."""
+    station = _station(
+        100,
+        "Test Station",
+        connections=[_conn(200)],
+        extra_attrs=[
+            _attr("marker", "tst1"),
+            _attr("date_start", "2010-01-01"),
+            _attr("subtype", "GPS stöð"),
+            _attr("altitude", 12.3),
+        ],
+    )
+    router = _device(200, "router", [_attr("subtype", "4G LTE")])
+    client = _client_for({100: station, 200: router})
+    report = audit_station_missing_attributes(
+        client, id_entity=100, catalog_path=catalog_path
+    )
+
+    assert report.devices_skipped == 1
+    assert all(v.id_entity != 200 for v in report.violations)
+
+
+def test_monument_specific_inscription_flagged(catalog_path: Path):
+    """``inscription`` only applies to monuments — naturally picked up via
+    the gps_required_for filter when the device subtype is ``monument``."""
+    station = _station(
+        100,
+        "Test Station",
+        connections=[_conn(300)],
+        extra_attrs=[
+            _attr("marker", "tst1"),
+            _attr("date_start", "2010-01-01"),
+            _attr("subtype", "GPS stöð"),
+            _attr("altitude", 12.3),
+        ],
+    )
+    monument = _device(300, "monument", [_attr("serial_number", "MON001")])
+    client = _client_for({100: station, 300: monument})
+    report = audit_station_missing_attributes(
+        client, id_entity=100, catalog_path=catalog_path
+    )
+
+    insc = [v for v in report.violations if v.code == "inscription"]
+    assert len(insc) == 1
+    assert insc[0].subtype == "monument"
+
+
+# ---------------------------------------------------------------------------
+# Walker — scope isolation (cross-scope collision regression)
+# ---------------------------------------------------------------------------
+
+
+def test_station_subtype_not_shadowed_by_devices_subtype(catalog_path: Path):
+    """The regression the rename + scoped loader fixes: TOS uses the same
+    code ``subtype`` on both scopes. The station-scope rule has
+    ``gps_required_for: [geophysical]`` with a default; the devices-scope
+    rule is TODO / not GPS-relevant. The walker must hit the station-scope
+    rule when auditing the station entity, not be silenced by the devices
+    rule."""
+    station = _station(
+        100,
+        "Test Station",
+        connections=[],
+        extra_attrs=[
+            _attr("marker", "tst1"),
+            _attr("date_start", "2010-01-01"),
+            _attr("altitude", 12.3),
+            # subtype missing — must flag with stations-scope rule
+        ],
+    )
+    client = _client_for({100: station})
+    report = audit_station_missing_attributes(
+        client, id_entity=100, catalog_path=catalog_path
+    )
+
+    subtype_vios = [v for v in report.violations if v.code == "subtype"]
+    assert len(subtype_vios) == 1
+    v = subtype_vios[0]
+    assert v.scope == "stations"
+    assert v.suggested_value == "GPS stöð"
+
+
+def test_device_with_present_subtype_emits_no_subtype_violation(
+    catalog_path: Path,
+):
+    """The devices-scope ``subtype`` rule has gps_relevance=no — even when
+    a device has no ``subtype`` attribute, it must not be flagged. Confirms
+    the gps_relevance filter."""
+    station = _station(
+        100,
+        "Test Station",
+        connections=[_conn(200)],
+        extra_attrs=[
+            _attr("marker", "tst1"),
+            _attr("date_start", "2010-01-01"),
+            _attr("subtype", "GPS stöð"),
+            _attr("altitude", 12.3),
+        ],
+    )
+    device = _device(
+        200,
+        "gnss_receiver",
+        [_attr("serial_number", "SN001"), _attr("model", "POLARX5")],
+        # subtype attribute absent — but gps_relevance="no" in devices scope
+        # so it must not flag
+    )
+    client = _client_for({100: station, 200: device})
+    report = audit_station_missing_attributes(
+        client, id_entity=100, catalog_path=catalog_path
+    )
+
+    assert not any(v.code == "subtype" and v.scope == "devices" for v in report.violations)
+
+
+def test_not_relevant_code_skipped_even_when_required(catalog_path: Path):
+    """A code with gps_required_for: [gnss_receiver] BUT gps_relevance: 'no'
+    is NOT audited — gps_relevance gates above gps_required_for."""
+    station = _station(
+        100,
+        "Test Station",
+        connections=[_conn(200)],
+        extra_attrs=[
+            _attr("marker", "tst1"),
+            _attr("date_start", "2010-01-01"),
+            _attr("subtype", "GPS stöð"),
+            _attr("altitude", 12.3),
+        ],
+    )
+    device = _device(
+        200,
+        "gnss_receiver",
+        [_attr("serial_number", "SN001"), _attr("model", "POLARX5")],
+        # `not_relevant` absent — must not flag (gps_relevance=no)
+    )
+    client = _client_for({100: station, 200: device})
+    report = audit_station_missing_attributes(
+        client, id_entity=100, catalog_path=catalog_path
+    )
+
+    assert all(v.code != "not_relevant" for v in report.violations)
+
+
+# ---------------------------------------------------------------------------
+# Walker — date hint selection
+# ---------------------------------------------------------------------------
+
+
+def test_device_with_multiple_open_joins_picks_earliest_date(
+    catalog_path: Path,
+):
+    """A device returns to a station after a stint elsewhere — multiple
+    open joins. The earliest time_from anchors the date hint."""
+    station = _station(
+        100,
+        "Test Station",
+        connections=[
+            _conn(200, time_from="2018-06-01"),
+            _conn(200, time_from="2012-03-15"),
+            _conn(200, time_from="2020-01-01"),
+        ],
+        extra_attrs=[
+            _attr("marker", "tst1"),
+            _attr("date_start", "2010-01-01"),
+            _attr("subtype", "GPS stöð"),
+            _attr("altitude", 12.3),
+        ],
+    )
+    device = _device(200, "antenna", [])  # missing serial_number + model
+    client = _client_for({100: station, 200: device})
+    report = audit_station_missing_attributes(
+        client, id_entity=100, catalog_path=catalog_path
+    )
+
+    serial_vios = [v for v in report.violations if v.code == "serial_number"]
+    assert len(serial_vios) == 1
+    assert serial_vios[0].suggested_date_from == "2012-03-15"
+
+
+def test_station_violations_have_no_date_hint(catalog_path: Path):
+    """Station-level missing attributes don't carry a date hint — the
+    operator picks the date when uncommenting the triage line."""
+    station = _station(
+        100,
+        "Test Station",
+        connections=[],
+        extra_attrs=[
+            _attr("marker", "tst1"),
+            _attr("subtype", "GPS stöð"),
+            _attr("altitude", 12.3),
+            # date_start missing
+        ],
+    )
+    client = _client_for({100: station})
+    report = audit_station_missing_attributes(
+        client, id_entity=100, catalog_path=catalog_path
+    )
+
+    for v in report.violations:
+        assert v.suggested_date_from is None
+
+
+# ---------------------------------------------------------------------------
+# Walker — report bookkeeping
+# ---------------------------------------------------------------------------
+
+
+def test_audited_entities_counts_station_plus_open_devices(catalog_path: Path):
+    """One station + two open devices + one closed device + one router
+    (skipped). audited_entities counts station + open GPS devices only."""
+    station = _station(
+        100,
+        "Test Station",
+        connections=[
+            _conn(200),
+            _conn(201),
+            _conn(202, time_to="2015-01-01"),  # closed
+            _conn(203),  # router → skipped
+        ],
+        extra_attrs=[
+            _attr("marker", "tst1"),
+            _attr("date_start", "2010-01-01"),
+            _attr("subtype", "GPS stöð"),
+            _attr("altitude", 12.3),
+        ],
+    )
+    history_by_id = {
+        100: station,
+        200: _device(200, "gnss_receiver",
+                     [_attr("serial_number", "A"), _attr("model", "X")]),
+        201: _device(201, "antenna",
+                     [_attr("serial_number", "B"), _attr("model", "Y")]),
+        202: _device(202, "gnss_receiver", []),
+        203: _device(203, "router", []),
+    }
+    client = _client_for(history_by_id)
+    report = audit_station_missing_attributes(
+        client, id_entity=100, catalog_path=catalog_path
+    )
+
+    assert report.audited_entities == 3  # station + 2 open GPS devices
+    assert report.devices_skipped == 1   # router
+    assert not report.has_violations
+
+
+def test_report_carries_station_id_and_name(catalog_path: Path):
+    station = _station(
+        100,
+        "Test Station Display Name",
+        connections=[],
+        extra_attrs=[
+            _attr("marker", "tst1"),
+            _attr("date_start", "2010-01-01"),
+            _attr("subtype", "GPS stöð"),
+            _attr("altitude", 12.3),
+        ],
+    )
+    client = _client_for({100: station})
+    report = audit_station_missing_attributes(
+        client, id_entity=100, catalog_path=catalog_path
+    )
+
+    assert report.station_id == 100
+    assert report.station_name == "Test Station Display Name"

--- a/tests/test_audit_missing_attributes.py
+++ b/tests/test_audit_missing_attributes.py
@@ -13,7 +13,13 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from tostools.audit_missing_attributes import audit_station_missing_attributes
+from tostools.audit_missing_attributes import (
+    FILL_DATE_PLACEHOLDER,
+    FILL_VALUE_PLACEHOLDER,
+    audit_station_missing_attributes,
+    format_triage_file,
+    load_missing_suppressions,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -591,3 +597,279 @@ def test_report_carries_station_id_and_name(catalog_path: Path):
 
     assert report.station_id == 100
     assert report.station_name == "Test Station Display Name"
+
+
+# ---------------------------------------------------------------------------
+# Suppression file parsing
+# ---------------------------------------------------------------------------
+
+
+def test_load_missing_suppressions_parses_2tuple(tmp_path: Path):
+    """One SUPPRESS line per known-good gap. Key is (id_entity, code)
+    — no date anchor since 'missing' has no date_from."""
+    p = tmp_path / "missing_attributes.txt"
+    p.write_text(
+        "# Header comment\n"
+        "SUPPRESS 100 wigos_number\n"
+        "SUPPRESS 200 firmware_version  # inline comment\n"
+        "\n"
+        "SUPPRESS 300 date_start\n",
+        encoding="utf-8",
+    )
+    supps, errors, path = load_missing_suppressions(p)
+    assert errors == []
+    assert path == p
+    assert (100, "wigos_number") in supps
+    assert (200, "firmware_version") in supps
+    assert (300, "date_start") in supps
+
+
+def test_load_missing_suppressions_file_not_found_is_silent(tmp_path: Path):
+    """The suppression file is opt-in — file-not-found returns empty,
+    not an exception."""
+    supps, errors, path = load_missing_suppressions(tmp_path / "nope.txt")
+    assert supps == {}
+    assert errors == []
+    assert path == tmp_path / "nope.txt"
+
+
+def test_load_missing_suppressions_collects_malformed_lines(tmp_path: Path):
+    """Errors are collected, not raised — operator can fix every typo in
+    one cycle."""
+    p = tmp_path / "missing_attributes.txt"
+    p.write_text(
+        "SUPPRESS 100 wigos_number\n"
+        "OOPS 200 wrong_verb\n"
+        "SUPPRESS notanint code\n"
+        "SUPPRESS 300\n"  # too few args
+        "SUPPRESS 400 ok_code\n",
+        encoding="utf-8",
+    )
+    supps, errors, _ = load_missing_suppressions(p)
+    assert (100, "wigos_number") in supps
+    assert (400, "ok_code") in supps
+    assert len(supps) == 2
+    assert len(errors) == 3
+    messages = " ".join(e.message for e in errors)
+    assert "expected line to start with 'SUPPRESS'" in messages
+    assert "id_entity must be int" in messages
+    assert "requires 2 arguments" in messages
+
+
+def test_walker_filters_suppressed_violations(catalog_path: Path, tmp_path: Path):
+    """Suppressed entries are removed from ``violations`` but preserved on
+    ``suppressed`` so verbose output can show what was silenced."""
+    station = _station(
+        100,
+        "Test Station",
+        connections=[],
+        extra_attrs=[
+            _attr("marker", "tst1"),
+            _attr("subtype", "GPS stöð"),
+            _attr("altitude", 12.3),
+            # date_start missing → will be flagged
+        ],
+    )
+    supp_file = tmp_path / "missing_attributes.txt"
+    supp_file.write_text("SUPPRESS 100 date_start\n", encoding="utf-8")
+
+    client = _client_for({100: station})
+    report = audit_station_missing_attributes(
+        client,
+        id_entity=100,
+        catalog_path=catalog_path,
+        suppressions_path=supp_file,
+    )
+
+    assert not report.has_violations
+    assert report.suppressed_count == 1
+    assert report.suppressed[0].violation.code == "date_start"
+    assert report.suppressed[0].line_no == 1
+
+
+def test_walker_bypasses_suppressions_when_disabled(
+    catalog_path: Path, tmp_path: Path
+):
+    """``use_suppressions=False`` reports every hit regardless of the
+    suppression file content."""
+    station = _station(
+        100,
+        "Test Station",
+        connections=[],
+        extra_attrs=[
+            _attr("marker", "tst1"),
+            _attr("subtype", "GPS stöð"),
+            _attr("altitude", 12.3),
+        ],
+    )
+    supp_file = tmp_path / "missing_attributes.txt"
+    supp_file.write_text("SUPPRESS 100 date_start\n", encoding="utf-8")
+
+    client = _client_for({100: station})
+    report = audit_station_missing_attributes(
+        client,
+        id_entity=100,
+        catalog_path=catalog_path,
+        suppressions_path=supp_file,
+        use_suppressions=False,
+    )
+
+    assert report.has_violations
+    assert any(v.code == "date_start" for v in report.violations)
+    assert report.suppressions_disabled is True
+
+
+# ---------------------------------------------------------------------------
+# Triage file emission
+# ---------------------------------------------------------------------------
+
+
+def _station_with_two_gaps(catalog_path: Path):
+    """Build a small fixture exercising both station + device gaps and
+    both default-value + no-default cases."""
+    station = _station(
+        100,
+        "Test Station",
+        connections=[_conn(200, time_from="2015-06-01")],
+        extra_attrs=[
+            _attr("marker", "tst1"),
+            _attr("altitude", 12.3),
+            # subtype missing → has default
+            # date_start missing → no default
+        ],
+    )
+    device = _device(
+        200,
+        "gnss_receiver",
+        [_attr("model", "POLARX5")],
+        # serial_number missing → no default
+    )
+    client = _client_for({100: station, 200: device})
+    report = audit_station_missing_attributes(
+        client, id_entity=100, catalog_path=catalog_path
+    )
+    return report
+
+
+def test_triage_emits_header_and_workflow_block(catalog_path: Path):
+    report = _station_with_two_gaps(catalog_path)
+    out = format_triage_file(
+        report,
+        audit_command="tos audit missing-attributes tst1",
+        generated_at="2026-05-20T00:00:00+00:00",
+    )
+    assert "tos audit missing-attributes — triage action file" in out
+    assert "Generated:  2026-05-20T00:00:00+00:00" in out
+    assert "tos audit missing-attributes tst1" in out
+    assert f"Violations: {len(report.violations)}" in out
+    assert "tos audit apply <file>" in out
+
+
+def test_triage_default_value_pre_filled_in_action_line(catalog_path: Path):
+    """A code with a catalog default_value renders its value into the
+    ACTION line — no <FILL_VALUE> placeholder needed."""
+    report = _station_with_two_gaps(catalog_path)
+    out = format_triage_file(
+        report, generated_at="2026-05-20T00:00:00+00:00"
+    )
+    # subtype → default "GPS stöð" → shlex-quoted to "'GPS stöð'"
+    assert "#ACTION 100 add-attribute subtype 'GPS stöð'" in out
+
+
+def test_triage_fill_value_placeholder_when_no_default(catalog_path: Path):
+    """date_start has no catalog default → triage emits the placeholder."""
+    report = _station_with_two_gaps(catalog_path)
+    out = format_triage_file(
+        report, generated_at="2026-05-20T00:00:00+00:00"
+    )
+    # date_start has no default, and station violations have no date hint
+    # → both placeholders appear.
+    assert (
+        f"#ACTION 100 add-attribute date_start {FILL_VALUE_PLACEHOLDER} "
+        f"{FILL_DATE_PLACEHOLDER}" in out
+    )
+
+
+def test_triage_device_date_hint_used_when_present(catalog_path: Path):
+    """For device violations, the earliest open-join time_from is used
+    as the date hint — no placeholder."""
+    report = _station_with_two_gaps(catalog_path)
+    out = format_triage_file(
+        report, generated_at="2026-05-20T00:00:00+00:00"
+    )
+    # serial_number missing → no default value, but join date 2015-06-01
+    # used as date hint.
+    assert (
+        f"#ACTION 200 add-attribute serial_number {FILL_VALUE_PLACEHOLDER} "
+        "2015-06-01" in out
+    )
+
+
+def test_triage_action_lines_commented_by_default(catalog_path: Path):
+    """All ACTION lines must start with '#' so a freshly-emitted triage
+    file is a no-op when fed through `tos audit apply` — the operator
+    must explicitly uncomment what they want to fire."""
+    report = _station_with_two_gaps(catalog_path)
+    out = format_triage_file(
+        report, generated_at="2026-05-20T00:00:00+00:00"
+    )
+    action_lines = [
+        line for line in out.splitlines() if "add-attribute" in line and line.strip().startswith(("ACTION", "#ACTION"))
+    ]
+    assert action_lines, "expected at least one ACTION line"
+    for line in action_lines:
+        assert line.startswith("#ACTION")
+
+
+def test_triage_suppress_hint_per_violation(catalog_path: Path):
+    """Every violation block carries a SUPPRESS hint the operator can
+    paste into data/audit_suppressions/missing_attributes.txt."""
+    report = _station_with_two_gaps(catalog_path)
+    out = format_triage_file(
+        report, generated_at="2026-05-20T00:00:00+00:00"
+    )
+    assert "# (or suppress: SUPPRESS 100 subtype)" in out
+    assert "# (or suppress: SUPPRESS 100 date_start)" in out
+    assert "# (or suppress: SUPPRESS 200 serial_number)" in out
+
+
+def test_triage_empty_report_yields_header_only(catalog_path: Path):
+    """Clean station → header + 'no violations' note, no ACTION lines."""
+    station = _station(
+        100,
+        "Clean Station",
+        connections=[],
+        extra_attrs=[
+            _attr("marker", "tst1"),
+            _attr("date_start", "2010-01-01"),
+            _attr("subtype", "GPS stöð"),
+            _attr("altitude", 12.3),
+        ],
+    )
+    client = _client_for({100: station})
+    report = audit_station_missing_attributes(
+        client, id_entity=100, catalog_path=catalog_path
+    )
+    out = format_triage_file(
+        report, generated_at="2026-05-20T00:00:00+00:00"
+    )
+    assert "(no violations — nothing to triage)" in out
+    # No actual ACTION lines (uncommented or commented-out) — the header's
+    # format explanation contains the literal "add-attribute" as documentation,
+    # but no `#ACTION ...` violation lines should be present.
+    action_lines = [
+        line for line in out.splitlines() if line.startswith("#ACTION")
+    ]
+    assert action_lines == []
+
+
+def test_triage_groups_station_first_then_devices(catalog_path: Path):
+    """Station entity block always precedes device blocks so the operator
+    reads the file linearly."""
+    report = _station_with_two_gaps(catalog_path)
+    out = format_triage_file(
+        report, generated_at="2026-05-20T00:00:00+00:00"
+    )
+    station_idx = out.index("# --- geophysical id_entity=100")
+    device_idx = out.index("# --- gnss_receiver id_entity=200")
+    assert station_idx < device_idx


### PR DESCRIPTION
## Summary

Closes Layer 6 of the TOS audit work — detection of *missing* required
attributes (complements Layers 1-5's detection of *misdated* attributes).
The new verb walks a station + its open child devices + monument and
flags every catalog code where `entity.code_entity_subtype ∈ gps_required_for`
but the entity has no open attribute period for that code.

Full design in `.interrogate-tos-audit-missing-attributes.md`.

## What's new

| Commit | Scope |
|---|---|
| `c1b076d` | Catalog rename `stations.station_subtype:` → `stations.subtype:` + `load_catalog_scoped()` returning `{scope: {code: entry}}`. Layers 2-5 unaffected (their walker only touches `devices` scope). |
| `85dd3a2` | Walker `audit_station_missing_attributes()` — iterates rules per entity's natural scope so cross-scope code collisions (`subtype`, `date_start`, `lat`, …) stay distinct. Station entity → `catalog['stations']`; each open GPS-quartet device → `catalog['devices']`. |
| `3951df1` | CLI verb `tos audit missing-attributes <STA>` with `--triage`, `--suppressions`, `--no-suppressions`, `--json`, `--verbose`. Suppression file at `data/audit_suppressions/missing_attributes.txt` uses a 2-tuple `(id_entity, code)` key. Triage emitter pre-fills `<value>` from the catalog's `default_value` (e.g. `'GPS stöð'` for station `subtype`); otherwise emits `<FILL_VALUE>`. |
| `6c3b6c0` | Apply verb `add-attribute <code> <value> <date_from>`. Parser now uses `shlex.split` so quoted values like `'GPS stöð'` survive the round trip. Dispatcher pre-flights: refuses `<FILL_*>` placeholders, validates date format, fetches existing periods to refuse silent overwrites, idempotent skip on same-value re-runs. |

## Worked example (fixture-driven, no VPN)

Walker against a fake "HAUC-like" station (id 4257) with missing `subtype`,
`date_start`, and an antenna missing `serial_number`:

```
Station: 'Haumýrar' (id=4257)
Audited entities: 4   (1 station + 3 devices)
Violations: 43        (catalog gps_required_for is aggressive)
  - subtype     suggested 'GPS stöð'      (catalog default)
  - serial_number suggested <FILL_VALUE>  (no default → operator fills in)
  - …
```

Triage file emits commented `#ACTION` lines per violation:
```
#ACTION 4257 add-attribute subtype 'GPS stöð' <FILL_DATE>
#ACTION 7200 add-attribute serial_number <FILL_VALUE> 2018-03-15
```

Operator uncomments + fills placeholders; `tos audit apply hauc.txt` runs
the dispatcher; `--apply` commits.

## Test coverage

- 5 scoped-loader tests (cross-scope `subtype` collision regression)
- 15 walker tests (clean station, REYK-style missing `date_start`, default
  pre-fill, FILL_VALUE placeholder, device-missing-serial, closed-join skip,
  non-GPS-device skip, monument-specific inscription via `gps_required_for`
  filter, station-subtype-not-shadowed-by-devices-subtype regression,
  gps_relevance gate above gps_required_for, multi-join earliest-date hint,
  bookkeeping)
- 13 suppression + triage emitter tests
- 18 apply-verb tests (shlex parser, quoted values, conflict detection
  in both directions, placeholder rejection, idempotent skip, multiple
  open periods, network-failure surfacing, closed-period filtering)

End-to-end smoke verified the walker → triage → parser round-trip on
the real catalog: 43 violations rendered, all 43 re-parse cleanly
including the shlex-quoted `'GPS stöð'`.

**Suite: 535 passed, 2 skipped (baseline 484/2 + 51 new).**

## DoD checklist

- [x] Catalog convention sweep complete (PR #23 → merged)
- [x] `tos audit missing-attributes <STA>` walks station + devices + monument; exit 1 on violation, 0 clean
- [x] `data/audit_suppressions/missing_attributes.txt` (2-tuple key) is read at audit time; suppressed entries filtered from `violations` but preserved on `suppressed` for `--verbose`
- [x] End-to-end: `--triage` emits draft → operator fills + uncomments → `tos audit apply --apply` → TOS reflects the new attribute values (live verification awaits VPN, but the dispatch path is fully unit-tested)

## Test plan

- [ ] Run on real HAUC: `tos audit missing-attributes HAUC --triage hauc.txt`
- [ ] Inspect output, edit triage file (uncomment, fill placeholders)
- [ ] Dry-run: `tos audit apply hauc.txt`
- [ ] Live: `tos audit apply hauc.txt --apply` (credentials from `[tos]` in database.cfg or env)
- [ ] Re-audit: `tos audit missing-attributes HAUC` — violations from applied lines should be gone

## Out of scope (deliberately deferred)

- Fleet-wide sweep (`--all`)
- `tosGPS timespan --audit` integration (project todo)
- Sibling audit `tos audit misplaced-attributes`
- Catalog cleanup: some `default_value` entries look like placeholders (`ip_address: 192.168.100.60`); the catalog audit/review is its own pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)