### PR TITLE
fix(writer): route add_attribute_value through admin endpoint

### DIFF
--- a/src/tostools/api/tos_writer.py
+++ b/src/tostools/api/tos_writer.py
@@ -246,6 +246,13 @@ class TOSWriter:
         self._token: Optional[str] = None
         self._token_exp: float = 0.0
 
+        # Lazily-populated ``code → id_attribute`` map from
+        # ``GET /admin_attribute_rows``. Used by ``add_attribute_value``,
+        # which posts to the admin endpoint (the only attribute-value POST
+        # path that accepts our tokens — the public ``/attribute_values``
+        # endpoint returns confusing 401s, see :meth:`add_attribute_value`).
+        self._id_attribute_cache: Optional[Dict[str, int]] = None
+
     # ------------------------------------------------------------------
     # Authentication
     # ------------------------------------------------------------------
@@ -622,6 +629,33 @@ class TOSWriter:
             dt = f"{dt}T00:00:00"
         return dt
 
+    def _resolve_id_attribute(self, code: str) -> int:
+        """Look up the integer ``id_attribute`` FK for an attribute ``code``.
+
+        Loads the full attribute table from ``GET /admin_attribute_rows``
+        on first call and caches it on the instance — there's no
+        ``/attributes/<code>`` lookup endpoint per the OpenAPI spec
+        (confirmed 2026-05-20), so client-side filtering is the only path.
+
+        Raises :class:`ValueError` if the code isn't present in TOS's
+        attribute catalog — surfaces typos at the boundary rather than
+        sending an unresolvable POST.
+        """
+        if self._id_attribute_cache is None:
+            rows = self._request("GET", "/admin_attribute_rows")
+            self._id_attribute_cache = {
+                r["code"]: int(r["id"])
+                for r in (rows or [])
+                if r.get("code") and r.get("id") is not None
+            }
+        if code not in self._id_attribute_cache:
+            raise ValueError(
+                f"unknown attribute code {code!r} — not in "
+                "/admin_attribute_rows. Check spelling or refresh the "
+                "writer instance to bust the cache."
+            )
+        return self._id_attribute_cache[code]
+
     def add_attribute_value(
         self,
         id_entity: int,
@@ -632,16 +666,31 @@ class TOSWriter:
     ) -> Any:
         """Add an attribute value to an existing entity.
 
-        Does NOT check for existing values — use :meth:`upsert_attribute_value`
-        for idempotent writes.
+        Routes through ``POST /admin_attribute_value_rows`` rather than
+        the public ``/attribute_values`` endpoint. The public endpoint
+        returns 401 ``"User provided an invalid token"`` for many
+        (entity, code) combinations even with valid ``jwt_auth_simple``
+        tokens — confirmed empirically 2026-05-20 on the live API. The
+        admin endpoint accepts the same JWT bearer (we already require
+        ``API.TOS.Admin`` in the scope claim for other writes) and works
+        cleanly. Mirrors the precedent set by :meth:`update_entity_subtype`,
+        which uses ``/admin_entity_row/`` for the same reason.
+
+        Tradeoff: the admin endpoint takes an integer ``id_attribute`` FK
+        rather than the string ``code``, so we cache the catalog from
+        ``GET /admin_attribute_rows`` on first call (see
+        :meth:`_resolve_id_attribute`).
+
+        Does NOT check for existing values — use
+        :meth:`upsert_attribute_value` for idempotent writes.
         """
         return self._request(
             "POST",
-            "/attribute_values",
+            "/admin_attribute_value_rows",
             data={
                 "id_entity": id_entity,
-                "code": code,
-                "value": value,
+                "id_attribute": self._resolve_id_attribute(code),
+                "value_varchar": value,
                 "date_from": self._tos_date(date_from),
                 "date_to": self._tos_date(date_to),
             },

--- a/tests/test_tos_writer.py
+++ b/tests/test_tos_writer.py
@@ -189,6 +189,9 @@ def _logged_in_writer(**kwargs: object) -> TOSWriter:
 
 def test_dry_run_returns_dry_run_result_for_post():
     w = _logged_in_writer(dry_run=True)
+    # Pre-populate the id_attribute cache so the writer doesn't try to
+    # GET /admin_attribute_rows during the dry-run smoke test.
+    w._id_attribute_cache = {"marker": 1, "name": 2}
     result = w.add_attribute_value(
         id_entity=1,
         code="marker",
@@ -197,9 +200,87 @@ def test_dry_run_returns_dry_run_result_for_post():
     )
     assert isinstance(result, DryRunResult)
     assert result.method == "POST"
-    assert result.endpoint == "/attribute_values"
+    # Admin endpoint — the public /attribute_values returns 401 on
+    # many real (entity, code) combinations. See add_attribute_value
+    # docstring.
+    assert result.endpoint == "/admin_attribute_value_rows"
     assert result.payload is not None
-    assert result.payload["value"] == "eldc"
+    assert result.payload["value_varchar"] == "eldc"
+    assert result.payload["id_attribute"] == 1
+    assert result.payload["id_entity"] == 1
+
+
+def test_resolve_id_attribute_caches_admin_attribute_rows():
+    """First call fetches /admin_attribute_rows; subsequent calls hit
+    the cache. Keeps the per-action POST cost at one GET amortised
+    across an apply run."""
+    w = _logged_in_writer(dry_run=True)
+    rows = [
+        {"id": 1, "code": "marker"},
+        {"id": 2, "code": "name"},
+        {"id": 30, "code": "visit_class"},
+    ]
+    with patch.object(w, "_request", return_value=rows) as mock_req:
+        assert w._resolve_id_attribute("marker") == 1
+        assert w._resolve_id_attribute("visit_class") == 30
+        assert w._resolve_id_attribute("name") == 2
+    # Only one GET should have been issued — the cache absorbs the rest.
+    assert mock_req.call_count == 1
+    assert mock_req.call_args.args == ("GET", "/admin_attribute_rows")
+
+
+def test_resolve_id_attribute_unknown_code_raises_value_error():
+    """Surfacing typos at the boundary beats sending an unresolvable POST."""
+    w = _logged_in_writer(dry_run=True)
+    w._id_attribute_cache = {"marker": 1}
+    with pytest.raises(ValueError, match="unknown attribute code"):
+        w._resolve_id_attribute("not_a_real_code")
+
+
+def test_resolve_id_attribute_skips_rows_missing_id_or_code():
+    """Defensive: malformed rows from /admin_attribute_rows (missing
+    ``id`` or ``code``) are silently filtered, not crashed on."""
+    w = _logged_in_writer(dry_run=True)
+    rows = [
+        {"id": 1, "code": "marker"},
+        {"id": None, "code": "ghost"},
+        {"code": "no_id"},
+        {"id": 2},  # no code
+    ]
+    with patch.object(w, "_request", return_value=rows):
+        assert w._resolve_id_attribute("marker") == 1
+    assert w._id_attribute_cache == {"marker": 1}
+
+
+def test_add_attribute_value_resolves_id_then_posts_admin_endpoint():
+    """End-to-end: add_attribute_value performs the lookup, then POSTs
+    to the admin endpoint with id_attribute (int) and value_varchar."""
+    w = _logged_in_writer(dry_run=False)
+    rows = [{"id": 30, "code": "visit_class"}]
+
+    with patch.object(w, "_request") as mock_req:
+        # First call (GET /admin_attribute_rows) returns the rows;
+        # second call (POST) returns the create response.
+        mock_req.side_effect = [rows, {"id_attribute_value": 99001}]
+        result = w.add_attribute_value(
+            id_entity=4257,
+            code="visit_class",
+            value="B",
+            date_from="2018-03-15",
+        )
+
+    assert result == {"id_attribute_value": 99001}
+    assert mock_req.call_count == 2
+    # Second call is the POST — assert URL + body.
+    post_call = mock_req.call_args_list[1]
+    assert post_call.args[0] == "POST"
+    assert post_call.args[1] == "/admin_attribute_value_rows"
+    body = post_call.kwargs["data"]
+    assert body["id_entity"] == 4257
+    assert body["id_attribute"] == 30
+    assert body["value_varchar"] == "B"
+    assert body["date_from"] == "2018-03-15T00:00:00"  # _tos_date promotes
+    assert body["date_to"] is None
 
 
 def test_dry_run_does_not_send_http():
@@ -343,6 +424,9 @@ def test_upsert_noop_when_value_already_matches():
 
 def test_upsert_posts_when_no_open_value():
     w = _logged_in_writer(dry_run=False)
+    # Pre-populate the id_attribute cache so the POST path doesn't
+    # need to fetch /admin_attribute_rows during the test.
+    w._id_attribute_cache = {"marker": 1}
     closed = [{"id": 10, "code": "marker", "value": "old", "date_to": "2021-12-31"}]
 
     with patch.object(w, "get_attribute_values", return_value=closed):
@@ -352,7 +436,8 @@ def test_upsert_posts_when_no_open_value():
 
     call = mock_req.call_args
     assert call.args[0] == "POST"
-    assert call.args[1] == "/attribute_values"
+    # add_attribute_value routes through the admin endpoint.
+    assert call.args[1] == "/admin_attribute_value_rows"
 
 
 # ---------------------------------------------------------------------------
@@ -427,6 +512,9 @@ def test_upsert_with_date_hint_targets_open_period():
 def test_upsert_with_date_hint_no_match_posts():
     """date_hint that falls in no period falls back to POST."""
     w = _logged_in_writer(dry_run=False)
+    # Pre-populate the id_attribute cache; the POST path goes through
+    # add_attribute_value → admin endpoint with id_attribute (int FK).
+    w._id_attribute_cache = {"firmware_version": 7}
     existing = [
         {
             "id_attribute_value": 10,


### PR DESCRIPTION
## Summary

The public `POST /attribute_values` endpoint returns 401 `"User provided an invalid token"` for real `(entity, code)` combinations even with valid `jwt_auth_simple` tokens — confirmed empirically against the live API on 2026-05-20.

Same Bearer token works for:
- `GET /entity/<id>/history` ✓
- `POST /admin_attribute_value_rows` (returns 400 ForeignKeyViolation on dummy id_entity, meaning auth passes ✓)

So the deployed `/attribute_values` endpoint is broken in some unspecified way; the 401 is the API's misleading generic-rejection message rather than a literal token-invalid error.

**Fix:** route `add_attribute_value` through `POST /admin_attribute_value_rows`. Mirrors the existing precedent set by `update_entity_subtype`, which uses `/admin_entity_row/` for the same reason (public endpoint unreliable; admin endpoint accepts the JWT bearer we already obtain).

## Implementation notes

The admin endpoint takes an integer `id_attribute` FK instead of the string `code`. New helper `_resolve_id_attribute()` fetches `GET /admin_attribute_rows` once and caches the `code → id_attribute` map on the writer instance for the session. Per-action POST cost: 1 GET (amortised across an apply run) + 1 POST.

Body field rename: `value` → `value_varchar` (admin endpoint convention).

## Inherits the fix automatically

- `add_attribute_value` itself
- `upsert_attribute_value` — when no open period exists and falls through to POST
- `transition_attribute_value` — calls `add_attribute_value` to open the new period after closing the old one

## Why this is a separate PR from #24

PR #24 (Layer 6 `tos audit missing-attributes`) is feature work — walker, triage emitter, parser, dispatcher, `add-attribute` apply verb. All of those are correct and unit-tested. The 401 issue is downstream in the writer's primitive HTTP call.

Keeping them separate:
- Smaller, focused review surfaces
- This PR can land on its own merit (fixes a latent bug in `upsert_attribute_value` and `transition_attribute_value` POST paths even without Layer 6)
- #24's reviewers don't need to context-switch into writer/endpoint debugging

**Land this before/with #24** so the operator-side live test of Layer 6's audit → triage → apply loop works end-to-end on first try.

## Test plan

- [x] `python -m pytest tests/test_tos_writer.py` — 45 passed (was 41, +4 new)
- [x] `python -m pytest tests/` — 488 passed (was 484), 2 skipped
- [x] Empirical confirmation against live TOS: `POST /admin_attribute_value_rows` returns 400 with FK violation on dummy id_entity, confirming auth + payload shape are correct
- [ ] Live `tos audit apply hauc.txt --apply` against a real station after this lands (operator-side; #24 dependency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)