### PR TITLE
feat(audit): Layer 6 date shortcuts — cascade + now/start tokens

### DIFF
--- a/src/tostools/audit_missing_attributes.py
+++ b/src/tostools/audit_missing_attributes.py
@@ -45,6 +45,7 @@ from .audit_attribute_dates import (
     _open_attribute_value,
     _station_display_name,
     _station_joins_by_device,
+    classification_for,
     load_catalog_scoped,
 )
 
@@ -226,6 +227,61 @@ def _device_display_label(history: Dict[str, Any]) -> Optional[str]:
     return None
 
 
+def _earliest_open_attribute_date(history: Dict[str, Any]) -> Optional[str]:
+    """Min ``date_from`` across all OPEN attribute periods on an entity.
+
+    Used as the tier-2 cascade signal for ``inherent`` attribute date
+    hints when the entity has no explicit ``date_start`` of its own.
+    The operator's observation: inherent attrs like ``marker``, ``name``,
+    ``lat``, ``lon``, ``subtype`` are set together at TOS creation time,
+    so their min ``date_from`` is a reliable proxy for "when did this
+    entity start existing in TOS".
+
+    Closed periods (``date_to`` set) are excluded — a historical value
+    from 1995 that was later closed shouldn't anchor the date for a
+    new attribute period in 2018.
+    """
+    earliest: Optional[str] = None
+    for a in history.get("attributes") or []:
+        if a.get("date_to") is not None:
+            continue
+        df = a.get("date_from")
+        if not df:
+            continue
+        df_d = _date_only(str(df))
+        if earliest is None or df_d < earliest:
+            earliest = df_d
+    return earliest
+
+
+def _resolve_inherent_date_hint(
+    history: Dict[str, Any],
+    fallback: Optional[str],
+) -> Optional[str]:
+    """Cascade-resolve a date hint for an ``inherent`` attribute violation.
+
+    Order:
+    1. The entity's open ``date_start`` attribute value (if any).
+    2. The earliest open attribute ``date_from`` on the entity (proxy
+       for "when did this entity show up in TOS").
+    3. The caller-supplied ``fallback`` — for devices this is the
+       earliest open-join ``time_from``, which the dispatcher can't
+       see but the walker can.
+    4. ``None`` — triage will emit ``<FILL_DATE>``.
+
+    Returns date-only ``YYYY-MM-DD`` or None.
+    """
+    ds = _open_attribute_value(history, "date_start")
+    if ds:
+        ds_d = _date_only(str(ds))
+        if len(ds_d) == 10:
+            return ds_d
+    earliest = _earliest_open_attribute_date(history)
+    if earliest:
+        return earliest
+    return fallback
+
+
 def _required_codes_in_scope(
     scope_rules: Dict[str, Dict[str, Any]],
     entity_subtype: str,
@@ -257,7 +313,7 @@ def _audit_entity(
     entity_subtype: str,
     entity_label: Optional[str],
     scope_name: str,
-    suggested_date_from: Optional[str] = None,
+    device_join_date_hint: Optional[str] = None,
 ) -> None:
     """Walk one entity (station, device, or monument).
 
@@ -265,6 +321,22 @@ def _audit_entity(
     The caller passes the correct catalog scope (``catalog['stations']`` for
     a station entity, ``catalog['devices']`` for a device/monument) so
     cross-scope code collisions stay distinct.
+
+    ``device_join_date_hint`` — the earliest open-join ``time_from`` for
+    this entity from the station's perspective; passed as the tier-3
+    fallback of the inherent date cascade (devices only — stations have
+    no parent join, so callers pass ``None``).
+
+    Per-violation date hint resolution:
+
+    * ``classification == 'inherent'`` (per the polymorphic catalog
+      shape — handled by :func:`classification_for`): cascade through
+      :func:`_resolve_inherent_date_hint` — entity's open ``date_start``,
+      then the entity's earliest open attribute ``date_from``, then
+      ``device_join_date_hint``, then ``None``.
+    * ``classification == 'mutable'`` / ``'TODO'`` / unclassified:
+      ``suggested_date_from`` is ``None``. The operator must consciously
+      pick a date — no silent default for transitions.
     """
     report.audited_entities += 1
     for code, entry in _required_codes_in_scope(scope_rules, entity_subtype):
@@ -272,6 +344,16 @@ def _audit_entity(
             continue
         default = entry.get("default_value")
         suggested_value = str(default) if default is not None else None
+        # Date hint depends on classification — only inherent codes get
+        # an auto-filled date; mutable codes leave <FILL_DATE> for the
+        # operator to fill in consciously.
+        classification = classification_for(entry, entity_subtype)
+        if classification == "inherent":
+            suggested_date = _resolve_inherent_date_hint(
+                history, fallback=device_join_date_hint
+            )
+        else:
+            suggested_date = None
         report.violations.append(
             MissingAttributeViolation(
                 id_entity=entity_id,
@@ -280,7 +362,7 @@ def _audit_entity(
                 code=code,
                 scope=scope_name,
                 suggested_value=suggested_value,
-                suggested_date_from=suggested_date_from,
+                suggested_date_from=suggested_date,
             )
         )
 
@@ -371,6 +453,7 @@ def audit_station_missing_attributes(
     )
 
     # 1. Station entity itself — iterate stations scope.
+    #    Stations have no parent join, so no device_join_date_hint.
     _audit_entity(
         report=report,
         scope_rules=stations_rules,
@@ -379,7 +462,7 @@ def audit_station_missing_attributes(
         entity_subtype=station_subtype,
         entity_label=station_name,
         scope_name="stations",
-        suggested_date_from=None,
+        device_join_date_hint=None,
     )
 
     # 2. Each open child device — iterate devices scope. Closed joins
@@ -416,7 +499,7 @@ def audit_station_missing_attributes(
             entity_subtype=dev_subtype,
             entity_label=device_label,
             scope_name="devices",
-            suggested_date_from=suggested_date,
+            device_join_date_hint=suggested_date,
         )
 
     # Apply suppressions — partition violations into kept vs suppressed.
@@ -528,6 +611,11 @@ def format_triage_file(
     lines.append("#   2. Uncomment the ACTION line(s) you want to fire.")
     lines.append("#   3. tos audit apply <file>          # dry-run preview")
     lines.append("#   4. tos audit apply <file> --apply  # commit writes")
+    lines.append("#")
+    lines.append("# <date_from> accepts two shortcuts in addition to YYYY-MM-DD:")
+    lines.append("#   now    — today's UTC date (use for mutable transitions)")
+    lines.append("#   start  — entity's earliest open attribute date_from")
+    lines.append("#            (use for inherent backfills you forgot to record)")
     lines.append("#")
     lines.append("# Alternative for known-good gaps: copy the SUPPRESS hint into")
     lines.append("# data/audit_suppressions/missing_attributes.txt instead.")

--- a/src/tostools/tos.py
+++ b/src/tostools/tos.py
@@ -35,7 +35,7 @@ import sys
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import requests
 from tabulate import tabulate
@@ -2409,13 +2409,21 @@ def _audit_main(argv):
             "date_from — consumes triage files from\n"
             "                            `tos audit attribute-dates --triage`\n"
             "  add-attribute <code> <value> <date_from>\n"
-            "                            POST /attribute_values — add a new open "
-            "period to fill\n"
-            "                            a required-attribute gap. Consumes triage "
-            "files from\n"
-            "                            `tos audit missing-attributes --triage`. "
-            "Quote values\n"
-            "                            with spaces, e.g. `'GPS stöð'`.\n"
+            "                            POST a new open attribute period to fill "
+            "a required-\n"
+            "                            attribute gap. Consumes triage files "
+            "from\n"
+            "                            `tos audit missing-attributes --triage`.\n"
+            "                            <value>: quote with single/double quotes "
+            "if it has\n"
+            "                                     spaces, e.g. `'GPS stöð'`.\n"
+            "                            <date_from>: YYYY-MM-DD, or one of two "
+            "shortcuts:\n"
+            "                              `now`   → today's UTC date (for mutable "
+            "transitions)\n"
+            "                              `start` → entity's earliest open "
+            "attribute date_from\n"
+            "                                        (for inherent backfills)\n"
             "  defer                      no-op placeholder (review next run)\n\n"
             "Validation: each ACTION line is parsed before any HTTP call. "
             "If any line is malformed, nothing is sent. Otherwise actions "
@@ -3569,6 +3577,26 @@ def _dispatch_patch_attribute_date(writer, action: ParsedAction) -> ActionResult
     )
 
 
+def _earliest_open_attr_date_from(attrs: List[Dict[str, Any]]) -> Optional[str]:
+    """Min ``date_from`` (YYYY-MM-DD) across all OPEN attribute periods.
+
+    Used by ``add-attribute``'s ``start`` token to resolve the entity's
+    creation timestamp without a catalog lookup. Matches the walker's
+    cascade tier-2 logic — inherent attrs (marker, name, lat, lon) share
+    a creation date_from, so the min is a reliable proxy."""
+    earliest: Optional[str] = None
+    for a in attrs:
+        if a.get("date_to") is not None:
+            continue
+        df = a.get("date_from")
+        if not df:
+            continue
+        df_d = str(df)[:10]
+        if earliest is None or df_d < earliest:
+            earliest = df_d
+    return earliest
+
+
 def _dispatch_add_attribute(writer, action: ParsedAction) -> ActionResult:
     """Add a new attribute period to an existing entity.
 
@@ -3577,13 +3605,28 @@ def _dispatch_add_attribute(writer, action: ParsedAction) -> ActionResult:
     verb — used to fill the gap when an entity is required to carry a
     code but has no open period for it.
 
+    Date-token shortcuts
+    --------------------
+    The ``<date_from>`` field accepts two special tokens that expand at
+    dispatch time:
+
+    * ``now`` — today's UTC date (``YYYY-MM-DD``). For mutable transitions
+      the operator wants to start "right now" — saves typing the date.
+    * ``start`` — the entity's earliest open attribute ``date_from``,
+      i.e. when the entity first appeared in TOS. Useful for inherent
+      gaps that should backfill from the entity's beginning.
+
+    Both are expanded BEFORE the date-format check, so they're handled
+    transparently downstream.
+
     Pre-flight checks before POSTing
     --------------------------------
     * **Placeholder rejection** — if ``value`` or ``date_from`` still
       contains a ``<FILL_*>`` placeholder, the operator forgot to
       replace it. Refuse rather than POST a literal placeholder string
       to TOS.
-    * **Date format** — ``date_from`` must be ``YYYY-MM-DD``.
+    * **Date format** — ``date_from`` must be ``YYYY-MM-DD`` (after
+      token expansion).
     * **Conflict detection** — fetches existing periods via
       :meth:`writer.get_attribute_values`; if an open period already
       exists with the same value, the action is a no-op (idempotent).
@@ -3624,8 +3667,46 @@ def _dispatch_add_attribute(writer, action: ParsedAction) -> ActionResult:
             ),
         )
 
+    # Fetch the entity's attribute periods once. Used for both the
+    # `start` token expansion AND the conflict check below — same
+    # HTTP cost as the previous code-filtered fetch (the writer's
+    # get_attribute_values calls get_entity_history under the hood
+    # regardless of the code filter).
+    try:
+        all_attrs = writer.get_attribute_values(action.id_entity)
+    except Exception as exc:  # noqa: BLE001
+        return ActionResult(
+            action=action,
+            status="failed",
+            detail=f"get_attribute_values raised: {exc}",
+        )
+
+    # Date-token expansion: `now` → today; `start` → entity's earliest
+    # open attribute date_from. Mutable transitions usually want `now`;
+    # inherent backfills usually want `start`. Reduces operator typing
+    # and removes the "look up the entity's start date" detour.
+    if date_from_raw == "now":
+        from datetime import datetime, timezone
+
+        date_from = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    elif date_from_raw == "start":
+        resolved = _earliest_open_attr_date_from(all_attrs)
+        if resolved is None:
+            return ActionResult(
+                action=action,
+                status="failed",
+                detail=(
+                    f"add-attribute: 'start' token requires the entity to "
+                    f"have at least one open attribute period; "
+                    f"id_entity={action.id_entity} has none. Use an "
+                    "explicit YYYY-MM-DD date."
+                ),
+            )
+        date_from = resolved
+    else:
+        date_from = date_from_raw[:10]
+
     # Date format check — same YYYY-MM-DD contract as patch-attribute-date.
-    date_from = date_from_raw[:10]
     if len(date_from) != 10 or date_from[4] != "-" or date_from[7] != "-":
         return ActionResult(
             action=action,
@@ -3636,14 +3717,8 @@ def _dispatch_add_attribute(writer, action: ParsedAction) -> ActionResult:
             ),
         )
 
-    try:
-        existing = writer.get_attribute_values(action.id_entity, code)
-    except Exception as exc:  # noqa: BLE001
-        return ActionResult(
-            action=action,
-            status="failed",
-            detail=f"get_attribute_values raised: {exc}",
-        )
+    # Conflict detection — filter the cached list rather than a second GET.
+    existing = [a for a in all_attrs if a.get("code") == code]
 
     open_values = [a for a in existing if a.get("date_to") is None]
     if len(open_values) > 1:

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -1015,7 +1015,9 @@ def test_dispatch_add_attribute_happy_path():
     )
 
     assert result.status == "ok"
-    writer.get_attribute_values.assert_called_once_with(4257, "date_start")
+    # The dispatcher fetches all attrs (unfiltered) so it can serve both
+    # `start`-token expansion and conflict detection from one call.
+    writer.get_attribute_values.assert_called_once_with(4257)
     writer.add_attribute_value.assert_called_once_with(
         4257, "date_start", "2010-06-15", "2010-06-15"
     )
@@ -1217,4 +1219,127 @@ def test_dispatch_add_attribute_skips_closed_periods_for_conflict_check():
     assert result.status == "ok"
     writer.add_attribute_value.assert_called_once_with(
         4390, "subtype", "GPS stöð", "2006-01-01"
+    )
+
+
+# ---------------------------------------------------------------------------
+# _dispatch_action — add-attribute date-token shortcuts (`now`, `start`)
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_add_attribute_now_token_expands_to_today():
+    """`now` resolves to today's UTC date — saves the operator from
+    typing the current date when applying a mutable transition."""
+    from datetime import datetime, timezone
+
+    writer = MagicMock()
+    writer.get_attribute_values.return_value = []
+    writer.add_attribute_value.return_value = {"id_attribute_value": 99100}
+
+    result = _dispatch_action(
+        writer,
+        _make_action(
+            4257, "add-attribute", "firmware_version", "5.6.0", "now"
+        ),
+    )
+
+    expected_today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    assert result.status == "ok"
+    writer.add_attribute_value.assert_called_once_with(
+        4257, "firmware_version", "5.6.0", expected_today
+    )
+
+
+def test_dispatch_add_attribute_start_token_uses_earliest_open_attr():
+    """`start` resolves to the entity's earliest open attribute date_from
+    — the proxy for 'when this entity began existing in TOS', useful
+    for inherent backfills."""
+    writer = MagicMock()
+    # Entity has three open attrs with varying date_from — the min wins.
+    writer.get_attribute_values.return_value = [
+        _attr_value(50001, "name", "Test", "2010-05-01 00:00:00"),
+        _attr_value(50002, "marker", "tst1", "2008-03-15 00:00:00"),
+        _attr_value(50003, "subtype", "GPS stöð", "2008-03-15 00:00:00"),
+    ]
+    writer.add_attribute_value.return_value = {"id_attribute_value": 99101}
+
+    result = _dispatch_action(
+        writer,
+        _make_action(
+            4257, "add-attribute", "date_start", "2008-03-15", "start"
+        ),
+    )
+
+    assert result.status == "ok"
+    writer.add_attribute_value.assert_called_once_with(
+        4257, "date_start", "2008-03-15", "2008-03-15"
+    )
+
+
+def test_dispatch_add_attribute_start_token_skips_closed_periods():
+    """Closed periods don't anchor the `start` token — they reflect
+    *previous* values, not when the entity began. The 1995 closed
+    period must NOT be picked over the 2010 open one."""
+    writer = MagicMock()
+    writer.get_attribute_values.return_value = [
+        _attr_value(
+            50001, "marker", "old", "1995-01-01 00:00:00",
+            date_to="2010-04-30 00:00:00",
+        ),
+        _attr_value(50002, "marker", "tst1", "2010-05-01 00:00:00"),
+        _attr_value(50003, "subtype", "GPS stöð", "2010-05-01 00:00:00"),
+    ]
+    writer.add_attribute_value.return_value = {"id_attribute_value": 99102}
+
+    result = _dispatch_action(
+        writer,
+        _make_action(
+            4257, "add-attribute", "date_start", "2010-05-01", "start"
+        ),
+    )
+
+    assert result.status == "ok"
+    writer.add_attribute_value.assert_called_once_with(
+        4257, "date_start", "2010-05-01", "2010-05-01"
+    )
+
+
+def test_dispatch_add_attribute_start_token_refuses_when_no_open_attrs():
+    """An entity with no open attributes can't anchor the `start`
+    token — refuse with a clear message rather than POST garbage."""
+    writer = MagicMock()
+    writer.get_attribute_values.return_value = []
+
+    result = _dispatch_action(
+        writer,
+        _make_action(
+            4257, "add-attribute", "date_start", "2010-05-01", "start"
+        ),
+    )
+
+    assert result.status == "failed"
+    assert "'start' token requires" in result.detail
+    writer.add_attribute_value.assert_not_called()
+
+
+def test_dispatch_add_attribute_now_works_when_entity_has_no_attrs():
+    """`now` does NOT depend on entity history — it always resolves to
+    today. Empty-attrs entity should still accept `now`."""
+    from datetime import datetime, timezone
+
+    writer = MagicMock()
+    writer.get_attribute_values.return_value = []
+    writer.add_attribute_value.return_value = {"id_attribute_value": 99103}
+
+    result = _dispatch_action(
+        writer,
+        _make_action(
+            4257, "add-attribute", "subtype", "GPS stöð", "now"
+        ),
+    )
+
+    expected_today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    assert result.status == "ok"
+    writer.add_attribute_value.assert_called_once_with(
+        4257, "subtype", "GPS stöð", expected_today
     )

--- a/tests/test_audit_missing_attributes.py
+++ b/tests/test_audit_missing_attributes.py
@@ -272,7 +272,12 @@ def test_violation_without_default_has_no_suggested_value(catalog_path: Path):
 
 
 def test_device_missing_serial_number_flagged(catalog_path: Path):
-    """Open device missing required attribute on devices scope."""
+    """Open device missing required attribute on devices scope.
+
+    Date hint cascade for the inherent ``serial_number`` violation:
+    tier 1 (device.date_start) missing → tier 2 (earliest open
+    attribute date_from on the device) → 2015-06-01 (the ``model``
+    attribute's date_from)."""
     station = _station(
         100,
         "Test Station",
@@ -287,7 +292,7 @@ def test_device_missing_serial_number_flagged(catalog_path: Path):
     device = _device(
         200,
         "gnss_receiver",
-        [_attr("model", "POLARX5")],
+        [_attr("model", "POLARX5", date_from="2015-06-01")],
         # serial_number missing
     )
     client = _client_for({100: station, 200: device})
@@ -301,7 +306,6 @@ def test_device_missing_serial_number_flagged(catalog_path: Path):
     assert v.id_entity == 200
     assert v.subtype == "gnss_receiver"
     assert v.scope == "devices"
-    # Earliest open-join time_from used as date hint for the triage line.
     assert v.suggested_date_from == "2015-06-01"
 
 
@@ -512,9 +516,14 @@ def test_device_with_multiple_open_joins_picks_earliest_date(
     assert serial_vios[0].suggested_date_from == "2012-03-15"
 
 
-def test_station_violations_have_no_date_hint(catalog_path: Path):
-    """Station-level missing attributes don't carry a date hint — the
-    operator picks the date when uncommenting the triage line."""
+def test_station_inherent_cascade_uses_other_attribute_dates(catalog_path: Path):
+    """Station inherent violations get a date hint via cascade.
+
+    Tier 1 (station.date_start) is missing, but tier 2 (earliest open
+    attribute date_from on the station — marker, subtype, altitude all
+    set at 2010-01-01) picks up 2010-01-01. Per operator: even REYK
+    (no date_start) has a usable signal from its inherent attributes'
+    shared creation timestamp."""
     station = _station(
         100,
         "Test Station",
@@ -531,8 +540,114 @@ def test_station_violations_have_no_date_hint(catalog_path: Path):
         client, id_entity=100, catalog_path=catalog_path
     )
 
-    for v in report.violations:
-        assert v.suggested_date_from is None
+    # `date_start` is inherent → cascade tier 2 → 2010-01-01
+    date_vio = next(v for v in report.violations if v.code == "date_start")
+    assert date_vio.suggested_date_from == "2010-01-01"
+
+
+def test_inherent_cascade_tier1_uses_entity_date_start(catalog_path: Path):
+    """When the entity has an open ``date_start`` attribute, tier 1
+    of the cascade wins — it's the most authoritative anchor."""
+    station = _station(
+        100,
+        "Test Station",
+        connections=[],
+        extra_attrs=[
+            _attr("marker", "tst1", date_from="2010-01-01"),
+            _attr("date_start", "2008-05-15", date_from="2010-01-01"),
+            _attr("altitude", 12.3, date_from="2010-01-01"),
+            # subtype missing — should pick up tier 1 (date_start's value)
+        ],
+    )
+    client = _client_for({100: station})
+    report = audit_station_missing_attributes(
+        client, id_entity=100, catalog_path=catalog_path
+    )
+
+    sub_vio = next(v for v in report.violations if v.code == "subtype")
+    assert sub_vio.suggested_date_from == "2008-05-15"
+
+
+def test_inherent_cascade_tier3_falls_back_to_join_date(catalog_path: Path):
+    """When the device has no date_start AND no other open attributes,
+    the cascade falls through to tier 3 — the earliest open-join
+    time_from from the station's perspective."""
+    station = _station(
+        100,
+        "Test Station",
+        connections=[_conn(200, time_from="2018-03-15")],
+        extra_attrs=[
+            _attr("marker", "tst1"),
+            _attr("date_start", "2010-01-01"),
+            _attr("subtype", "GPS stöð"),
+            _attr("altitude", 12.3),
+        ],
+    )
+    # Device has NO attributes — cascade tier 1 and tier 2 both miss.
+    device = _device(200, "gnss_receiver", [])
+    client = _client_for({100: station, 200: device})
+    report = audit_station_missing_attributes(
+        client, id_entity=100, catalog_path=catalog_path
+    )
+
+    serial_vio = next(v for v in report.violations if v.code == "serial_number")
+    assert serial_vio.suggested_date_from == "2018-03-15"
+
+
+def test_mutable_attribute_gets_no_auto_date(catalog_path: Path):
+    """Mutable attributes are explicitly NOT pre-filled — the operator
+    must consciously choose the transition date (today vs entity-start
+    vs explicit), and that decision is theirs to make."""
+    # firmware_version is mutable in the test catalog.
+    station = _station(
+        100,
+        "Test Station",
+        connections=[_conn(200, time_from="2018-03-15")],
+        extra_attrs=[
+            _attr("marker", "tst1"),
+            _attr("date_start", "2010-01-01"),
+            _attr("subtype", "GPS stöð"),
+            _attr("altitude", 12.3),
+        ],
+    )
+    # Mutable codes don't have gps_required_for: [gnss_receiver] in the
+    # test fixture, so synthesize a station where the test catalog's
+    # mutable code DOES apply. Easier: add a custom catalog inline.
+    import yaml as _yaml
+    custom_catalog = (catalog_path.parent / "custom_catalog.yaml")
+    custom_catalog.write_text(_yaml.safe_dump({
+        "devices": {
+            "serial_number": {
+                "classification": "inherent",
+                "gps_required_for": ["gnss_receiver"],
+                "applies_to": ["gnss_receiver"],
+                "gps_relevance": "yes",
+            },
+            "firmware_version": {
+                "classification": "mutable",
+                "gps_required_for": ["gnss_receiver"],
+                "applies_to": ["gnss_receiver"],
+                "gps_relevance": "yes",
+            },
+        },
+        "locations": {},
+        "stations": {},
+    }), encoding="utf-8")
+
+    device = _device(
+        200,
+        "gnss_receiver",
+        [_attr("serial_number", "SN001", date_from="2018-03-15")],
+        # firmware_version missing (mutable)
+    )
+    client = _client_for({100: station, 200: device})
+    report = audit_station_missing_attributes(
+        client, id_entity=100, catalog_path=custom_catalog
+    )
+
+    fw_vio = next(v for v in report.violations if v.code == "firmware_version")
+    # Mutable → no auto-date even though tier 2 / tier 3 would resolve.
+    assert fw_vio.suggested_date_from is None
 
 
 # ---------------------------------------------------------------------------
@@ -777,31 +892,34 @@ def test_triage_default_value_pre_filled_in_action_line(catalog_path: Path):
 
 
 def test_triage_fill_value_placeholder_when_no_default(catalog_path: Path):
-    """date_start has no catalog default → triage emits the placeholder."""
+    """date_start has no catalog default → value placeholder appears.
+    Date hint comes from cascade tier 2 (earliest open attr on station,
+    2010-01-01 from the fixture's marker/altitude default date_from)."""
     report = _station_with_two_gaps(catalog_path)
     out = format_triage_file(
         report, generated_at="2026-05-20T00:00:00+00:00"
     )
-    # date_start has no default, and station violations have no date hint
-    # → both placeholders appear.
     assert (
         f"#ACTION 100 add-attribute date_start {FILL_VALUE_PLACEHOLDER} "
-        f"{FILL_DATE_PLACEHOLDER}" in out
+        "2010-01-01" in out
     )
 
 
-def test_triage_device_date_hint_used_when_present(catalog_path: Path):
-    """For device violations, the earliest open-join time_from is used
-    as the date hint — no placeholder."""
+def test_triage_device_date_hint_from_inherent_cascade(catalog_path: Path):
+    """Device violation date hint comes from the inherent cascade.
+
+    serial_number is inherent; cascade tier 1 (device.date_start) is
+    missing; cascade tier 2 (earliest open attr on device) = 2010-01-01
+    (the ``model`` attribute's default date_from from ``_attr()``).
+    Without cascade, the operator would have fallen back to the join
+    time_from (2015-06-01) — same idea, more precise."""
     report = _station_with_two_gaps(catalog_path)
     out = format_triage_file(
         report, generated_at="2026-05-20T00:00:00+00:00"
     )
-    # serial_number missing → no default value, but join date 2015-06-01
-    # used as date hint.
     assert (
         f"#ACTION 200 add-attribute serial_number {FILL_VALUE_PLACEHOLDER} "
-        "2015-06-01" in out
+        "2010-01-01" in out
     )
 
 


### PR DESCRIPTION
## Summary

Two operator-ergonomics enhancements layered on Layer 6. Both keep the
strict safety contract intact (refuse silent magic for mutable, refuse
unresolvable inputs at the boundary).

## A. Triage emitter — inherent date cascade

For violations with catalog `classification: inherent`, the walker now
resolves `suggested_date_from` via cascade:

1. Entity's open `date_start` attribute value
2. Earliest open attribute `date_from` on the entity (proxy for "when
   did this entity first appear in TOS" — operator's insight: inherent
   attrs like `marker`/`name`/`lat`/`lon` share a creation timestamp)
3. For devices only: earliest open-join `time_from` from the station
4. `<FILL_DATE>` if nothing resolves

For `mutable` / `TODO` / unclassified: no auto-fill. Operator must
consciously pick the transition date.

## B. Apply dispatcher — `now` / `start` tokens

`_dispatch_add_attribute` accepts two special tokens for `<date_from>`:

- `now` → today's UTC date
- `start` → earliest open attribute `date_from` on the entity

Both documented in the triage workflow header and in
`tos audit apply --help`. The `start` token shares the entity-attrs
fetch with conflict detection, so no extra HTTP cost.

## Example

For `visit_class` (now `operational_class` post-catalog-rename) the
triage line that used to look like:

```
#ACTION 4257 add-attribute operational_class B <FILL_DATE>
```

now renders as:

```
#ACTION 4257 add-attribute operational_class B 2010-01-01
```

with the date auto-filled from the cascade. Or operator can use the
`now` / `start` shortcuts when overriding.

## Test plan

- [x] 547 passed (was 539 on master, +8 new), 2 skipped
- [ ] Live test on real station via VPN — verify triage rendering
      and `now` / `start` expansion work end-to-end

## Sequencing

Stacks cleanly on master (which has merged #24 + #25). Independent of
the still-pending catalog rename pass (Track 1) and the proposed
`tos audit catalog-vs-tos` verb (Track 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)