### PR TITLE
fix(devices): warehouse intake uses entity_connection, not string location

### DIFF
--- a/src/tostools/api/tos_writer.py
+++ b/src/tostools/api/tos_writer.py
@@ -589,9 +589,7 @@ class TOSWriter:
                 entity ID. Better to fail loudly than to leave the
                 device floating without a placement.
         """
-        location_id = self.find_location_by_name(
-            location_name, type_filter=type_filter
-        )
+        location_id = self.find_location_by_name(location_name, type_filter=type_filter)
         if location_id is None:
             raise ValueError(
                 f"connect_device_to_location: location {location_name!r} not "

--- a/src/tostools/api/tos_writer.py
+++ b/src/tostools/api/tos_writer.py
@@ -502,6 +502,110 @@ class TOSWriter:
                 return entity
         return None
 
+    def find_location_by_name(
+        self,
+        name: str,
+        type_filter: str = "vöruhús",
+    ) -> Optional[int]:
+        """Look up a warehouse / location entity by its ``name`` attribute.
+
+        Uses ``POST /basic_search/`` to search for the literal location name
+        string, filters to hits with ``code='name'`` and ``distance=0``, and
+        returns the matching entity's ``id_entity`` (the entity is identified
+        by ``id_lvl_two`` in basic_search results since the match is on the
+        location entity itself, not on a child of it).
+
+        Args:
+            name: Full location name as recorded in TOS, e.g.
+                ``"B9 - Kjallari - Jörð"``. Matched exactly (case-sensitive,
+                no whitespace normalisation).
+            type_filter: Restrict to a TOS ``type_lvl_two`` (e.g.
+                ``"vöruhús"`` for warehouses, ``"stöð"`` for stations).
+                Set to ``""`` or ``None`` to disable the type filter.
+
+        Returns:
+            The entity's ``id_entity`` (an int) or ``None`` when no exact
+            match exists.
+        """
+        if not name:
+            return None
+
+        results = self._request(
+            "POST",
+            "/basic_search/",
+            data={"search_term": name},
+            _force_send=True,
+        )
+        if not isinstance(results, list):
+            return None
+
+        for hit in results:
+            if hit.get("code") != "name":
+                continue
+            if hit.get("distance") != 0:
+                continue
+            if hit.get("value_varchar") != name:
+                continue
+            if type_filter and hit.get("type_lvl_two") != type_filter:
+                continue
+            # The location entity itself is at lvl_two — the match was on its
+            # name attribute, not on a child entity's attribute.
+            entity_id = hit.get("id_entity") or hit.get("id_lvl_two")
+            if entity_id:
+                return int(entity_id)
+        return None
+
+    def connect_device_to_location(
+        self,
+        id_device: int,
+        location_name: str,
+        date_start: str,
+        *,
+        type_filter: str = "vöruhús",
+    ) -> Any:
+        """Resolve a location name to an entity ID and join the device to it.
+
+        Convenience wrapper around :meth:`find_location_by_name` +
+        :meth:`create_entity_connection` — this is the canonical way to
+        place a device at a warehouse / station so it appears under that
+        location in the TOS web UI (e.g. ``station_device_status``).
+
+        Args:
+            id_device: Entity ID of the child (the device entity, freshly
+                returned by :meth:`create_device`).
+            location_name: The full location name in TOS (e.g.
+                ``"B9 - Kjallari - Jörð"``).
+            date_start: ISO-8601 date marking when the device was placed
+                at the location. Passed through to the connection as
+                ``time_from``.
+            type_filter: Forwarded to :meth:`find_location_by_name`.
+
+        Returns:
+            The API response from :meth:`create_entity_connection`, or
+            :class:`DryRunResult` in dry-run mode.
+
+        Raises:
+            ValueError: When the location name cannot be resolved to an
+                entity ID. Better to fail loudly than to leave the
+                device floating without a placement.
+        """
+        location_id = self.find_location_by_name(
+            location_name, type_filter=type_filter
+        )
+        if location_id is None:
+            raise ValueError(
+                f"connect_device_to_location: location {location_name!r} not "
+                f"found in TOS (type_filter={type_filter!r}). The device has "
+                f"already been created (id_entity={id_device}); register the "
+                f"location first or pass a name that matches a TOS entity."
+            )
+        return self.create_entity_connection(
+            id_parent=location_id,
+            id_child=id_device,
+            time_from=date_start,
+            time_to=None,
+        )
+
     def get_attribute_values(
         self,
         id_entity: int,

--- a/src/tostools/audit_missing_attributes.py
+++ b/src/tostools/audit_missing_attributes.py
@@ -402,9 +402,7 @@ def audit_station_missing_attributes(
 
         device_label = _device_display_label(history)
         join_dates = [
-            _date_only(str(j["time_from"]))
-            for j in open_joins
-            if j.get("time_from")
+            _date_only(str(j["time_from"])) for j in open_joins if j.get("time_from")
         ]
         suggested_date = min(join_dates) if join_dates else None
 

--- a/src/tostools/device.py
+++ b/src/tostools/device.py
@@ -52,7 +52,8 @@ REQUIRED_ATTR_CODES: Tuple[str, ...] = (
     "serial_number",
     "model",
     "owner",
-    "location",
+    "status",
+    "date_start",
 )
 
 # Order here drives the iteration order in :func:`iter_optional_attributes`
@@ -177,13 +178,30 @@ def build_required_attributes(
     serial: str,
     model: str,
     owner: str,
-    location: str,
     date_start: str,
 ) -> List[Dict[str, Optional[str]]]:
     """Build the attribute list passed to :meth:`TOSWriter.create_device`.
 
     Each attribute carries an explicit ``date_to: None`` — the TOS ``/entities``
     endpoint treats the field as required-present even when the period is open.
+
+    Returns the canonical warehouse-device attribute set verified against
+    existing open children of B9 - Kjallari - Jörð (id_entity=4) on
+    2026-05-21:
+
+    - ``serial_number``, ``model``, ``owner`` — device identity
+    - ``status`` = ``"virkt"`` (active) — canonical "device is alive" marker
+    - ``date_start`` — separate from the per-attribute ``date_from`` field;
+      stored as its own attribute_value row by TOS
+
+    Note: ``location`` was previously written here as a free-text attribute
+    on the device. It has been removed — TOS represents "device at
+    location" via an ``entity_connection`` row joining the device entity
+    to the location entity, not via a string attribute on the device.
+    Callers must call :meth:`TOSWriter.create_entity_connection` after
+    :meth:`TOSWriter.create_device` to record the placement; see
+    :meth:`TOSWriter.connect_device_to_location` for the resolve + connect
+    convenience wrapper.
     """
     return [
         {
@@ -205,8 +223,14 @@ def build_required_attributes(
             "date_to": None,
         },
         {
-            "code": "location",
-            "value": location,
+            "code": "status",
+            "value": "virkt",
+            "date_from": date_start,
+            "date_to": None,
+        },
+        {
+            "code": "date_start",
+            "value": date_start,
             "date_from": date_start,
             "date_to": None,
         },

--- a/src/tostools/tos.py
+++ b/src/tostools/tos.py
@@ -3681,9 +3681,7 @@ def _dispatch_add_attribute(writer, action: ParsedAction) -> ActionResult:
 
     open_values = [a for a in existing if a.get("date_to") is None]
     if len(open_values) > 1:
-        ids = ", ".join(
-            str(a.get("id_attribute_value")) for a in open_values
-        )
+        ids = ", ".join(str(a.get("id_attribute_value")) for a in open_values)
         return ActionResult(
             action=action,
             status="failed",
@@ -3719,9 +3717,7 @@ def _dispatch_add_attribute(writer, action: ParsedAction) -> ActionResult:
         )
 
     try:
-        response = writer.add_attribute_value(
-            action.id_entity, code, value, date_from
-        )
+        response = writer.add_attribute_value(action.id_entity, code, value, date_from)
     except Exception as exc:  # noqa: BLE001
         return ActionResult(
             action=action,

--- a/src/tostools/tos.py
+++ b/src/tostools/tos.py
@@ -1985,6 +1985,7 @@ def _device_main(argv):
             "required_attributes": required,
             "optional_attributes": [{"code": c, "value": v} for c, v in optional],
             "upsert_results": upsert_responses,
+            "location_connection": connection_response,
         }
         print(_json.dumps(payload, ensure_ascii=False, indent=2))
     else:
@@ -1994,6 +1995,13 @@ def _device_main(argv):
             f"Created {args.subtype} serial={args.serial} "
             f"id_entity={id_str}{suffix}"
         )
+        if not dry_run and isinstance(connection_response, dict):
+            conn_id = connection_response.get("id_connection")
+            if conn_id is not None:
+                print(
+                    f"Connected to location {args.location!r} "
+                    f"(connection id={conn_id})"
+                )
     return 0
 
 

--- a/src/tostools/tos.py
+++ b/src/tostools/tos.py
@@ -1895,7 +1895,6 @@ def _device_main(argv):
         serial=args.serial,
         model=igs_model,
         owner=args.owner,
-        location=args.location,
         date_start=date_start,
     )
     optional = device_helpers.iter_optional_attributes(
@@ -1926,6 +1925,33 @@ def _device_main(argv):
     id_entity = None
     if isinstance(response, dict):
         id_entity = response.get("id_entity")
+
+    # ---- Location join (parent area entity → child device) --------------
+    # Replaces the old "location as a free-text attribute on the device"
+    # approach; physical placement in TOS is conveyed via entity_connection.
+    if dry_run or id_entity is None:
+        if not args.json:
+            print(
+                f"DRY RUN: would resolve location {args.location!r} → entity_id "
+                f"and create entity_connection(parent=<area>, "
+                f"child={id_entity if id_entity is not None else '<new>'}, "
+                f"time_from={date_start})"
+            )
+        connection_response = {"location": args.location, "dry_run": True}
+    else:
+        try:
+            connection_response = writer.connect_device_to_location(
+                id_device=id_entity,
+                location_name=args.location,
+                date_start=date_start,
+            )
+        except ValueError as e:
+            print(
+                f"Device created (id_entity={id_entity}) but location join "
+                f"failed: {e}",
+                file=sys.stderr,
+            )
+            return 1
 
     # ---- Optional attributes --------------------------------------------
     upsert_responses = []

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -131,7 +131,6 @@ def test_build_required_attributes_shape() -> None:
         serial="SN1",
         model="SEPT POLARX5",
         owner="Veðurstofa Íslands",
-        location="Bench A",
         date_start="2026-05-11T00:00:00",
     )
     assert [a["code"] for a in attrs] == list(REQUIRED_ATTR_CODES)
@@ -140,7 +139,11 @@ def test_build_required_attributes_shape() -> None:
     assert by_code["serial_number"] == "SN1"
     assert by_code["model"] == "SEPT POLARX5"
     assert by_code["owner"] == "Veðurstofa Íslands"
-    assert by_code["location"] == "Bench A"
+    assert by_code["status"] == "virkt"
+    assert by_code["date_start"] == "2026-05-11T00:00:00"
+    # Location is intentionally NOT an attribute on the device — it is
+    # represented via an entity_connection to the location entity instead.
+    assert "location" not in by_code
 
 
 # ---------------------------------------------------------------------------
@@ -240,7 +243,10 @@ def test_device_main_dry_run_happy_path(base_argv: list, capsys) -> None:
     assert attrs["model"] == "SEPT POLARX5"
     assert attrs["serial_number"] == "SN_HAPPY"
     assert attrs["owner"] == "Veðurstofa Íslands"
-    assert attrs["location"] == "Bench A"
+    # location is NOT a device attribute — it is conveyed via entity_connection
+    assert "location" not in attrs
+    assert attrs["status"] == "virkt"
+    assert attrs["date_start"] == "2026-05-11T00:00:00"
     assert call.kwargs["force"] is False
     # No optional inputs → no upsert calls.
     writer.upsert_attribute_value.assert_not_called()

--- a/tests/test_tos_writer.py
+++ b/tests/test_tos_writer.py
@@ -744,6 +744,117 @@ def test_find_device_by_serial_search_runs_in_dry_run_mode():
     assert mock_req.call_args.args[0] == "POST"
 
 
+# ---------------------------------------------------------------------------
+# find_location_by_name / connect_device_to_location
+# ---------------------------------------------------------------------------
+
+
+def _basic_search_location_hit(
+    name: str,
+    entity_id: int,
+    type_lvl_two: str = "vöruhús",
+    distance: int = 0,
+) -> dict:
+    """Mirror the basic_search hit shape for an entity-name match (location)."""
+    return {
+        "code": "name",
+        "value_varchar": name,
+        "distance": distance,
+        "id_entity": entity_id,
+        "id_lvl_two": entity_id,
+        "id_lvl_three": None,
+        "type_lvl_two": type_lvl_two,
+        "subtype_lvl_two": "Lager",
+    }
+
+
+def test_find_location_by_name_returns_id_on_exact_match():
+    w = _logged_in_writer(dry_run=False)
+    hits = [_basic_search_location_hit("B9 - Kjallari - Jörð", entity_id=4)]
+    with patch.object(w, "_request", return_value=hits):
+        assert w.find_location_by_name("B9 - Kjallari - Jörð") == 4
+
+
+def test_find_location_by_name_returns_none_on_no_match():
+    w = _logged_in_writer(dry_run=False)
+    with patch.object(w, "_request", return_value=[]):
+        assert w.find_location_by_name("Nowhere") is None
+
+
+def test_find_location_by_name_filters_distance_and_value():
+    w = _logged_in_writer(dry_run=False)
+    hits = [
+        # fuzzy match — should be skipped
+        _basic_search_location_hit("B9 - Kjallari", entity_id=999, distance=2),
+        # wrong value_varchar with distance=0 — should be skipped
+        _basic_search_location_hit("B7 - Kjallari", entity_id=998),
+        # the right one
+        _basic_search_location_hit("B9 - Kjallari - Jörð", entity_id=4),
+    ]
+    with patch.object(w, "_request", return_value=hits):
+        assert w.find_location_by_name("B9 - Kjallari - Jörð") == 4
+
+
+def test_find_location_by_name_filters_type():
+    w = _logged_in_writer(dry_run=False)
+    # value matches but type_lvl_two doesn't match the warehouse filter
+    hits = [
+        _basic_search_location_hit(
+            "B9 - Kjallari - Jörð", entity_id=999, type_lvl_two="stöð"
+        )
+    ]
+    with patch.object(w, "_request", return_value=hits):
+        assert w.find_location_by_name("B9 - Kjallari - Jörð") is None
+    # Disabling the type filter recovers the match.
+    with patch.object(w, "_request", return_value=hits):
+        assert (
+            w.find_location_by_name("B9 - Kjallari - Jörð", type_filter="")
+            == 999
+        )
+
+
+def test_find_location_by_name_empty_short_circuits():
+    w = _logged_in_writer(dry_run=False)
+    with patch.object(w, "_request") as mock_req:
+        assert w.find_location_by_name("") is None
+    mock_req.assert_not_called()
+
+
+def test_connect_device_to_location_resolves_then_creates_join():
+    w = _logged_in_writer(dry_run=False)
+    hits = [_basic_search_location_hit("B9 - Kjallari - Jörð", entity_id=4)]
+    join_response = {"id_connection": 12345}
+    with patch.object(w, "_request") as mock_req:
+        # 1st call: basic_search hits; 2nd call: create_entity_connection POST
+        mock_req.side_effect = [hits, join_response]
+        result = w.connect_device_to_location(
+            id_device=21499,
+            location_name="B9 - Kjallari - Jörð",
+            date_start="2026-05-21T00:00:00",
+        )
+
+    assert result is join_response
+    # Confirm the second call was POST /entity_connection/ with the right body
+    post = mock_req.call_args_list[1]
+    assert post.args[0] == "POST"
+    body = post.kwargs.get("data") or post.args[2]
+    assert body["id_entity_parent"] == 4
+    assert body["id_entity_child"] == 21499
+    assert body["time_from"] == "2026-05-21T00:00:00"
+    assert body["time_to"] is None
+
+
+def test_connect_device_to_location_raises_when_unresolved():
+    w = _logged_in_writer(dry_run=False)
+    with patch.object(w, "_request", return_value=[]):
+        with pytest.raises(ValueError, match="not found in TOS"):
+            w.connect_device_to_location(
+                id_device=21499,
+                location_name="Unknown - Place",
+                date_start="2026-05-21T00:00:00",
+            )
+
+
 def test_create_device_rejects_duplicate_serial():
     w = _logged_in_writer(dry_run=True)
     existing = {


### PR DESCRIPTION
## Summary

`tos device add` + the receivers wrapper `cfg add-receiver` were producing device entities that didn't appear in the TOS web UI's `station_device_status` page filtered to their warehouse. The pages list devices via `entity_connection` rows (parent=area-entity → child=device); our intake only wrote a `location` *string attribute* on the device — wrong representation, never actually joined to anything.

## Verified against production TOS (2026-05-21)

Surveyed open children of B9 - Kjallari - Jörð (`id_entity=4`, subtype `area`):

- 625 currently-open child connections
- Every working device has `serial_number`, `model`, `owner`, `status='virkt'`, `date_start` attributes
- Plus device-specific extras (`firmware_version`, `software_version`, `http_port`, `ip_address`)
- **None of the working devices have a `location` string attribute** — that field was unique to our broken-intake entities

## Changes

- `device.build_required_attributes` — drop `location` param, add `status='virkt'` and `date_start` attributes. `REQUIRED_ATTR_CODES` updated to match.
- `TOSWriter.find_location_by_name(name, type_filter='vöruhús')` — resolve warehouse name to `id_entity` via `/basic_search/` (code='name', distance=0, type_lvl_two filter)
- `TOSWriter.connect_device_to_location(id_device, location_name, date_start)` — resolve + `create_entity_connection` in one call. Raises `ValueError` when unresolved (better than leaving a floating device)
- `tos._device_main` — calls the new wrapper after `create_device`. Dry-run print suppressed under `--json`.
- Tests: shape assertion updated; +7 new tests for the new methods

## Breaking change

`build_required_attributes` signature changed (dropped `location` param). Direct callers in this repo updated; downstream receivers wrapper will need its call site updated too — separate PR on the receivers repo will pin to this commit/tag and update the caller.

## Test plan

- [x] `pytest tests/test_device.py` — 31 passing (was 29)
- [x] Full suite — 546 passing (+7 new), 2 skipped, 0 regressions
- [ ] Live verification against TOS once merged + bumped on the receivers side

## Followups (not in this PR)

- Duplicate-serial guard still uses `/basic_search/` which lags behind fresh writes (verified: `3070589` finds, `4101524` doesn't until indexer catches up). `--force` already bypasses; can switch to a direct attribute lookup later.
- Two existing orphan entities `id_entity=21499` and `id_entity=21500` on production TOS still need cleanup (created with the old broken shape). Tostools needs a `delete_entity` API (`feat/tos-writer-delete` upstream branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)