### PR TITLE
feat(apply): add patch-attribute-value verb for in-place data fixes

### DIFF
--- a/src/tostools/tos.py
+++ b/src/tostools/tos.py
@@ -2442,6 +2442,15 @@ def _audit_main(argv):
             "                            PATCH /attribute_value/<id> "
             "date_from — consumes triage files from\n"
             "                            `tos audit attribute-dates --triage`\n"
+            "  patch-attribute-value <code> <date_from> <new_value>\n"
+            "                            PATCH /attribute_value/<id> "
+            "value — in-place\n"
+            "                            data-quality correction (typo, "
+            "trailing whitespace,\n"
+            "                            casing). Leaves dates untouched. "
+            "Refuses ambiguous\n"
+            "                            matches and idempotent no-ops on "
+            "matching value.\n"
             "  add-attribute <code> <value> <date_from>\n"
             "                            POST /attribute_values — add a new open "
             "period to fill\n"
@@ -3068,6 +3077,7 @@ _SUPPORTED_VERBS = (
     "fill-gap",
     "move",
     "patch-attribute-date",
+    "patch-attribute-value",
 )
 
 
@@ -3234,6 +3244,19 @@ def _parse_action_file(text: str) -> tuple[List[ParsedAction], List[ParseError]]
                         "<code> <value> <date_from> "
                         "(quote the value if it contains spaces, e.g. "
                         "'GPS stöð')"
+                    ),
+                    raw=raw,
+                )
+            )
+            continue
+        if verb == "patch-attribute-value" and len(tokens) != 6:
+            errors.append(
+                ParseError(
+                    line_no=i,
+                    message=(
+                        "patch-attribute-value requires exactly three "
+                        "arguments: <code> <date_from> <new_value> "
+                        "(quote the new value if it contains spaces)"
                     ),
                     raw=raw,
                 )
@@ -3736,6 +3759,156 @@ def _dispatch_add_attribute(writer, action: ParsedAction) -> ActionResult:
     )
 
 
+def _dispatch_patch_attribute_value(writer, action: ParsedAction) -> ActionResult:
+    """In-place correction of an attribute value (Pattern 1).
+
+    Action shape: ``ACTION <id_entity> patch-attribute-value <code>
+    <date_from> <new_value>``. PATCHes the matching attribute period's
+    ``value`` field, leaving ``date_from`` / ``date_to`` untouched.
+
+    The intended use case is data-quality cleanup — fixing typos,
+    trailing whitespace, casing errors on an existing value where the
+    semantic record is correct but the literal string is wrong (e.g.
+    serial number ``'3099973 '`` with trailing space → ``'3099973'``).
+    For a genuine value change that should preserve history (e.g. a
+    firmware update), use a transition pattern instead.
+
+    Match rule
+    ----------
+    A period matches when its ``date_from`` *date-only* prefix
+    (``YYYY-MM-DD``) equals the action's ``<date_from>`` — same
+    normalisation as :func:`_dispatch_patch_attribute_date`.
+
+    Failure modes
+    -------------
+    * **Zero matches** — no period found. The operator's audit was
+      stale; rerun and regenerate.
+    * **Multiple matches** — two or more periods share the date-only
+      prefix. Refuse rather than PATCH arbitrarily.
+    * **``<FILL_*>`` placeholder** in new_value — operator forgot to
+      replace; refuse before any network call.
+    * **Period has no ``id_attribute_value``** — partial TOS payload.
+    * **Value already matches** — idempotent no-op (safe to re-run).
+    """
+    code = action.args[0]
+    date_from_raw = action.args[1]
+    new_value = action.args[2]
+
+    # Placeholder rejection — same shape check as add-attribute.
+    if new_value.startswith("<") and new_value.endswith(">"):
+        return ActionResult(
+            action=action,
+            status="failed",
+            detail=(
+                f"patch-attribute-value: value placeholder {new_value!r} "
+                "not replaced — fill in the new value before applying"
+            ),
+        )
+
+    date_from = date_from_raw[:10]
+    if len(date_from) != 10 or date_from[4] != "-" or date_from[7] != "-":
+        return ActionResult(
+            action=action,
+            status="failed",
+            detail=(
+                f"patch-attribute-value: date_from must be YYYY-MM-DD "
+                f"(got {date_from_raw!r})"
+            ),
+        )
+
+    try:
+        attrs = writer.get_attribute_values(action.id_entity, code)
+    except Exception as exc:  # noqa: BLE001
+        return ActionResult(
+            action=action,
+            status="failed",
+            detail=f"get_attribute_values raised: {exc}",
+        )
+
+    matches = [
+        a for a in attrs
+        if str(a.get("date_from") or "")[:10] == date_from
+    ]
+    if not matches:
+        return ActionResult(
+            action=action,
+            status="failed",
+            detail=(
+                f"patch-attribute-value: no period found for "
+                f"id_entity={action.id_entity} code={code!r} "
+                f"date_from={date_from} (re-audit and regenerate triage)"
+            ),
+        )
+    if len(matches) > 1:
+        ids = ", ".join(str(a.get("id_attribute_value")) for a in matches)
+        return ActionResult(
+            action=action,
+            status="failed",
+            detail=(
+                f"patch-attribute-value: {len(matches)} periods share "
+                f"date_from={date_from} for code {code!r} on "
+                f"id_entity={action.id_entity} (ids: {ids}) — refusing to "
+                "PATCH ambiguously. Operator must disambiguate manually."
+            ),
+        )
+
+    target = matches[0]
+    id_av_raw = target.get("id_attribute_value")
+    if id_av_raw is None:
+        return ActionResult(
+            action=action,
+            status="failed",
+            detail=(
+                "patch-attribute-value: matched period has no "
+                "id_attribute_value (unexpected TOS payload shape); "
+                "re-audit against a fresh history"
+            ),
+        )
+
+    try:
+        id_av = int(id_av_raw)
+    except (TypeError, ValueError):
+        return ActionResult(
+            action=action,
+            status="failed",
+            detail=(
+                f"patch-attribute-value: id_attribute_value={id_av_raw!r} "
+                "is not an integer (unexpected TOS payload shape)"
+            ),
+        )
+
+    old_value = target.get("value")
+    if str(old_value) == new_value:
+        return ActionResult(
+            action=action,
+            status="ok",
+            detail=(
+                f"already correct: id_attribute_value={id_av} for "
+                f"id_entity={action.id_entity} code={code!r} "
+                f"date_from={date_from} already has value {new_value!r} (no-op)"
+            ),
+        )
+
+    try:
+        response = writer.patch_attribute_value(id_av, value=new_value)
+    except Exception as exc:  # noqa: BLE001
+        return ActionResult(
+            action=action,
+            status="failed",
+            detail=f"patch_attribute_value raised: {exc}",
+        )
+
+    return ActionResult(
+        action=action,
+        status="ok",
+        detail=(
+            f"PATCH /attribute_value/{id_av} "
+            f"value {old_value!r} → {new_value!r} "
+            f"(code={code!r}, date_from={date_from}) — {response!r}"
+        ),
+    )
+
+
 def _dispatch_action(
     writer,
     action: ParsedAction,
@@ -3773,6 +3946,8 @@ def _dispatch_action(
         return _dispatch_fill_gap(writer, action)
     if action.verb == "patch-attribute-date":
         return _dispatch_patch_attribute_date(writer, action)
+    if action.verb == "patch-attribute-value":
+        return _dispatch_patch_attribute_value(writer, action)
     if action.verb == "add-attribute":
         return _dispatch_add_attribute(writer, action)
     if action.verb == "change-subtype":

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -919,6 +919,50 @@ def test_dispatch_patch_attribute_date_captures_read_exception():
 
 
 # ---------------------------------------------------------------------------
+# _parse_action_file — patch-attribute-value
+# ---------------------------------------------------------------------------
+
+
+def test_parse_action_file_patch_attribute_value_three_args():
+    text = "ACTION 20516 patch-attribute-value serial_number 2024-08-29 3099973\n"
+    actions, errors = _parse_action_file(text)
+    assert errors == []
+    assert len(actions) == 1
+    assert actions[0].verb == "patch-attribute-value"
+    assert actions[0].args == ["serial_number", "2024-08-29", "3099973"]
+
+
+def test_parse_action_file_patch_attribute_value_quoted_value():
+    """Quoted new_value with spaces survives the shlex round-trip."""
+    text = (
+        'ACTION 4390 patch-attribute-value description 2001-07-19 '
+        '"GPS station deployed by U Arizona"\n'
+    )
+    actions, errors = _parse_action_file(text)
+    assert errors == []
+    assert actions[0].args == [
+        "description", "2001-07-19", "GPS station deployed by U Arizona"
+    ]
+
+
+def test_parse_action_file_patch_attribute_value_rejects_too_few_args():
+    text = "ACTION 20516 patch-attribute-value serial_number 2024-08-29\n"
+    actions, errors = _parse_action_file(text)
+    assert actions == []
+    assert "patch-attribute-value requires exactly three arguments" in errors[0].message
+
+
+def test_parse_action_file_patch_attribute_value_rejects_extra_args():
+    text = (
+        "ACTION 20516 patch-attribute-value serial_number "
+        "2024-08-29 3099973 EXTRA\n"
+    )
+    actions, errors = _parse_action_file(text)
+    assert actions == []
+    assert "patch-attribute-value requires exactly three arguments" in errors[0].message
+
+
+# ---------------------------------------------------------------------------
 # _parse_action_file — add-attribute
 # ---------------------------------------------------------------------------
 
@@ -1218,3 +1262,186 @@ def test_dispatch_add_attribute_skips_closed_periods_for_conflict_check():
     writer.add_attribute_value.assert_called_once_with(
         4390, "subtype", "GPS stöð", "2006-01-01"
     )
+
+
+# ---------------------------------------------------------------------------
+# _dispatch_action — patch-attribute-value
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_patch_attribute_value_happy_path():
+    """Single matching period → PATCH the value field; dates left alone."""
+    writer = MagicMock()
+    writer.get_attribute_values.return_value = [
+        _attr_value(55101, "serial_number", "3099973 ", "2024-08-29 00:00:00"),
+    ]
+    writer.patch_attribute_value.return_value = {"ok": True}
+
+    result = _dispatch_action(
+        writer,
+        _make_action(
+            20516, "patch-attribute-value", "serial_number", "2024-08-29", "3099973"
+        ),
+    )
+
+    assert result.status == "ok"
+    writer.get_attribute_values.assert_called_once_with(20516, "serial_number")
+    writer.patch_attribute_value.assert_called_once_with(55101, value="3099973")
+    assert "PATCH /attribute_value/55101" in result.detail
+    assert "'3099973 ' → '3099973'" in result.detail
+
+
+def test_dispatch_patch_attribute_value_normalises_tos_datetime():
+    """TOS stores `2024-08-29 00:00:00` but the action carries `2024-08-29`.
+    Without date-only normalisation the match would silently fail."""
+    writer = MagicMock()
+    writer.get_attribute_values.return_value = [
+        _attr_value(55101, "serial_number", "old", "2024-08-29 00:00:00"),
+    ]
+    writer.patch_attribute_value.return_value = {"ok": True}
+
+    result = _dispatch_action(
+        writer,
+        _make_action(
+            20516, "patch-attribute-value", "serial_number", "2024-08-29", "new"
+        ),
+    )
+    assert result.status == "ok"
+    writer.patch_attribute_value.assert_called_once_with(55101, value="new")
+
+
+def test_dispatch_patch_attribute_value_zero_matches_fails():
+    """No period with the given date_from → failed; never PATCHes some
+    other arbitrary period."""
+    writer = MagicMock()
+    writer.get_attribute_values.return_value = [
+        _attr_value(55101, "serial_number", "X", "2010-01-01 00:00:00"),
+    ]
+    result = _dispatch_action(
+        writer,
+        _make_action(
+            20516, "patch-attribute-value", "serial_number", "2024-08-29", "new"
+        ),
+    )
+    assert result.status == "failed"
+    assert "no period found" in result.detail
+    writer.patch_attribute_value.assert_not_called()
+
+
+def test_dispatch_patch_attribute_value_ambiguous_match_fails():
+    """Two periods with the same date-only date_from → refuse rather
+    than PATCH arbitrarily. Same safety contract as patch-attribute-date."""
+    writer = MagicMock()
+    writer.get_attribute_values.return_value = [
+        _attr_value(55101, "serial_number", "A", "2024-08-29 00:00:00"),
+        _attr_value(55102, "serial_number", "B", "2024-08-29 12:00:00"),
+    ]
+    result = _dispatch_action(
+        writer,
+        _make_action(
+            20516, "patch-attribute-value", "serial_number", "2024-08-29", "new"
+        ),
+    )
+    assert result.status == "failed"
+    assert "2 periods share" in result.detail
+    writer.patch_attribute_value.assert_not_called()
+
+
+def test_dispatch_patch_attribute_value_value_already_matches_is_no_op():
+    """Idempotent skip when the value is already correct — safe to re-run."""
+    writer = MagicMock()
+    writer.get_attribute_values.return_value = [
+        _attr_value(55101, "serial_number", "3099973", "2024-08-29 00:00:00"),
+    ]
+    result = _dispatch_action(
+        writer,
+        _make_action(
+            20516, "patch-attribute-value", "serial_number", "2024-08-29", "3099973"
+        ),
+    )
+    assert result.status == "ok"
+    assert "already correct" in result.detail
+    writer.patch_attribute_value.assert_not_called()
+
+
+def test_dispatch_patch_attribute_value_placeholder_refuses():
+    """<FILL_VALUE> in new_value → refuse before any network call."""
+    writer = MagicMock()
+    result = _dispatch_action(
+        writer,
+        _make_action(
+            20516, "patch-attribute-value", "serial_number",
+            "2024-08-29", "<FILL_VALUE>"
+        ),
+    )
+    assert result.status == "failed"
+    assert "placeholder" in result.detail
+    writer.get_attribute_values.assert_not_called()
+    writer.patch_attribute_value.assert_not_called()
+
+
+def test_dispatch_patch_attribute_value_invalid_date_format_refuses():
+    writer = MagicMock()
+    result = _dispatch_action(
+        writer,
+        _make_action(
+            20516, "patch-attribute-value", "serial_number",
+            "not-a-date", "new"
+        ),
+    )
+    assert result.status == "failed"
+    assert "YYYY-MM-DD" in result.detail
+    writer.get_attribute_values.assert_not_called()
+
+
+def test_dispatch_patch_attribute_value_get_raises_returns_failed():
+    """Network/auth errors from get_attribute_values surface as failed,
+    never raise out of the dispatcher."""
+    writer = MagicMock()
+    writer.get_attribute_values.side_effect = RuntimeError("simulated 503")
+    result = _dispatch_action(
+        writer,
+        _make_action(
+            20516, "patch-attribute-value", "serial_number", "2024-08-29", "new"
+        ),
+    )
+    assert result.status == "failed"
+    assert "get_attribute_values raised" in result.detail
+    writer.patch_attribute_value.assert_not_called()
+
+
+def test_dispatch_patch_attribute_value_writer_raises_returns_failed():
+    writer = MagicMock()
+    writer.get_attribute_values.return_value = [
+        _attr_value(55101, "serial_number", "old", "2024-08-29 00:00:00"),
+    ]
+    writer.patch_attribute_value.side_effect = RuntimeError("simulated 500")
+    result = _dispatch_action(
+        writer,
+        _make_action(
+            20516, "patch-attribute-value", "serial_number", "2024-08-29", "new"
+        ),
+    )
+    assert result.status == "failed"
+    assert "patch_attribute_value raised" in result.detail
+
+
+def test_dispatch_patch_attribute_value_handles_trailing_space_serial():
+    """The motivating use case: serial '3099973 ' (trailing space) →
+    '3099973'. This is exactly the data-quality issue surfaced during
+    the HAUC operator review on receiver 20516."""
+    writer = MagicMock()
+    writer.get_attribute_values.return_value = [
+        _attr_value(55101, "serial_number", "3099973 ", "2024-08-29 00:00:00"),
+    ]
+    writer.patch_attribute_value.return_value = {"value": "3099973"}
+
+    result = _dispatch_action(
+        writer,
+        _make_action(
+            20516, "patch-attribute-value", "serial_number", "2024-08-29", "3099973"
+        ),
+    )
+
+    assert result.status == "ok"
+    writer.patch_attribute_value.assert_called_once_with(55101, value="3099973")


### PR DESCRIPTION
## Summary

Adds the apply-verb counterpart to `patch-attribute-date` for the value side. PATCHes an existing attribute period's `value` field in place, leaving dates untouched. For data-quality cleanup where the semantic record is correct but the literal string is wrong (typos, trailing whitespace, casing).

## Motivating case

Surfaced during HAUC operator review: receiver 20516 has serial number `'3099973 '` (trailing space) in TOS — clear typo. None of the existing verbs could fix it: `add-attribute` refuses when an open period already exists with a different value, `patch-attribute-date` only edits dates. `patch-attribute-value` fills that gap.

## Action shape

```
ACTION <id_entity> patch-attribute-value <code> <date_from> <new_value>
```

Same shape as `patch-attribute-date`; third arg is the new value instead of the new date. Quoted values supported via shlex.

## Safety contract (mirrors patch-attribute-date)

- Match by `code` + date-only prefix of `date_from`
- Ambiguous match → refuse rather than PATCH arbitrarily
- Zero matches → fail with re-audit hint
- `<FILL_*>` placeholder in new_value → refuse pre-flight
- Value already equals new_value → idempotent no-op

## Use it now

For the HAUC trailing-space case:
```
ACTION 20516 patch-attribute-value serial_number 2024-08-29 3099973
```

`tos audit apply file.txt --apply` will PATCH the attribute value in place.

## Tests

14 new — 4 parser (happy path, quoted value, too-few-args, extra-args), 10 dispatcher (happy path, date normalisation, zero/ambiguous matches, idempotent, placeholder rejection, date format, get/patch error propagation, motivating trailing-space test).

**Suite: 560 passed, 2 skipped (was 546 on master, +14 new).**

## Out of scope

- Automated value-quality audit verb (would emit `patch-attribute-value` triage lines automatically) — separate project
- Pattern 2 (transition: close + open) value changes — explicitly Pattern 1 in-place semantics here

🤖 Generated with [Claude Code](https://claude.com/claude-code)