### PR TITLE
feat(tos-writer): move_device + add_maintenance_visit + delete_entity_connection (8 new methods)

### DIFF
--- a/docs/architecture/tos-write-api.md
+++ b/docs/architecture/tos-write-api.md
@@ -43,6 +43,12 @@ Base URL: `https://vi-api.vedur.is/tos/v1`
 | PATCH | `/attribute_value/{id_attribute_value}` | JWT | Edit existing value (value, date_from, date_to — any combination) |
 | POST | `/joins` | JWT | Create parent→child entity connection |
 | PATCH | `/join/{id_connection}` | JWT | Modify a join record (e.g. close a device session) |
+| GET | `/entity/parent_history/{id_child}` | None | List all (open + closed) parent connections of a child entity |
+| POST | `/basic_search/` | None | Fuzzy search by attribute code/value (returns `distance` per hit) |
+| POST | `/maintenances/id_entity/{id_entity}` | JWT | Create vitjun stub; seeds blank attribute-value rows. Returns `{id, …}` but NOT the seeded value IDs |
+| GET | `/maintenances/id_entity/{id_entity}` | None | List vitjun records for an entity (flat web-UI shape) |
+| GET | `/maintenance/id_maintenance/{id}` | None | One vitjun's full detail incl. `maintenance_attribute_values[]` with each row's `id_maintenance_attribute_value` |
+| PUT | `/maintenance/id_maintenance/{id}` | JWT | Fill in vitjun details: `participants`, dates, `completed`, list of `{id_maintenance_attribute_value, value}` |
 
 ## Python Client
 
@@ -68,6 +74,11 @@ The JWT is kept in memory only. `TOSWriter` re-authenticates when the token is w
 - `patch_attribute_value(id_attribute_value, *, value, date_from, date_to)` — PATCH, only non-None fields sent
 - `create_entity_connection(id_parent, id_child, time_from, time_to=None)` — POST `/joins`
 - `patch_entity_connection(id_connection, **kwargs)` — PATCH `/join/{id}`
+- `find_station_by_marker(marker)` — case-insensitive RINEX-marker → `id_entity` lookup; filters to `type_lvl_two="stöð"`
+- `get_open_parent_join(id_child)` — GET `/entity/parent_history/{id}`, return the row with `time_to is None`
+- `move_device(id_device, to_id_entity, transition_date, from_id_entity=None)` — **Pattern 2 for joins** (close open parent + open new), see below
+- `list_maintenance_visits(id_entity)` / `get_maintenance_visit(id_maintenance)` — read vitjun
+- `add_maintenance_visit(id_entity, *, start_time, end_time=None, maintenance_type, participants, reasons, work, comment, remaining, completed)` — 3-call POST + GET + PUT flow for creating vitjun
 
 ## Write Patterns
 
@@ -101,6 +112,46 @@ writer.add_attribute_value(id_entity, "altitude", "112.5", "2019-06-01T00:00:00"
 
 Same as Pattern 1 but targets a historical record. `upsert_attribute_value` operates on the most recent open value; for a closed period, use `get_attribute_values()` to locate the record by `date_from`, then call `patch_attribute_value()` directly.
 
+### Pattern 2 for joins (device move)
+
+Pattern 2 also applies to *joins* — closing the open parent connection and opening a new one is how devices change locations (warehouse → station, station → station, station → warehouse). Use `move_device()`:
+
+```python
+# Auto-detect from (B9 warehouse 4) → HRAC station 16096:
+writer.move_device(id_device=21501, to_id_entity=16096,
+                   transition_date="2026-05-22")
+
+# Sanity-check the current parent (raises ValueError on mismatch):
+writer.move_device(21501, 16096, "2026-05-22", from_id_entity=4)
+```
+
+The transition date sets `time_to` on the closed join and `time_from` on the new one (same string for both — TOS allows back-to-back joins with no gap). Bare dates (`"2026-05-22"`) are promoted to midnight by `_tos_date()`.
+
+### Vitjun (maintenance / station visit)
+
+A vitjun is created in three round-trips because TOS does not return the auto-seeded attribute-value IDs on POST:
+
+```python
+writer.add_maintenance_visit(
+    id_entity=16096,                        # station HRAC
+    start_time="2026-05-22",                # accepts YYYY-MM-DD or full ISO
+    maintenance_type="on_site",             # or "remote" (Fjarvitjun)
+    participants="bgo@vedur.is",            # comma-sep emails
+    reasons=["change"],                     # multi-select; allowed:
+                                            # change/repairs/inspection/improvements/other
+    work="Skipt um móttakara",              # Framkvæmt
+    comment=None,                           # Athugasemdir (None → leave default)
+    remaining=None,                         # Útistandandi
+    completed=True,
+)
+```
+
+Internally: POST `/maintenances/id_entity/{id_entity}` → GET `/maintenance/id_maintenance/{new_id}` to discover seeded `id_maintenance_attribute_value` per code (`reason_change`, `work`, etc.) → PUT `/maintenance/id_maintenance/{new_id}` with the value list.
+
+Reason fields are stored as **booleans** ("true"/"false") — multiple can be true on one vitjun. Text fields not passed (`None`) are left at the seeded default (empty string).
+
+In `dry_run=True` mode the POST short-circuits and returns `id_maintenance="<dry-run>"` — the GET + PUT roundtrip cannot be simulated without a real ID.
+
 ## IGS Equipment Name Convention
 
 TOS stores equipment names in IGS rcvr_ant.tab format: `"SEPT POLARX5"`, `"TRIMBLE NETR9"`, `"LEICA GR10"`, `"SEPPOLANT X_MF"`, `"NONE"` (for no radome). The `receivers` health system reports abbreviated names (`"PolaRx5"`, `"NetR9"`). Convert before writing:
@@ -132,4 +183,5 @@ the attribute and join verbs for routine metadata writes.
 
 ## Future Work
 
-- **Join record updates** — Device session start/end dates live in the join record. `patch_entity_connection` is implemented but not yet wired to any reconcile workflow.
+- **Join record updates** — Device session start/end dates live in the join record. `patch_entity_connection` is implemented but not yet wired to any reconcile workflow. `move_device()` now covers the close+open flow for receiver/antenna installs.
+- **CLI verbs** — The `tos` CLI today only exposes read verbs. `move_device` and `add_maintenance_visit` are reached from the `receivers cfg install-device` / `receivers cfg visit` workflow (see `receivers/CLAUDE.md`). A standalone `tos device move` / `tos visit add` is open work.

--- a/src/tostools/api/tos_writer.py
+++ b/src/tostools/api/tos_writer.py
@@ -961,6 +961,32 @@ class TOSWriter:
                 kwargs[key] = self._tos_date(kwargs[key])
         return self._request("PATCH", f"/join/{id_connection}", data=kwargs)
 
+    def delete_entity_connection(self, id_connection: int) -> Any:
+        """Permanently remove a join row from TOS.
+
+        .. warning::
+
+           Destructive admin endpoint. Use only for cleaning up known
+           bad rows (e.g. zero-duration orphans created by historical
+           bugs in add-device flows). The default :meth:`move_device`
+           workflow closes joins via PATCH; deletion erases history.
+
+        Uses ``DELETE /admin_entity_connection_row/{id}``. Requires
+        admin-level TOS access.
+
+        Args:
+            id_connection: The ``id`` of the join row (e.g. from
+                :meth:`get_open_parent_join` or
+                ``/entity/parent_history/{id_child}``).
+
+        Returns:
+            API response (typically empty 204), or
+            :class:`DryRunResult` in dry-run mode.
+        """
+        return self._request(
+            "DELETE", f"/admin_entity_connection_row/{id_connection}"
+        )
+
     def transition_attribute_value(
         self,
         id_entity: int,
@@ -1066,6 +1092,487 @@ class TOSWriter:
             f"/admin_entity_row/{id_entity}",
             data={"id_entity_subtype": int(id_entity_subtype)},
         )
+
+    # ---------------------------------------------------------------------
+    # Station resolution
+    # ---------------------------------------------------------------------
+
+    def find_station_by_marker(
+        self,
+        marker: str,
+        type_filter: str = "stöð",
+    ) -> Optional[int]:
+        """Look up a GPS station entity by its 4-char marker code.
+
+        Wraps ``POST /basic_search/`` looking for hits with
+        ``code='marker'``, ``distance=0``, and an exact case-insensitive
+        match on ``value_varchar``. TOS records markers in lowercase
+        (e.g. ``"hrac"``); we lowercase the needle for comparison so
+        callers can pass either ``"HRAC"`` or ``"hrac"``.
+
+        Args:
+            marker: 4-character RINEX marker.
+            type_filter: Restrict to a TOS ``type_lvl_two`` (default
+                ``"stöð"`` for any station). Empty / ``None`` disables
+                the type filter.
+
+        Returns:
+            The station's ``id_entity`` or ``None`` if no exact match.
+        """
+        if not marker:
+            return None
+        needle = marker.lower()
+        results = self._request(
+            "POST",
+            "/basic_search/",
+            data={"search_term": needle},
+            _force_send=True,
+        )
+        if not isinstance(results, list):
+            return None
+        for hit in results:
+            if hit.get("code") != "marker":
+                continue
+            if hit.get("distance") != 0:
+                continue
+            if (hit.get("value_varchar") or "").lower() != needle:
+                continue
+            if type_filter and hit.get("type_lvl_two") != type_filter:
+                continue
+            entity_id = hit.get("id_entity") or hit.get("id_lvl_two")
+            if entity_id:
+                return int(entity_id)
+        return None
+
+    # ---------------------------------------------------------------------
+    # Entity-connection (join) helpers — Pattern 2 for joins
+    # ---------------------------------------------------------------------
+
+    def get_open_parent_join(self, id_child: int) -> Optional[Dict[str, Any]]:
+        """Return the currently-open parent connection of an entity.
+
+        Queries ``GET /entity/parent_history/{id_child}`` and filters
+        to the join whose ``time_to is None``. The TOS invariant is
+        "at most one open parent join per child" (a receiver is at
+        one location at a time); if multiple are open, the most
+        recent ``time_from`` wins.
+
+        Args:
+            id_child: Child entity id (e.g. a gnss_receiver's
+                id_entity).
+
+        Returns:
+            Dict with keys ``id``, ``id_entity_child``,
+            ``id_entity_parent``, ``time_from``, ``time_to``, or
+            ``None`` if no open join exists.
+        """
+        history = self._request("GET", f"/entity/parent_history/{id_child}")
+        if not isinstance(history, list):
+            return None
+        open_joins = [j for j in history if j.get("time_to") is None]
+        if not open_joins:
+            return None
+        return max(open_joins, key=lambda j: j.get("time_from") or "")
+
+    def move_device(
+        self,
+        id_device: int,
+        to_id_entity: int,
+        transition_date: str,
+        from_id_entity: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """Move a device between parents (Pattern 2 for joins).
+
+        Closes the currently-open parent connection at
+        ``transition_date`` and opens a new one to ``to_id_entity``
+        from the same date. Two HTTP calls
+        (``PATCH /join/{id}`` + ``POST /joins``).
+
+        Canonical use cases:
+          - Warehouse → station install
+          - Station A → station B transfer
+          - Station → warehouse retire/decommission
+
+        Args:
+            id_device: The device entity to move.
+            to_id_entity: The destination entity (station, warehouse,
+                …).
+            transition_date: ISO-8601 date or datetime for both close
+                of old and open of new. ``YYYY-MM-DD`` is accepted and
+                promoted to a full datetime by :meth:`_tos_date`.
+            from_id_entity: If given, sanity-check that the open join
+                is from this parent (raises ``ValueError`` otherwise).
+                If ``None``, auto-detect from the open join.
+
+        Returns:
+            ``{"closed": <patch_response>, "opened": <post_response>,
+               "from_id_entity": <int|None>, "to_id_entity": <int>}``.
+            ``closed`` is ``None`` when no pre-existing open parent
+            existed — caller decides whether that's an error.
+        """
+        normalized = self._tos_date(transition_date)
+        assert normalized is not None, "transition_date is required"
+        open_join = self.get_open_parent_join(id_device)
+        closed_resp: Any = None
+        detected_from: Optional[int] = None
+        if open_join is not None:
+            detected_from = open_join.get("id_entity_parent")
+            if from_id_entity is not None and detected_from != from_id_entity:
+                raise ValueError(
+                    f"move_device: device {id_device} is currently under "
+                    f"parent {detected_from}, not the expected "
+                    f"{from_id_entity}"
+                )
+            id_conn = open_join.get("id")
+            if id_conn is not None:
+                closed_resp = self.patch_entity_connection(
+                    int(id_conn), time_to=normalized
+                )
+        opened_resp = self.create_entity_connection(
+            id_parent=to_id_entity,
+            id_child=id_device,
+            time_from=normalized,
+            time_to=None,
+        )
+        return {
+            "closed": closed_resp,
+            "opened": opened_resp,
+            "from_id_entity": detected_from,
+            "to_id_entity": to_id_entity,
+        }
+
+    # ---------------------------------------------------------------------
+    # Maintenance (vitjun)
+    # ---------------------------------------------------------------------
+
+    #: Reason codes accepted by :meth:`add_maintenance_visit`. Each maps
+    #: to a ``reason_*`` boolean attribute on the maintenance record.
+    MAINTENANCE_REASON_CODES = frozenset(
+        {"change", "repairs", "inspection", "improvements", "other"}
+    )
+
+    def list_maintenance_visits(self, id_entity: int) -> List[Dict[str, Any]]:
+        """List all vitjun (maintenance) records for an entity.
+
+        Returns the flat shape used by the TOS web UI (``reason``,
+        ``work``, ``remaining``, ``participants``,
+        ``participants_names``, ``maintenance_type``, ``start_time``,
+        ``end_time``, ``completed``, ``id``).
+
+        Args:
+            id_entity: Entity to query (e.g. a station's id_entity).
+
+        Returns:
+            List of maintenance dicts, oldest first. Empty list if
+            none exist or the entity is unknown.
+        """
+        result = self._request("GET", f"/maintenances/id_entity/{id_entity}")
+        return result if isinstance(result, list) else []
+
+    def get_maintenance_visit(
+        self, id_maintenance: int
+    ) -> Optional[Dict[str, Any]]:
+        """Return full detail for one vitjun, including attribute rows.
+
+        Unlike :meth:`list_maintenance_visits`, this returns the
+        ``maintenance_attribute_values`` array with each row's
+        ``id_maintenance_attribute_value`` — needed to PUT updates.
+
+        Args:
+            id_maintenance: The maintenance record's primary key.
+
+        Returns:
+            Detail dict, or ``None`` if not found. Keys include
+            ``id_maintenance``, ``maintenance_type``, ``start_time``,
+            ``end_time``, ``participants``, ``completed``,
+            ``maintenance_attribute_values``, and ``employees``.
+        """
+        result = self._request(
+            "GET", f"/maintenance/id_maintenance/{id_maintenance}"
+        )
+        return result if isinstance(result, dict) else None
+
+    def add_maintenance_visit(
+        self,
+        id_entity: int,
+        *,
+        start_time: str,
+        end_time: Optional[str] = None,
+        maintenance_type: str = "on_site",
+        participants: str = "",
+        reasons: Optional[List[str]] = None,
+        work: Optional[str] = None,
+        comment: Optional[str] = None,
+        remaining: Optional[str] = None,
+        completed: bool = True,
+    ) -> Dict[str, Any]:
+        """Create a new vitjun (visit/maintenance record) on an entity.
+
+        Three-call flow:
+          1. ``POST /maintenances/id_entity/{id_entity}`` — creates
+             the record and auto-seeds ``maintenance_attribute_value``
+             rows for the applicable maintenance attributes.
+          2. ``GET /maintenance/id_maintenance/{new_id}`` — discover
+             the seeded value-row IDs (TOS does not return them on
+             POST).
+          3. ``PUT /maintenance/id_maintenance/{new_id}`` — fill in
+             the slots requested (reason booleans + work / comment /
+             remaining text).
+
+        Args:
+            id_entity: Target station (id_entity).
+            start_time: ISO-8601 datetime the visit started. Accepts
+                ``YYYY-MM-DD`` (promoted to midnight) or a full ISO
+                datetime.
+            end_time: ISO-8601 datetime the visit ended. Defaults to
+                ``start_time`` (instantaneous visit).
+            maintenance_type: ``"on_site"`` (Staðarvitjun) or
+                ``"remote"`` (Fjarvitjun). Default ``"on_site"``.
+            participants: Comma-separated emails (e.g.
+                ``"bgo@vedur.is,bhb@vedur.is"``). TOS resolves to
+                ``participants_names`` on read.
+            reasons: Subset of
+                :attr:`MAINTENANCE_REASON_CODES`. Each maps to the
+                ``reason_*`` boolean. Default ``None`` = no reasons
+                set true. Unknown codes raise ``ValueError``.
+            work: Free-text "Framkvæmt" / "Vinna" description.
+            comment: Free-text "Athugasemdir".
+            remaining: Free-text "Útistandandi" outstanding work.
+            completed: Whether the visit is closed. Default ``True``.
+
+        Returns:
+            ``{"id_maintenance": <new_id>, "created": <post_response>,
+               "updated": <put_response>}``. In dry-run mode the
+            create step returns a :class:`DryRunResult` and the
+            method short-circuits with ``id_maintenance="<dry-run>"``
+            and ``updated=None`` (we cannot discover seeded IDs
+            without sending the POST).
+        """
+        if reasons:
+            unknown = set(reasons) - self.MAINTENANCE_REASON_CODES
+            if unknown:
+                raise ValueError(
+                    f"add_maintenance_visit: unknown reason codes "
+                    f"{sorted(unknown)} — allowed: "
+                    f"{sorted(self.MAINTENANCE_REASON_CODES)}"
+                )
+        if maintenance_type not in ("on_site", "remote"):
+            raise ValueError(
+                f"add_maintenance_visit: maintenance_type must be "
+                f"'on_site' or 'remote', got {maintenance_type!r}"
+            )
+
+        norm_start = self._tos_date(start_time)
+        norm_end = self._tos_date(end_time or start_time)
+
+        created = self._request(
+            "POST",
+            f"/maintenances/id_entity/{id_entity}",
+            data={
+                "maintenance_type": maintenance_type,
+                "start_time": norm_start,
+                "end_time": norm_end,
+            },
+        )
+
+        if isinstance(created, DryRunResult):
+            return {
+                "id_maintenance": "<dry-run>",
+                "created": created,
+                "updated": None,
+            }
+
+        new_id = created.get("id") if isinstance(created, dict) else None
+        if new_id is None:
+            raise RuntimeError(
+                f"add_maintenance_visit: POST returned no id; got "
+                f"{created!r}"
+            )
+        new_id = int(new_id)
+
+        detail = self.get_maintenance_visit(new_id)
+        if not detail:
+            raise RuntimeError(
+                f"add_maintenance_visit: created maintenance {new_id} "
+                f"but the follow-up GET returned no detail (cannot "
+                f"discover seeded attribute IDs)"
+            )
+
+        by_code: Dict[str, int] = {}
+        for av in detail.get("maintenance_attribute_values") or []:
+            code = av.get("code")
+            av_id = av.get("id_maintenance_attribute_value")
+            if code and av_id is not None and code not in by_code:
+                by_code[code] = int(av_id)
+
+        values: List[Dict[str, Any]] = []
+        reason_set = set(reasons or [])
+        for r in ("change", "repairs", "inspection", "improvements", "other"):
+            attr_code = f"reason_{r}"
+            if attr_code in by_code:
+                values.append(
+                    {
+                        "id_maintenance_attribute_value": by_code[attr_code],
+                        "value": "true" if r in reason_set else "false",
+                    }
+                )
+        for code, value in (
+            ("work", work),
+            ("comment", comment),
+            ("remaining", remaining),
+        ):
+            if value is not None and code in by_code:
+                values.append(
+                    {
+                        "id_maintenance_attribute_value": by_code[code],
+                        "value": value,
+                    }
+                )
+
+        updated = self._request(
+            "PUT",
+            f"/maintenance/id_maintenance/{new_id}",
+            data={
+                "participants": participants,
+                "start_time": norm_start,
+                "end_time": norm_end,
+                "completed": completed,
+                "maintenance_attribute_values": values,
+            },
+        )
+        return {
+            "id_maintenance": new_id,
+            "created": created,
+            "updated": updated,
+        }
+
+    def update_maintenance_visit(
+        self,
+        id_maintenance: int,
+        *,
+        start_time: Optional[str] = None,
+        end_time: Optional[str] = None,
+        participants: Optional[str] = None,
+        completed: Optional[bool] = None,
+        reasons: Optional[List[str]] = None,
+        work: Optional[str] = None,
+        comment: Optional[str] = None,
+        remaining: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Edit an existing vitjun (maintenance) record in place.
+
+        TOS only exposes a full-record PUT, so this method fetches the
+        current state, merges in only the fields the caller supplied,
+        and re-PUTs the result. Fields passed as ``None`` are
+        preserved at their current TOS values; explicit ``""`` is a
+        write (sets the field to empty).
+
+        ``reasons`` is a *replacement* set: passing
+        ``reasons=["change"]`` sets ``reason_change=true`` and all
+        other reason booleans to ``false``. Pass ``None`` (or omit) to
+        preserve the current reason flags entirely.
+
+        Args:
+            id_maintenance: ``id_maintenance`` of the vitjun to edit.
+            start_time / end_time / participants / completed: See
+                :meth:`add_maintenance_visit`.
+            reasons: Replacement reason set or ``None`` to preserve.
+            work / comment / remaining: New text or ``None`` to
+                preserve.
+
+        Returns:
+            ``{"id_maintenance": int, "updated": <put_response>,
+               "before": <prior_state>, "after": <merged_payload>}``.
+            In dry-run mode the PUT step returns a
+            :class:`DryRunResult` but the merge is still computed so
+            callers can review the payload via ``after``.
+
+        Raises:
+            RuntimeError: If the maintenance id is unknown to TOS.
+            ValueError: For unknown reason codes.
+        """
+        if reasons:
+            unknown = set(reasons) - self.MAINTENANCE_REASON_CODES
+            if unknown:
+                raise ValueError(
+                    f"update_maintenance_visit: unknown reason codes "
+                    f"{sorted(unknown)} — allowed: "
+                    f"{sorted(self.MAINTENANCE_REASON_CODES)}"
+                )
+
+        current = self.get_maintenance_visit(id_maintenance)
+        if not current:
+            raise RuntimeError(
+                f"update_maintenance_visit: no maintenance with id "
+                f"{id_maintenance} (GET returned empty)"
+            )
+
+        merged_start = (
+            self._tos_date(start_time) if start_time is not None
+            else current.get("start_time")
+        )
+        merged_end = (
+            self._tos_date(end_time) if end_time is not None
+            else current.get("end_time")
+        )
+        merged_participants = (
+            participants if participants is not None
+            else (current.get("participants") or "")
+        )
+        merged_completed = (
+            completed if completed is not None
+            else bool(current.get("completed", True))
+        )
+
+        # Build the attribute_values list — preserve every current
+        # row's value unless caller overrides via reasons / work /
+        # comment / remaining.
+        reason_set = set(reasons) if reasons is not None else None
+        text_overrides = {"work": work, "comment": comment, "remaining": remaining}
+
+        values: List[Dict[str, Any]] = []
+        for av in current.get("maintenance_attribute_values") or []:
+            code = av.get("code")
+            av_id = av.get("id_maintenance_attribute_value")
+            if code is None or av_id is None:
+                continue
+
+            if code.startswith("reason_") and reason_set is not None:
+                # Replacement mode — set per the new reason set
+                reason_key = code[len("reason_"):]
+                new_val = "true" if reason_key in reason_set else "false"
+            elif code in text_overrides and text_overrides[code] is not None:
+                new_val = text_overrides[code]
+            else:
+                # Preserve current value
+                new_val = av.get("value", "")
+
+            values.append(
+                {
+                    "id_maintenance_attribute_value": int(av_id),
+                    "value": new_val,
+                }
+            )
+
+        payload = {
+            "participants": merged_participants,
+            "start_time": merged_start,
+            "end_time": merged_end,
+            "completed": merged_completed,
+            "maintenance_attribute_values": values,
+        }
+
+        updated = self._request(
+            "PUT",
+            f"/maintenance/id_maintenance/{id_maintenance}",
+            data=payload,
+        )
+        return {
+            "id_maintenance": id_maintenance,
+            "updated": updated,
+            "before": current,
+            "after": payload,
+        }
 
 
 # ---------------------------------------------------------------------------

--- a/src/tostools/api/tos_writer.py
+++ b/src/tostools/api/tos_writer.py
@@ -983,9 +983,7 @@ class TOSWriter:
             API response (typically empty 204), or
             :class:`DryRunResult` in dry-run mode.
         """
-        return self._request(
-            "DELETE", f"/admin_entity_connection_row/{id_connection}"
-        )
+        return self._request("DELETE", f"/admin_entity_connection_row/{id_connection}")
 
     def transition_attribute_value(
         self,
@@ -1269,9 +1267,7 @@ class TOSWriter:
         result = self._request("GET", f"/maintenances/id_entity/{id_entity}")
         return result if isinstance(result, list) else []
 
-    def get_maintenance_visit(
-        self, id_maintenance: int
-    ) -> Optional[Dict[str, Any]]:
+    def get_maintenance_visit(self, id_maintenance: int) -> Optional[Dict[str, Any]]:
         """Return full detail for one vitjun, including attribute rows.
 
         Unlike :meth:`list_maintenance_visits`, this returns the
@@ -1287,9 +1283,7 @@ class TOSWriter:
             ``end_time``, ``participants``, ``completed``,
             ``maintenance_attribute_values``, and ``employees``.
         """
-        result = self._request(
-            "GET", f"/maintenance/id_maintenance/{id_maintenance}"
-        )
+        result = self._request("GET", f"/maintenance/id_maintenance/{id_maintenance}")
         return result if isinstance(result, dict) else None
 
     def add_maintenance_visit(
@@ -1385,8 +1379,7 @@ class TOSWriter:
         new_id = created.get("id") if isinstance(created, dict) else None
         if new_id is None:
             raise RuntimeError(
-                f"add_maintenance_visit: POST returned no id; got "
-                f"{created!r}"
+                f"add_maintenance_visit: POST returned no id; got " f"{created!r}"
             )
         new_id = int(new_id)
 
@@ -1508,20 +1501,22 @@ class TOSWriter:
             )
 
         merged_start = (
-            self._tos_date(start_time) if start_time is not None
+            self._tos_date(start_time)
+            if start_time is not None
             else current.get("start_time")
         )
         merged_end = (
-            self._tos_date(end_time) if end_time is not None
+            self._tos_date(end_time)
+            if end_time is not None
             else current.get("end_time")
         )
         merged_participants = (
-            participants if participants is not None
+            participants
+            if participants is not None
             else (current.get("participants") or "")
         )
         merged_completed = (
-            completed if completed is not None
-            else bool(current.get("completed", True))
+            completed if completed is not None else bool(current.get("completed", True))
         )
 
         # Build the attribute_values list — preserve every current
@@ -1539,7 +1534,7 @@ class TOSWriter:
 
             if code.startswith("reason_") and reason_set is not None:
                 # Replacement mode — set per the new reason set
-                reason_key = code[len("reason_"):]
+                reason_key = code[len("reason_") :]
                 new_val = "true" if reason_key in reason_set else "false"
             elif code in text_overrides and text_overrides[code] is not None:
                 new_val = text_overrides[code]

--- a/tests/test_tos_writer.py
+++ b/tests/test_tos_writer.py
@@ -955,3 +955,642 @@ def test_create_device_raises_with_empty_serial():
                 }
             ],
         )
+
+
+# ---------------------------------------------------------------------------
+# find_station_by_marker
+# ---------------------------------------------------------------------------
+
+
+def _basic_search_marker_hit(
+    marker: str,
+    entity_id: int,
+    type_lvl_two: str = "stöð",
+    distance: int = 0,
+) -> dict:
+    """Mirror the basic_search hit shape for a marker-attribute match."""
+    return {
+        "code": "marker",
+        "value_varchar": marker,
+        "distance": distance,
+        "id_entity": entity_id,
+        "id_lvl_two": entity_id,
+        "id_lvl_three": None,
+        "type_lvl_two": type_lvl_two,
+        "subtype_lvl_two": "geophysical",
+    }
+
+
+def test_find_station_by_marker_returns_id_on_exact_match():
+    w = _logged_in_writer(dry_run=False)
+    hits = [_basic_search_marker_hit("hrac", entity_id=16096)]
+    with patch.object(w, "_request", return_value=hits):
+        assert w.find_station_by_marker("HRAC") == 16096
+
+
+def test_find_station_by_marker_is_case_insensitive():
+    """TOS stores markers lowercase; the helper accepts either case."""
+    w = _logged_in_writer(dry_run=False)
+    hits = [_basic_search_marker_hit("hrac", entity_id=16096)]
+    with patch.object(w, "_request", return_value=hits):
+        assert w.find_station_by_marker("hrac") == 16096
+    with patch.object(w, "_request", return_value=hits):
+        assert w.find_station_by_marker("Hrac") == 16096
+
+
+def test_find_station_by_marker_returns_none_on_no_match():
+    w = _logged_in_writer(dry_run=False)
+    with patch.object(w, "_request", return_value=[]):
+        assert w.find_station_by_marker("XXXX") is None
+
+
+def test_find_station_by_marker_filters_distance_value_and_type():
+    w = _logged_in_writer(dry_run=False)
+    hits = [
+        _basic_search_marker_hit("hraf", entity_id=999, distance=1),
+        _basic_search_marker_hit("save", entity_id=998),
+        _basic_search_marker_hit(
+            "hrac", entity_id=997, type_lvl_two="vöruhús"
+        ),
+        _basic_search_marker_hit("hrac", entity_id=16096),
+    ]
+    with patch.object(w, "_request", return_value=hits):
+        assert w.find_station_by_marker("HRAC") == 16096
+
+
+def test_find_station_by_marker_empty_short_circuits():
+    w = _logged_in_writer(dry_run=False)
+    with patch.object(w, "_request") as mock_req:
+        assert w.find_station_by_marker("") is None
+    mock_req.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# get_open_parent_join / move_device — Pattern 2 for joins
+# ---------------------------------------------------------------------------
+
+
+def test_get_open_parent_join_returns_open_one():
+    w = _logged_in_writer(dry_run=False)
+    history = [
+        {
+            "id": 100,
+            "id_entity_child": 21501,
+            "id_entity_parent": 1,
+            "time_from": "2020-01-01T00:00:00",
+            "time_to": "2026-05-21T00:00:00",
+        },
+        {
+            "id": 200,
+            "id_entity_child": 21501,
+            "id_entity_parent": 4,
+            "time_from": "2026-05-21T00:00:00",
+            "time_to": None,
+        },
+    ]
+    with patch.object(w, "_request", return_value=history):
+        join = w.get_open_parent_join(21501)
+    assert join is not None
+    assert join["id"] == 200
+    assert join["id_entity_parent"] == 4
+
+
+def test_get_open_parent_join_returns_none_when_no_open():
+    w = _logged_in_writer(dry_run=False)
+    history = [
+        {
+            "id": 100,
+            "id_entity_parent": 1,
+            "time_from": "2020-01-01T00:00:00",
+            "time_to": "2026-05-21T00:00:00",
+        },
+    ]
+    with patch.object(w, "_request", return_value=history):
+        assert w.get_open_parent_join(21501) is None
+
+
+def test_get_open_parent_join_handles_multiple_open():
+    """Defensive: if TOS has >1 open join (invariant violation), pick newest."""
+    w = _logged_in_writer(dry_run=False)
+    history = [
+        {
+            "id": 100,
+            "id_entity_parent": 1,
+            "time_from": "2020-01-01T00:00:00",
+            "time_to": None,
+        },
+        {
+            "id": 200,
+            "id_entity_parent": 4,
+            "time_from": "2026-05-21T00:00:00",
+            "time_to": None,
+        },
+    ]
+    with patch.object(w, "_request", return_value=history):
+        join = w.get_open_parent_join(21501)
+    assert join is not None
+    assert join["id"] == 200
+
+
+def test_move_device_closes_old_and_opens_new():
+    w = _logged_in_writer(dry_run=False)
+    open_join = {
+        "id": 28698,
+        "id_entity_child": 21501,
+        "id_entity_parent": 4,
+        "time_from": "2026-05-21T00:00:00",
+        "time_to": None,
+    }
+    with patch.object(w, "_request") as mock_req:
+        mock_req.side_effect = [
+            [open_join],
+            {"id": 28698, "time_to": "2026-05-22T00:00:00"},
+            {"id_connection": 28699},
+        ]
+        result = w.move_device(21501, 16096, "2026-05-22")
+    assert result["from_id_entity"] == 4
+    assert result["to_id_entity"] == 16096
+    methods = [c.args[0] for c in mock_req.call_args_list]
+    assert methods == ["GET", "PATCH", "POST"]
+    patch_call = mock_req.call_args_list[1]
+    assert patch_call.args[1] == "/join/28698"
+    assert patch_call.kwargs["data"]["time_to"] == "2026-05-22T00:00:00"
+    post_call = mock_req.call_args_list[2]
+    assert post_call.args[1] == "/joins"
+    assert post_call.kwargs["data"]["id_entity_parent"] == 16096
+    assert post_call.kwargs["data"]["id_entity_child"] == 21501
+    assert post_call.kwargs["data"]["time_from"] == "2026-05-22T00:00:00"
+    assert post_call.kwargs["data"]["time_to"] is None
+
+
+def test_move_device_when_no_open_join_still_opens_new():
+    """Floating device (no open parent) — move_device just opens new join."""
+    w = _logged_in_writer(dry_run=False)
+    with patch.object(w, "_request") as mock_req:
+        mock_req.side_effect = [[], {"id_connection": 99}]
+        result = w.move_device(21501, 16096, "2026-05-22")
+    assert result["closed"] is None
+    assert result["from_id_entity"] is None
+    methods = [c.args[0] for c in mock_req.call_args_list]
+    assert methods == ["GET", "POST"]
+
+
+def test_move_device_raises_when_from_mismatch():
+    w = _logged_in_writer(dry_run=False)
+    open_join = {
+        "id": 100,
+        "id_entity_parent": 4,
+        "time_from": "2026-05-21T00:00:00",
+        "time_to": None,
+    }
+    with patch.object(w, "_request", return_value=[open_join]):
+        with pytest.raises(ValueError, match="currently under parent 4"):
+            w.move_device(21501, 16096, "2026-05-22", from_id_entity=999)
+
+
+def test_move_device_promotes_bare_date():
+    """transition_date as YYYY-MM-DD must promote to full datetime."""
+    w = _logged_in_writer(dry_run=False)
+    open_join = {
+        "id": 100,
+        "id_entity_parent": 4,
+        "time_from": "2026-05-21T00:00:00",
+        "time_to": None,
+    }
+    with patch.object(w, "_request") as mock_req:
+        mock_req.side_effect = [[open_join], {}, {"id_connection": 99}]
+        w.move_device(21501, 16096, "2026-05-22")
+    assert mock_req.call_args_list[1].kwargs["data"]["time_to"] == (
+        "2026-05-22T00:00:00"
+    )
+    assert mock_req.call_args_list[2].kwargs["data"]["time_from"] == (
+        "2026-05-22T00:00:00"
+    )
+
+
+def test_move_device_dry_run_returns_dry_run_results():
+    w = _logged_in_writer(dry_run=True)
+    open_join = {
+        "id": 100,
+        "id_entity_parent": 4,
+        "time_from": "2026-05-21T00:00:00",
+        "time_to": None,
+    }
+
+    def side_effect(method, path, *_a, **kw):
+        if method == "GET":
+            return [open_join]
+        return DryRunResult(method=method, endpoint=path, payload=kw.get("data"))
+
+    with patch.object(w, "_request", side_effect=side_effect):
+        result = w.move_device(21501, 16096, "2026-05-22")
+    assert isinstance(result["closed"], DryRunResult)
+    assert isinstance(result["opened"], DryRunResult)
+
+
+# ---------------------------------------------------------------------------
+# Maintenance / vitjun
+# ---------------------------------------------------------------------------
+
+
+def _maintenance_detail_with_seeded_attrs(
+    id_maintenance: int = 9999,
+    base: int = 80000,
+) -> dict:
+    """Realistic detail-GET shape, with auto-seeded attribute_value rows."""
+    return {
+        "id_maintenance": id_maintenance,
+        "maintenance_type": "on_site",
+        "start_time": "2026-05-22T00:00:00",
+        "end_time": "2026-05-22T00:00:00",
+        "participants": "",
+        "completed": False,
+        "maintenance_attribute_values": [
+            {
+                "code": "reason_change",
+                "id_maintenance_attribute_value": base + 1,
+                "value": "false",
+            },
+            {
+                "code": "reason_repairs",
+                "id_maintenance_attribute_value": base + 2,
+                "value": "false",
+            },
+            {
+                "code": "reason_inspection",
+                "id_maintenance_attribute_value": base + 3,
+                "value": "false",
+            },
+            {
+                "code": "reason_improvements",
+                "id_maintenance_attribute_value": base + 4,
+                "value": "false",
+            },
+            {
+                "code": "reason_other",
+                "id_maintenance_attribute_value": base + 5,
+                "value": "false",
+            },
+            {
+                "code": "work",
+                "id_maintenance_attribute_value": base + 6,
+                "value": "",
+            },
+            {
+                "code": "comment",
+                "id_maintenance_attribute_value": base + 7,
+                "value": "",
+            },
+            {
+                "code": "remaining",
+                "id_maintenance_attribute_value": base + 8,
+                "value": "",
+            },
+        ],
+        "employees": [],
+    }
+
+
+def test_list_maintenance_visits_returns_list():
+    w = _logged_in_writer(dry_run=False)
+    sample = [{"id": 5146, "maintenance_type": "on_site", "reason": "Breyting"}]
+    with patch.object(w, "_request", return_value=sample) as mock_req:
+        assert w.list_maintenance_visits(16096) == sample
+    mock_req.assert_called_once_with("GET", "/maintenances/id_entity/16096")
+
+
+def test_list_maintenance_visits_empty_when_not_list():
+    w = _logged_in_writer(dry_run=False)
+    with patch.object(w, "_request", return_value={"error": "404"}):
+        assert w.list_maintenance_visits(99999) == []
+
+
+def test_get_maintenance_visit_returns_dict():
+    w = _logged_in_writer(dry_run=False)
+    sample = {"id_maintenance": 5146, "maintenance_attribute_values": []}
+    with patch.object(w, "_request", return_value=sample) as mock_req:
+        assert w.get_maintenance_visit(5146) == sample
+    mock_req.assert_called_once_with("GET", "/maintenance/id_maintenance/5146")
+
+
+def test_add_maintenance_visit_validates_unknown_reason():
+    w = _logged_in_writer(dry_run=False)
+    with pytest.raises(ValueError, match="unknown reason codes"):
+        w.add_maintenance_visit(
+            16096, start_time="2026-05-22", reasons=["nope", "change"]
+        )
+
+
+def test_add_maintenance_visit_validates_maintenance_type():
+    w = _logged_in_writer(dry_run=False)
+    with pytest.raises(ValueError, match="maintenance_type must be"):
+        w.add_maintenance_visit(
+            16096, start_time="2026-05-22", maintenance_type="onsite"
+        )
+
+
+def test_add_maintenance_visit_three_call_flow():
+    """POST + GET + PUT with discovered attribute IDs."""
+    w = _logged_in_writer(dry_run=False)
+    created = {
+        "id": 9999,
+        "maintenance_type": "on_site",
+        "start_time": "2026-05-22T00:00:00",
+        "end_time": "2026-05-22T00:00:00",
+    }
+    detail = _maintenance_detail_with_seeded_attrs(9999, base=80000)
+    put_resp = {"ok": True}
+    with patch.object(w, "_request") as mock_req:
+        mock_req.side_effect = [created, detail, put_resp]
+        result = w.add_maintenance_visit(
+            16096,
+            start_time="2026-05-22",
+            maintenance_type="on_site",
+            participants="bgo@vedur.is",
+            reasons=["change"],
+            work="Skipt um móttakara",
+            remaining="Athuga loftnet næst",
+        )
+    assert result["id_maintenance"] == 9999
+    methods = [c.args[0] for c in mock_req.call_args_list]
+    assert methods == ["POST", "GET", "PUT"]
+
+    post_call = mock_req.call_args_list[0]
+    assert post_call.args[1] == "/maintenances/id_entity/16096"
+    assert post_call.kwargs["data"] == {
+        "maintenance_type": "on_site",
+        "start_time": "2026-05-22T00:00:00",
+        "end_time": "2026-05-22T00:00:00",
+    }
+
+    put_call = mock_req.call_args_list[2]
+    assert put_call.args[1] == "/maintenance/id_maintenance/9999"
+    put_body = put_call.kwargs["data"]
+    assert put_body["participants"] == "bgo@vedur.is"
+    assert put_body["completed"] is True
+    assert put_body["start_time"] == "2026-05-22T00:00:00"
+    av_by_id = {
+        row["id_maintenance_attribute_value"]: row["value"]
+        for row in put_body["maintenance_attribute_values"]
+    }
+    assert av_by_id[80001] == "true"   # reason_change
+    assert av_by_id[80002] == "false"  # reason_repairs
+    assert av_by_id[80003] == "false"  # reason_inspection
+    assert av_by_id[80004] == "false"  # reason_improvements
+    assert av_by_id[80005] == "false"  # reason_other
+    assert av_by_id[80006] == "Skipt um móttakara"           # work
+    assert av_by_id[80008] == "Athuga loftnet næst"          # remaining
+    # comment was not supplied → should NOT appear in PUT payload
+    assert 80007 not in av_by_id
+
+
+def test_add_maintenance_visit_dry_run_short_circuits():
+    """In dry-run we cannot discover IDs, so GET+PUT must NOT fire."""
+    w = _logged_in_writer(dry_run=True)
+    with patch.object(w, "_request") as mock_req:
+        mock_req.return_value = DryRunResult(
+            method="POST",
+            endpoint="/maintenances/id_entity/16096",
+            payload={},
+        )
+        result = w.add_maintenance_visit(
+            16096,
+            start_time="2026-05-22",
+            reasons=["change"],
+            work="dry-run test",
+        )
+    assert result["id_maintenance"] == "<dry-run>"
+    assert result["updated"] is None
+    assert mock_req.call_count == 1
+    assert mock_req.call_args.args[0] == "POST"
+
+
+def test_add_maintenance_visit_supports_multiple_reasons():
+    w = _logged_in_writer(dry_run=False)
+    created = {"id": 9999}
+    detail = _maintenance_detail_with_seeded_attrs(9999, base=80000)
+    with patch.object(w, "_request") as mock_req:
+        mock_req.side_effect = [created, detail, {"ok": True}]
+        w.add_maintenance_visit(
+            16096,
+            start_time="2026-05-22",
+            reasons=["change", "repairs"],
+            work="Skipt um móttakara og lagaði kapal",
+        )
+    put_body = mock_req.call_args_list[2].kwargs["data"]
+    av_by_id = {
+        r["id_maintenance_attribute_value"]: r["value"]
+        for r in put_body["maintenance_attribute_values"]
+    }
+    assert av_by_id[80001] == "true"   # change
+    assert av_by_id[80002] == "true"   # repairs
+    assert av_by_id[80003] == "false"  # inspection still false
+
+
+def test_add_maintenance_visit_no_reasons_sets_all_false():
+    """remote vitjun with no `reasons` arg — all reason_* booleans = false."""
+    w = _logged_in_writer(dry_run=False)
+    created = {"id": 9999}
+    detail = _maintenance_detail_with_seeded_attrs(9999, base=80000)
+    with patch.object(w, "_request") as mock_req:
+        mock_req.side_effect = [created, detail, {"ok": True}]
+        w.add_maintenance_visit(
+            16096,
+            start_time="2026-05-22",
+            maintenance_type="remote",
+            work="Stillti hluti yfir SSH",
+        )
+    put_body = mock_req.call_args_list[2].kwargs["data"]
+    av_by_id = {
+        r["id_maintenance_attribute_value"]: r["value"]
+        for r in put_body["maintenance_attribute_values"]
+    }
+    for attr_id in (80001, 80002, 80003, 80004, 80005):
+        assert av_by_id[attr_id] == "false"
+
+
+def test_add_maintenance_visit_raises_if_post_returns_no_id():
+    w = _logged_in_writer(dry_run=False)
+    with patch.object(w, "_request", return_value={"unexpected": "response"}):
+        with pytest.raises(RuntimeError, match="POST returned no id"):
+            w.add_maintenance_visit(16096, start_time="2026-05-22")
+
+
+def test_add_maintenance_visit_raises_if_detail_missing():
+    w = _logged_in_writer(dry_run=False)
+    created = {"id": 9999}
+    with patch.object(w, "_request") as mock_req:
+        mock_req.side_effect = [created, None]
+        with pytest.raises(RuntimeError, match="cannot discover seeded"):
+            w.add_maintenance_visit(16096, start_time="2026-05-22")
+
+
+# ---------------------------------------------------------------------------
+# delete_entity_connection
+# ---------------------------------------------------------------------------
+
+
+def test_delete_entity_connection_hits_admin_endpoint():
+    w = _logged_in_writer(dry_run=False)
+    with patch.object(w, "_request", return_value=None) as mock_req:
+        w.delete_entity_connection(27836)
+    mock_req.assert_called_once_with(
+        "DELETE", "/admin_entity_connection_row/27836"
+    )
+
+
+def test_delete_entity_connection_respects_dry_run():
+    w = _logged_in_writer(dry_run=True)
+    with patch.object(w, "_request") as mock_req:
+        mock_req.return_value = DryRunResult(
+            method="DELETE",
+            endpoint="/admin_entity_connection_row/27836",
+            payload=None,
+        )
+        result = w.delete_entity_connection(27836)
+    assert isinstance(result, DryRunResult)
+    assert result.method == "DELETE"
+    assert result.endpoint == "/admin_entity_connection_row/27836"
+
+
+# ---------------------------------------------------------------------------
+# update_maintenance_visit — fetch / merge / PUT
+# ---------------------------------------------------------------------------
+
+
+def test_update_maintenance_visit_preserves_unspecified_fields():
+    """Only the fields the caller passes should change; others preserve."""
+    w = _logged_in_writer(dry_run=False)
+    current = _maintenance_detail_with_seeded_attrs(5147, base=80000)
+    current["start_time"] = "2025-09-23T00:00:00"
+    current["end_time"] = "2025-09-23T00:00:00"
+    current["participants"] = "bhb@vedur.is"
+    current["completed"] = True
+    # Pretend "work" has existing text, reason_change=true:
+    for av in current["maintenance_attribute_values"]:
+        if av["code"] == "work":
+            av["value"] = "Old text"
+        if av["code"] == "reason_change":
+            av["value"] = "true"
+
+    with patch.object(w, "_request") as mock_req:
+        mock_req.side_effect = [current, {"ok": True}]
+        result = w.update_maintenance_visit(5147, remaining="Þarf að mála")
+
+    # Only "remaining" should be the new value; everything else preserved
+    put_call = mock_req.call_args_list[1]
+    assert put_call.args[0] == "PUT"
+    assert put_call.args[1] == "/maintenance/id_maintenance/5147"
+    body = put_call.kwargs["data"]
+    assert body["participants"] == "bhb@vedur.is"
+    assert body["start_time"] == "2025-09-23T00:00:00"
+    assert body["completed"] is True
+    av_by_code = {
+        row["id_maintenance_attribute_value"]: row["value"]
+        for row in body["maintenance_attribute_values"]
+    }
+    # work preserved
+    assert av_by_code[80006] == "Old text"
+    # remaining set
+    assert av_by_code[80008] == "Þarf að mála"
+    # reason_change preserved
+    assert av_by_code[80001] == "true"
+    assert result["id_maintenance"] == 5147
+
+
+def test_update_maintenance_visit_reasons_replaces_full_set():
+    """Passing `reasons` replaces all reason booleans, not just one."""
+    w = _logged_in_writer(dry_run=False)
+    current = _maintenance_detail_with_seeded_attrs(5147, base=80000)
+    for av in current["maintenance_attribute_values"]:
+        if av["code"] == "reason_change":
+            av["value"] = "true"
+        if av["code"] == "reason_repairs":
+            av["value"] = "false"
+
+    with patch.object(w, "_request") as mock_req:
+        mock_req.side_effect = [current, {"ok": True}]
+        w.update_maintenance_visit(5147, reasons=["repairs", "inspection"])
+
+    body = mock_req.call_args_list[1].kwargs["data"]
+    av_by_code = {
+        row["id_maintenance_attribute_value"]: row["value"]
+        for row in body["maintenance_attribute_values"]
+    }
+    assert av_by_code[80001] == "false"  # change — was true, replaced
+    assert av_by_code[80002] == "true"   # repairs — set
+    assert av_by_code[80003] == "true"   # inspection — set
+    assert av_by_code[80004] == "false"  # improvements
+    assert av_by_code[80005] == "false"  # other
+
+
+def test_update_maintenance_visit_empty_string_writes_empty():
+    """Caller passing '' should clear the field (not be treated as None)."""
+    w = _logged_in_writer(dry_run=False)
+    current = _maintenance_detail_with_seeded_attrs(5147, base=80000)
+    for av in current["maintenance_attribute_values"]:
+        if av["code"] == "remaining":
+            av["value"] = "old outstanding text"
+
+    with patch.object(w, "_request") as mock_req:
+        mock_req.side_effect = [current, {"ok": True}]
+        w.update_maintenance_visit(5147, remaining="")
+
+    body = mock_req.call_args_list[1].kwargs["data"]
+    av_by_code = {
+        row["id_maintenance_attribute_value"]: row["value"]
+        for row in body["maintenance_attribute_values"]
+    }
+    assert av_by_code[80008] == ""
+
+
+def test_update_maintenance_visit_validates_reason_codes():
+    w = _logged_in_writer(dry_run=False)
+    with pytest.raises(ValueError, match="unknown reason codes"):
+        w.update_maintenance_visit(5147, reasons=["bogus"])
+
+
+def test_update_maintenance_visit_raises_when_not_found():
+    w = _logged_in_writer(dry_run=False)
+    with patch.object(w, "_request", return_value=None):
+        with pytest.raises(RuntimeError, match="no maintenance with id"):
+            w.update_maintenance_visit(99999, work="x")
+
+
+def test_update_maintenance_visit_returns_before_after():
+    """The result includes pre-edit state + the payload sent."""
+    w = _logged_in_writer(dry_run=False)
+    current = _maintenance_detail_with_seeded_attrs(5147, base=80000)
+    current["participants"] = "old@vedur.is"
+
+    with patch.object(w, "_request") as mock_req:
+        mock_req.side_effect = [current, {"ok": True}]
+        result = w.update_maintenance_visit(5147, participants="bgo@vedur.is")
+
+    assert result["before"] is current
+    assert result["after"]["participants"] == "bgo@vedur.is"
+
+
+def test_update_maintenance_visit_dry_run_still_returns_merge():
+    """Dry-run: PUT short-circuits but merge is still computed."""
+    w = _logged_in_writer(dry_run=True)
+    current = _maintenance_detail_with_seeded_attrs(5147, base=80000)
+
+    def side_effect(method, path, *_a, **kw):
+        if method == "GET":
+            return current
+        return DryRunResult(method=method, endpoint=path, payload=kw.get("data"))
+
+    with patch.object(w, "_request", side_effect=side_effect):
+        result = w.update_maintenance_visit(
+            5147, work="test edit", reasons=["change"]
+        )
+    assert isinstance(result["updated"], DryRunResult)
+    # Merge still computed
+    body = result["after"]
+    av_by_code = {
+        r["id_maintenance_attribute_value"]: r["value"]
+        for r in body["maintenance_attribute_values"]
+    }
+    assert av_by_code[80001] == "true"   # reason_change
+    assert av_by_code[80006] == "test edit"

--- a/uv.lock
+++ b/uv.lock
@@ -1569,7 +1569,7 @@ wheels = [
 
 [[package]]
 name = "tostools"
-version = "0.3.7"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "argparse-logging" },


### PR DESCRIPTION
## Why

Unblocks receivers PR #71 (`feat/cfg-move-device-visit`), whose `cfg/operations.py` calls 8 `TOSWriter` methods that don't exist on the currently-pinned `tostools@v0.5.0`. See [receivers#71 review comment](https://github.com/bennigo/receivers/pull/71#issuecomment-4527927508) for the verified gap.

## What

Single commit `02d265d` adds all 8 missing methods to `src/tostools/api/tos_writer.py`:

| Method | Purpose |
|--------|---------|
| `find_station_by_marker` | Case-insensitive RINEX-marker → `id_entity` lookup (filters `type_lvl_two="stöð"`) |
| `get_open_parent_join` | Wraps `GET /entity/parent_history/{id}`, returns currently-open parent connection |
| `move_device` | Pattern 2 for joins: closes open parent + opens new join at `transition_date` (warehouse↔station moves, station↔station transfers) |
| `delete_entity_connection` | Hard-delete a join row (re-implementation of the version on the unmerged `feat/tos-writer-delete` branch) |
| `add_maintenance_visit` | Three-call create flow for vitjun records (POST → GET to discover seeded attribute IDs → PUT with values) |
| `get_maintenance_visit` | Read one vitjun record by `id_maintenance` |
| `list_maintenance_visits` | List vitjun records for an entity (matches TOS `station_visits` page) |
| `update_maintenance_visit` | Mutate fields on an existing vitjun record |

Date inputs accept both `YYYY-MM-DD` (promoted to midnight by `_tos_date`) and full ISO datetime — supports the field workflow where dates are entered after-the-fact.

## Test plan

- [x] +639 lines of new pytest coverage (31 new TOSWriter tests on top of existing 45 → 76 TOSWriter tests total)
- [x] Full suite at commit time: 570 passed / 2 skipped, 0 regressions
- [ ] Live dry-run of `move_device` against test TOS post-merge (gated to ops env)
- [ ] Live dry-run of `add_maintenance_visit` against test TOS post-merge

## Release path

Once merged, cut `v0.6.0` so receivers#71 can bump its pin from `@v0.5.0` to `@v0.6.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)