### PR TITLE
ci: drop Python 3.9-3.11; align ecosystem on 3.12+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Python 3.8 dropped 2026-05-12: the gtimes dependency no longer
-        # imports on 3.8 (uses newer-Python syntax in gtimes/exceptions.py).
-        # Project minimum is now 3.9.
-        python-version: [3.9, "3.10", "3.11", "3.12", "3.13"]
+        # 3.9-3.11 dropped 2026-05-24: ecosystem-wide alignment on 3.12+
+        # (root gpslibrary_new/CLAUDE.md targets 3.13; 3.12 is the floor
+        # for Debian stable). See pyproject.toml requires-python.
+        python-version: ["3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,18 +8,17 @@ authors = [
 description = "Python toolkit for GPS/GNSS station management and TOS API integration"
 readme = "README.md"
 classifiers = [
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
 maintainers = [{ name = "Benedikt Gunnar Ófeigsson", email = "bgo@vedur.is" }]
-# Python 3.8 dropped 2026-05-12: the gtimes dependency no longer imports on
-# 3.8 (newer-Python syntax in gtimes/exceptions.py).
-requires-python = ">=3.9"
+# 3.9-3.11 dropped 2026-05-24: ecosystem-wide alignment on 3.12+
+# (root gpslibrary_new/CLAUDE.md targets 3.13; 3.12 is the floor for
+# Debian stable). 3.8 was dropped earlier (2026-05-12) when gtimes
+# moved to newer-Python syntax.
+requires-python = ">=3.12"
 dependencies = [
     "requests>=2.31.0",
     "pandas>=2.0.3",


### PR DESCRIPTION
## Why

The ecosystem already moved on:
- `receivers/pyproject.toml` pins `requires-python = ">=3.10"`
- root `gpslibrary_new/CLAUDE.md` targets `>=3.13`
- production hosts (rek, rek-d01, gpsplot) all run ≥3.12

`tostools` was the lagging package still carrying the wide 3.9-3.13 matrix.

## What

- CI matrix: `[3.9, "3.10", "3.11", "3.12", "3.13"]` → `["3.12", "3.13"]`
- `pyproject.toml requires-python`: `">=3.9"` → `">=3.12"`
- Classifiers: drop 3.9, 3.10, 3.11 entries
- Update the matrix-comment with the new floor rationale

## Follow-up after merge

Update branch-protection on master to require `test (3.12)` + `test (3.13)` instead of the never-matching `test` — that's why every merge to master currently needs `--admin`.

## Test plan

- [x] Full suite green locally on 3.13: 579 passed / 2 skipped
- [ ] CI matrix runs 3.12 + 3.13 only

🤖 Generated with [Claude Code](https://claude.com/claude-code)