### PR TITLE
feat(tos): vitjanir read foundation —  + station/device-show integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,10 +305,14 @@ tosGPS --debug-all --log-dir logs sitelog RHOF
 ### `tos` subcommands
 
 ```bash
-tos station show <STN>             # current-state snapshot
+tos station show <STN>             # current-state snapshot (with Recent vitjanir)
 tos station triage <STN>           # combined triage file
 tos station verify <STN>           # apply→verify oracle
 tos device list --station <STN>    # currently-joined devices
+tos device show --id <id>          # device detail (with Recent vitjanir)
+tos visit list --station <STN>     # vitjanir attached to a station
+tos visit list --device <id>       # vitjanir attached to a device
+tos visit show <id_maintenance>    # one vitjun, full detail
 tos audit apply <triage_file>      # dry-run; --apply to commit
 tos fleet status                   # bulk verify oracle (exit 0/1/2)
 tos fleet triage                   # generate per-station triage files
@@ -317,6 +321,38 @@ tos fleet triage                   # generate per-station triage files
 Legacy flat-arg form (`tos RHOF`, `tos -s SERIAL`, `tos --fdsnxml/--sc3ml`)
 and the `json2ascii` / `metadata2rmq` console scripts were removed in
 v0.7. The SC3/FDSN XML export pipeline is out of scope for this package.
+
+### `tos visit` — vitjun (visit / maintenance) inspection
+
+Vitjanir are entity-attached temporal records (`id_maintenance`
+namespace, distinct from `id_entity` / `id_contact`). The schema is
+generic on `id_entity`: stations and devices can both carry vitjanir.
+In current GPS data every vitjun is station-attached (device-attached
+vitjanir today are exclusively on meteorological sensors); Phase C of
+the vitjanir expansion will start writing device-attached vitjanir for
+the GPS lifecycle tracker (firmware bumps, sent-for-repair, etc.).
+
+  * `tos visit list --station S` — vitjanir for a station, most-recent first
+  * `tos visit list --device <id>` — vitjanir for a single device
+  * `tos visit list --entity <id>` — escape hatch (any entity by id)
+  * `tos visit show <id_maintenance>` — one vitjun, full detail
+    including `maintenance_attribute_values` rows (`work` / `comment` /
+    `remaining` / per-reason booleans + each row's
+    `id_maintenance_attribute_value` for the writer's update path)
+
+Standard filter set (read-only): `--type {on_site,remote}`,
+`--reason CODE` (repeatable; `change` / `repairs` / `inspection` /
+`improvements` / `other`), `--since DATE`, `--participants SUBSTR`,
+`--open` / `--completed`. The `--reason` filter translates English
+codes to the Icelandic display strings TOS emits on the list endpoint
+(see `MAINTENANCE_REASON_DISPLAY` in `src/tostools/tos.py`).
+
+`tos station show` and `tos device show --id <id>` surface a "Recent
+vitjanir" section by default — every open visit + the 3 most-recent
+closed. Station show aggregates from the station + currently-joined
+devices with a `source` column for attribution (forward-compatible
+with Phase C). `--no-visits` suppresses the section (and skips the
+HTTP); `--all` on station show extends to full visit history.
 
 ## Architecture
 

--- a/src/tostools/api/tos_client.py
+++ b/src/tostools/api/tos_client.py
@@ -433,6 +433,34 @@ class TOSClient:
             return []
         return sorted(history, key=lambda j: j.get("time_from") or "")
 
+    def list_maintenance_visits(self, id_entity: int) -> List[Dict[str, Any]]:
+        """List vitjun (maintenance) records for an entity. Public read.
+
+        Wraps ``GET /maintenances/id_entity/{id_entity}``. Mirrors the
+        writer-side method of the same name but uses the unauthenticated
+        client path, so read verbs (``tos visit list``) don't force
+        operators to set up TOS credentials. Returns an empty list when
+        the endpoint yields no records or an unexpected payload shape.
+
+        Row shape: ``id``, ``maintenance_type``, ``start_time``,
+        ``end_time``, ``participants``, ``participants_names``,
+        ``reason``, ``work``, ``remaining``, ``completed``,
+        ``creation_time``.
+        """
+        result = self._make_request(f"/maintenances/id_entity/{id_entity}")
+        return result if isinstance(result, list) else []
+
+    def get_maintenance_visit(self, id_maintenance: int) -> Optional[Dict[str, Any]]:
+        """Return full detail for one vitjun. Public read.
+
+        Wraps ``GET /maintenance/id_maintenance/{id}``. Adds the
+        ``maintenance_attribute_values`` array (each row carries its own
+        ``id_maintenance_attribute_value`` — needed by the writer for
+        updates, useful here for the detail view).
+        """
+        result = self._make_request(f"/maintenance/id_maintenance/{id_maintenance}")
+        return result if isinstance(result, dict) else None
+
     def basic_search(self, search_term: str) -> List[Dict[str, Any]]:
         """
         Substring search across TOS attribute values.

--- a/src/tostools/tos.py
+++ b/src/tostools/tos.py
@@ -1204,34 +1204,71 @@ def _device_show_main(args) -> int:
     did = int(history["id_entity"])
     parent_history = client.get_parent_history(did)
 
+    no_visits = bool(getattr(args, "no_visits", False))
+    # Always fetch for the JSON path; for the pretty path skip the
+    # HTTP when the operator opted out via --no-visits or picked an
+    # explicit section flag that doesn't include visits.
+    show_all_sections = not (
+        args.section_list or args.section_attributes or args.section_attributes_history
+    )
+    want_visits = args.json or (show_all_sections and not no_visits)
+    visits: List[Dict[str, Any]] = []
+    if want_visits:
+        try:
+            visits = client.list_maintenance_visits(did) or []
+        except Exception as exc:  # noqa: BLE001
+            print(
+                f"warning: list_maintenance_visits({did}) failed: {exc}",
+                file=sys.stderr,
+            )
+            visits = []
+
     if args.json:
         payload = {
             "id_entity": did,
             "history": history,
             "parent_history": parent_history,
+            "visits": visits,
         }
         print(_json.dumps(payload, ensure_ascii=False, indent=2))
         return 0
 
     console = Console()
-    show_all = not (
-        args.section_list or args.section_attributes or args.section_attributes_history
-    )
 
-    if show_all or args.section_list or args.section_attributes:
+    if show_all_sections or args.section_list or args.section_attributes:
         _render_show_header(console, history)
 
-    if show_all or args.section_attributes:
+    if show_all_sections or args.section_attributes:
         console.print()
         _render_show_open_attributes(console, history, args)
 
-    if show_all or args.section_attributes_history:
+    if show_all_sections or args.section_attributes_history:
         console.print()
         _render_show_attribute_history(console, history, args)
 
-    if show_all or args.section_list:
+    if show_all_sections or args.section_list:
         console.print()
         _render_show_parent_history(console, client, parent_history, args)
+
+    if show_all_sections and not no_visits:
+        visible_visits, hidden = _trim_visits_for_show(visits, show_all=False)
+        console.print()
+        console.print(
+            f"Recent vitjanir — {len(visible_visits)} record(s) for device {did}"
+        )
+        if hidden:
+            console.print(
+                f"  [dim]({hidden} more closed — use "
+                f"`tos visit list --device {did}` to see them)[/dim]"
+            )
+        _render_visits_table(console, visible_visits, title="")
+        if visible_visits:
+            sample_id = visible_visits[0].get("id")
+            if sample_id:
+                console.print(
+                    f"[dim]Drill: tos visit show {sample_id}  |  "
+                    f"tos visit list --device {did}[/dim]"
+                )
 
     return 0
 
@@ -1467,6 +1504,15 @@ def _device_main(argv):
             "bulk-load sits at id_av ≈ 32000-35000; per-session writes "
             "land 5-10k higher each year. See CLAUDE.md 'Retrospective "
             "writes' section + memory project_tos_retrospective_writes_provenance_gap."
+        ),
+    )
+    p_show.add_argument(
+        "--no-visits",
+        dest="no_visits",
+        action="store_true",
+        help=(
+            "Suppress the Recent vitjanir section. Default-on; this device's "
+            "vitjanir surface alongside the attribute / parent-history panels."
         ),
     )
     add_attribute_filter_arguments(p_show)
@@ -2145,6 +2191,15 @@ def _station_main(argv):
         ),
     )
     p_show.add_argument(
+        "--no-visits",
+        dest="no_visits",
+        action="store_true",
+        help=(
+            "Suppress the Recent vitjanir section (aggregated from the "
+            "station + currently-joined devices). Default-on."
+        ),
+    )
+    p_show.add_argument(
         "--json", action="store_true", help="Emit JSON instead of plain text."
     )
     p_show.add_argument(
@@ -2493,6 +2548,51 @@ def _station_show_main(args) -> int:
             )
             contacts = []
 
+    # Aggregate vitjanir from the station + currently-joined devices.
+    # Forward-compatible with Phase C (lifecycle tracker): when device-
+    # attached vitjanir start landing on GPS receivers / antennas, they
+    # surface here automatically without an additional roundtrip beyond
+    # the per-child loop already done above. Each row gets a
+    # ``__source_label`` field so the renderer can show attribution
+    # ("station HEDI" vs "device 4830 (gnss_receiver)").
+    aggregated_visits: List[Dict[str, Any]] = []
+    no_visits = bool(getattr(args, "no_visits", False))
+    if not attributes_only and not no_visits:
+        try:
+            station_visits = client.list_maintenance_visits(station_id) or []
+        except Exception as exc:  # noqa: BLE001
+            print(
+                f"warning: list_maintenance_visits({station_id}) failed: {exc}",
+                file=sys.stderr,
+            )
+            station_visits = []
+        station_label_compact = marker or station_name or f"id={station_id}"
+        for v in station_visits:
+            v_copy = dict(v)
+            v_copy["__source_label"] = f"station {station_label_compact}"
+            v_copy["__source_kind"] = "station"
+            v_copy["__source_id"] = station_id
+            aggregated_visits.append(v_copy)
+        # Currently-joined children only — closed joins' visits are out
+        # of scope for the "what's going on at this station now" view.
+        for row in open_rows:
+            child_id = row["id_entity"]
+            try:
+                child_visits = client.list_maintenance_visits(child_id) or []
+            except Exception as exc:  # noqa: BLE001
+                print(
+                    f"warning: list_maintenance_visits({child_id}) failed: {exc}",
+                    file=sys.stderr,
+                )
+                child_visits = []
+            child_label = f"device {child_id} ({row['subtype']})"
+            for v in child_visits:
+                v_copy = dict(v)
+                v_copy["__source_label"] = child_label
+                v_copy["__source_kind"] = "device"
+                v_copy["__source_id"] = child_id
+                aggregated_visits.append(v_copy)
+
     if args.json:
         payload = {
             "id_entity": station_id,
@@ -2506,6 +2606,7 @@ def _station_show_main(args) -> int:
             "children_open": open_rows,
             "children_closed": closed_rows if include_closed else [],
             "contacts": contacts,
+            "visits": aggregated_visits,
         }
         print(_json.dumps(payload, ensure_ascii=False, indent=2))
         return 0
@@ -2569,6 +2670,33 @@ def _station_show_main(args) -> int:
 
     console.print()
     _render_station_contacts(console, contacts)
+
+    if not no_visits:
+        visible_visits, hidden = _trim_visits_for_show(
+            aggregated_visits, show_all=include_closed
+        )
+        console.print()
+        console.print(
+            f"Recent vitjanir — {len(visible_visits)} record(s) "
+            f"(aggregated from station + {len(open_rows)} joined device(s))"
+        )
+        if hidden:
+            console.print(
+                f"  [dim]({hidden} more closed — use --all to see them)[/dim]"
+            )
+        _render_visits_table(
+            console,
+            visible_visits,
+            title="",
+            source_label_col="source",
+        )
+        if aggregated_visits:
+            sample_id = visible_visits[0].get("id") if visible_visits else None
+            if sample_id:
+                console.print(
+                    f"[dim]Drill: tos visit show {sample_id}  |  "
+                    f"tos visit list --station {args.station}[/dim]"
+                )
 
     console.print()
     _render_show_drill_hint(
@@ -3544,6 +3672,7 @@ def _render_visits_table(
     visits: List[Dict[str, Any]],
     *,
     title: str,
+    source_label_col: Optional[str] = None,
 ) -> None:
     """Render a vitjun list table.
 
@@ -3551,6 +3680,13 @@ def _render_visits_table(
     work-summary. ``end_time`` is suppressed by default — most visits
     are instantaneous (``end_time == start_time``) and the column adds
     visual noise. Drill via ``tos visit show <id>`` for full detail.
+
+    When ``source_label_col`` is given, a second column with that
+    header is inserted between ``id`` and ``start``; each row's value
+    comes from the per-row ``__source_label`` key (added by the
+    aggregator in ``_station_show_main``). Used to show "station HEDI"
+    vs "device 4830 (gnss_receiver)" attribution in the station-show
+    aggregated view.
     """
     from rich.table import Table
 
@@ -3561,6 +3697,8 @@ def _render_visits_table(
 
     table = Table(title=title)
     table.add_column("id", justify="right")
+    if source_label_col is not None:
+        table.add_column(source_label_col)
     table.add_column("start")
     table.add_column("type")
     table.add_column("reasons")
@@ -3587,16 +3725,41 @@ def _render_visits_table(
         work_first = (work[0] if work else "") or "—"
         if len(work_first) > 60:
             work_first = work_first[:57] + "..."
-        table.add_row(
-            str(vid) if vid is not None else "?",
-            start,
-            vtype_cell,
-            reasons,
-            str(participants),
-            done_cell,
-            work_first,
+        row_cells = [str(vid) if vid is not None else "?"]
+        if source_label_col is not None:
+            row_cells.append(str(v.get("__source_label") or "?"))
+        row_cells.extend(
+            [start, vtype_cell, reasons, str(participants), done_cell, work_first]
         )
+        table.add_row(*row_cells)
     console.print(table)
+
+
+def _trim_visits_for_show(
+    visits: List[Dict[str, Any]],
+    *,
+    show_all: bool,
+    max_closed: int = 3,
+) -> "tuple[List[Dict[str, Any]], int]":
+    """Trim a visit list for the per-entity 'Recent visits' section.
+
+    Default view (``show_all=False``): every open visit + the
+    ``max_closed`` most-recent closed visits. ``show_all=True``:
+    every visit, no trim. Returns ``(visible_rows, hidden_count)``
+    so the caller can hint at how many more visits exist.
+
+    Sort within each group: start_time descending (most-recent first).
+    The composed return list preserves "open first, then closed
+    newest-first" — same operator-eye ordering as `tos visit list`.
+    """
+    by_recency = sorted(visits, key=lambda v: v.get("start_time") or "", reverse=True)
+    if show_all:
+        return by_recency, 0
+    open_rows = [v for v in by_recency if not v.get("completed")]
+    closed_rows = [v for v in by_recency if v.get("completed")]
+    visible_closed = closed_rows[:max_closed]
+    hidden = len(closed_rows) - len(visible_closed)
+    return open_rows + visible_closed, hidden
 
 
 def _render_visit_detail(console, visit: Dict[str, Any]) -> None:

--- a/src/tostools/tos.py
+++ b/src/tostools/tos.py
@@ -10,7 +10,15 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-KNOWN_SUBCOMMANDS = {"owners", "device", "audit", "station", "contact", "fleet"}
+KNOWN_SUBCOMMANDS = {
+    "owners",
+    "device",
+    "audit",
+    "station",
+    "contact",
+    "fleet",
+    "visit",
+}
 
 
 def _owners_main(argv):
@@ -290,6 +298,185 @@ def apply_device_filters(
                 continue
             if tt is not None and tt <= on_date:
                 continue
+        out.append(row)
+    return out
+
+
+#: Allowed maintenance-reason codes — match
+#: :attr:`TOSWriter.MAINTENANCE_REASON_CODES` exactly so the read-side
+#: filter and the (eventual) write-side validator stay in lock-step.
+MAINTENANCE_REASON_CODES = frozenset(
+    {"change", "repairs", "inspection", "improvements", "other"}
+)
+
+#: Display strings TOS uses on the list endpoint for each reason boolean.
+#: The list endpoint flattens ``reason_change=true,reason_repairs=true``
+#: into a single ``"reason"`` field with the Icelandic display strings
+#: comma-joined ("Breyting, Viðgerð"). The detail endpoint returns the
+#: raw booleans. ``apply_visit_filters`` uses this map to translate the
+#: filter operator's English codes into the strings TOS actually emits.
+#: ``change`` / ``repairs`` / ``improvements`` were empirically verified
+#: against live data 2026-05-30; ``inspection`` / ``other`` are unused
+#: in the GPS fleet today (best-guess translations — adjust if TOS
+#: reveals them).
+MAINTENANCE_REASON_DISPLAY = {
+    "change": "Breyting",
+    "repairs": "Viðgerð",
+    "inspection": "Skoðun",
+    "improvements": "Endurbætur",
+    "other": "Annað",
+}
+
+
+def add_visit_filter_arguments(parser) -> None:
+    """Add the standard vitjun-filter argument set to a subparser.
+
+    Reusable across ``tos visit list``, future ``tos visit show``
+    multi-match, and the visit-coverage audit. Match semantics are
+    documented on :func:`apply_visit_filters`.
+
+    Adds: ``--type {on_site,remote}``, ``--reason`` (repeatable),
+    ``--since DATE``, ``--participants SUBSTR``, ``--open``,
+    ``--completed`` (mutually exclusive).
+    """
+    parser.add_argument(
+        "--type",
+        dest="visit_type",
+        choices=["on_site", "remote"],
+        default=None,
+        help=(
+            "Filter to one visit type: on_site (Staðarvitjun) or remote "
+            "(Fjarvitjun)."
+        ),
+    )
+    parser.add_argument(
+        "--reason",
+        action="append",
+        dest="reasons",
+        choices=sorted(MAINTENANCE_REASON_CODES),
+        help=(
+            "Filter to one or more reason codes (e.g. --reason change "
+            "--reason repairs). Repeatable; OR'd within the filter."
+        ),
+    )
+    parser.add_argument(
+        "--since",
+        dest="since",
+        default=None,
+        help=(
+            "Filter to visits with start_time >= this date (YYYY-MM-DD). "
+            "Compared as a date-prefix lex compare against start_time."
+        ),
+    )
+    parser.add_argument(
+        "--participants",
+        dest="participants",
+        default=None,
+        help=(
+            "Filter by participants/participants_names — case-insensitive "
+            "substring (e.g. '--participants bgo' matches "
+            "'bgo@vedur.is' OR 'Benedikt Ófeigsson')."
+        ),
+    )
+    status_group = parser.add_mutually_exclusive_group()
+    status_group.add_argument(
+        "--open",
+        dest="open_only",
+        action="store_true",
+        help="Only visits with completed=False (long-running / unresolved).",
+    )
+    status_group.add_argument(
+        "--completed",
+        dest="completed_only",
+        action="store_true",
+        help="Only visits with completed=True (closed records).",
+    )
+
+
+def apply_visit_filters(
+    rows: List[Dict[str, Any]],
+    args,
+) -> List[Dict[str, Any]]:
+    """Filter vitjun rows by the standard CLI visit-filter set.
+
+    Reads ``args.visit_type``, ``args.reasons`` (list), ``args.since``,
+    ``args.participants``, ``args.open_only``, ``args.completed_only``
+    (any missing attribute is treated as "no constraint"). Filters are
+    AND'd; preserves input order.
+
+    Expected row shape: TOS vitjun dict as returned by
+    :meth:`TOSClient.list_maintenance_visits` —
+    ``maintenance_type``, ``start_time``, ``reason`` (string with
+    embedded codes; see below), ``participants`` /
+    ``participants_names``, ``completed``.
+
+    Match semantics:
+      - ``visit_type``: exact match against ``row['maintenance_type']``
+      - ``reasons``: TOS's list endpoint flattens the per-code
+        booleans into a single ``reason`` field with Icelandic display
+        strings ("Breyting, Viðgerð"). The filter translates the
+        operator's English codes via :data:`MAINTENANCE_REASON_DISPLAY`
+        and matches if any requested display string appears in the row
+        (OR within the filter, AND against other filters).
+      - ``since``: ``row['start_time'][:10] >= since[:10]`` (lex
+        compare; YYYY-MM-DD ordering)
+      - ``participants``: case-insensitive substring against
+        ``participants_names`` OR ``participants`` (whichever has a
+        value; participants_names is the human-resolved form)
+      - ``open_only``: ``row['completed']`` is falsy
+      - ``completed_only``: ``row['completed']`` is truthy
+    """
+    visit_type = getattr(args, "visit_type", None)
+    reasons = getattr(args, "reasons", None) or None
+    since_raw = getattr(args, "since", None)
+    since = since_raw[:10] if since_raw else None
+    participants_needle = getattr(args, "participants", None)
+    open_only = bool(getattr(args, "open_only", False))
+    completed_only = bool(getattr(args, "completed_only", False))
+
+    # Translate operator codes → TOS display strings. Skip unknown
+    # codes silently — argparse choices= already constrains input.
+    reason_displays = (
+        [
+            MAINTENANCE_REASON_DISPLAY[c]
+            for c in reasons
+            if c in MAINTENANCE_REASON_DISPLAY
+        ]
+        if reasons
+        else None
+    )
+    participants_lower = participants_needle.lower() if participants_needle else None
+
+    out: List[Dict[str, Any]] = []
+    for row in rows:
+        if visit_type and row.get("maintenance_type") != visit_type:
+            continue
+        if reason_displays:
+            raw = str(row.get("reason") or "")
+            # Comma-joined display strings; match if any operator-
+            # requested display appears as a substring of the field.
+            if not any(d in raw for d in reason_displays):
+                continue
+        if since:
+            start = (row.get("start_time") or "")[:10]
+            if start and start < since:
+                continue
+            if not start:
+                # Row with no start_time can't be filtered by --since;
+                # exclude rather than silently keep it.
+                continue
+        if participants_lower is not None:
+            names = str(row.get("participants_names") or "")
+            emails = str(row.get("participants") or "")
+            if (
+                participants_lower not in names.lower()
+                and participants_lower not in emails.lower()
+            ):
+                continue
+        if open_only and row.get("completed"):
+            continue
+        if completed_only and not row.get("completed"):
+            continue
         out.append(row)
     return out
 
@@ -3146,6 +3333,372 @@ def _render_contact_record(contact: Dict[str, Any]) -> None:
             rendered = f"[{_STATION_VALUE_COLOR}]{value}[/{_STATION_VALUE_COLOR}]"
         table.add_row(label, rendered)
     console.print(table)
+
+
+def _visit_main(argv):
+    """Handle ``tos visit <verb>`` subcommands.
+
+    Vitjun (visit / maintenance) records live on an entity, alongside
+    its attribute-value periods and entity-connection joins. The schema
+    is generic on ``id_entity`` — both stations and devices can have
+    them, though in current GPS data every vitjun is station-attached
+    (device-attached vitjanir today are exclusively on meteorological
+    sensors).
+
+    Verbs:
+
+      ``list --station S | --device <id> | --entity <id> [filters]``
+                            Listing for one entity. Standard filter set
+                            (--type, --reason, --since, --participants,
+                            --open / --completed).
+      ``show <id_maintenance>``
+                            One vitjun's full detail, including the
+                            ``maintenance_attribute_values`` rows.
+
+    Exit codes: 0 success, 1 lookup miss / no records, 2 usage error.
+    """
+    import json as _json
+
+    from .api.tos_client import TOSClient
+
+    p = argparse.ArgumentParser(
+        prog="tos visit",
+        description=(
+            "Inspect TOS vitjun (visit / maintenance) records. Vitjanir "
+            "are entity-attached temporal records (id_maintenance "
+            "namespace) — every visit hangs off an id_entity (station "
+            "or device).\n\n"
+            "Verbs:\n"
+            "  list --station S        Vitjanir attached to station S.\n"
+            "  list --device <id>      Vitjanir attached to a device by id_entity.\n"
+            "  list --entity <id>      Escape hatch — any entity by id_entity.\n"
+            "  show <id_maintenance>   One vitjun's full detail.\n\n"
+            "List accepts the standard visit-filter set: --type, "
+            "--reason (repeatable), --since DATE, --participants SUBSTR, "
+            "--open / --completed."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    sub = p.add_subparsers(dest="verb", required=True)
+
+    p_list = sub.add_parser(
+        "list",
+        help="List vitjanir attached to one entity (station / device).",
+        description=(
+            "List vitjun records for one entity. Exactly one of "
+            "--station, --device, --entity is required.\n\n"
+            "Default sort: start_time descending (most recent first). "
+            "Use --json for machine-readable output, or pass the "
+            "standard visit-filter set to narrow the listing."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    target_group = p_list.add_mutually_exclusive_group(required=True)
+    target_group.add_argument(
+        "--station",
+        default=None,
+        help="Station marker (e.g. HEDI) or display name. Primary affordance.",
+    )
+    target_group.add_argument(
+        "--device",
+        dest="device_id",
+        type=int,
+        default=None,
+        help=(
+            "Device id_entity. Useful for meteorological sensors and "
+            "(eventually) device-lifecycle vitjanir on GPS receivers."
+        ),
+    )
+    target_group.add_argument(
+        "--entity",
+        dest="entity_id",
+        type=int,
+        default=None,
+        help=(
+            "Escape hatch — any id_entity directly. Bypasses station/"
+            "device naming entirely."
+        ),
+    )
+    add_visit_filter_arguments(p_list)
+    p_list.add_argument(
+        "--json", action="store_true", help="Emit raw JSON instead of pretty."
+    )
+    p_list.add_argument(
+        "--server",
+        default="vi-api.vedur.is",
+        help="TOS API host (default: vi-api.vedur.is).",
+    )
+    p_list.add_argument("--port", type=int, default=443)
+
+    p_show = sub.add_parser(
+        "show",
+        help="Show one vitjun's full detail by id_maintenance.",
+        description=(
+            "Display all fields for one vitjun, including the "
+            "maintenance_attribute_values rows (with each row's "
+            "id_maintenance_attribute_value — needed by the writer for "
+            "updates). Use the id from `tos visit list`."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p_show.add_argument(
+        "id_maintenance",
+        type=int,
+        help="The vitjun's id_maintenance (column 'id' in `tos visit list`).",
+    )
+    p_show.add_argument(
+        "--json", action="store_true", help="Emit raw JSON instead of pretty."
+    )
+    p_show.add_argument(
+        "--server",
+        default="vi-api.vedur.is",
+        help="TOS API host (default: vi-api.vedur.is).",
+    )
+    p_show.add_argument("--port", type=int, default=443)
+
+    args = p.parse_args(argv)
+
+    scheme = "https" if args.port == 443 else "http"
+    base_url = f"{scheme}://{args.server}:{args.port}/tos/v1"
+    client = TOSClient(base_url=base_url)
+
+    if args.verb == "list":
+        # Resolve the target entity. Three input styles:
+        #   --station S      → marker / display-name resolution
+        #   --device <id>    → direct id_entity (no resolution)
+        #   --entity <id>    → direct id_entity (no resolution)
+        # Device vs entity is semantic only — both feed the same
+        # endpoint. The split exists so `--device` reads naturally on
+        # the operator's eye for the eventual lifecycle-tracker use case.
+        if args.station is not None:
+            id_entity = _resolve_parent_id(client, station_marker=args.station)
+            if id_entity is None:
+                print(
+                    f"No station found for marker {args.station!r}",
+                    file=sys.stderr,
+                )
+                return 1
+            target_label = args.station
+            target_kind = "station"
+        elif args.device_id is not None:
+            id_entity = args.device_id
+            target_label = f"device {id_entity}"
+            target_kind = "device"
+        else:
+            id_entity = args.entity_id
+            target_label = f"entity {id_entity}"
+            target_kind = "entity"
+
+        rows = client.list_maintenance_visits(id_entity)
+        rows = apply_visit_filters(rows, args)
+        # Most recent first — operators usually want the latest visit
+        # at the top, drilling backwards in time.
+        rows = sorted(rows, key=lambda r: r.get("start_time") or "", reverse=True)
+
+        if args.json:
+            payload = {
+                "target_kind": target_kind,
+                "target_label": target_label,
+                "id_entity": id_entity,
+                "visits": rows,
+            }
+            print(_json.dumps(payload, ensure_ascii=False, indent=2))
+            return 0
+
+        from rich.console import Console
+
+        console = Console()
+        _render_visits_table(
+            console,
+            rows,
+            title=f"Vitjanir — {len(rows)} record(s) for {target_label}",
+        )
+        if rows:
+            console.print()
+            sample_id = rows[0].get("id")
+            console.print(f"[dim]Drill: tos visit show {sample_id}[/dim]")
+        return 0
+
+    if args.verb == "show":
+        visit = client.get_maintenance_visit(args.id_maintenance)
+        if not visit:
+            print(
+                f"No vitjun found for id_maintenance={args.id_maintenance}",
+                file=sys.stderr,
+            )
+            return 1
+        if args.json:
+            print(_json.dumps(visit, ensure_ascii=False, indent=2))
+            return 0
+        from rich.console import Console
+
+        console = Console()
+        _render_visit_detail(console, visit)
+        return 0
+
+    return 2
+
+
+def _render_visits_table(
+    console,
+    visits: List[Dict[str, Any]],
+    *,
+    title: str,
+) -> None:
+    """Render a vitjun list table.
+
+    Columns: id, start_time, type, reasons, participants, completed,
+    work-summary. ``end_time`` is suppressed by default — most visits
+    are instantaneous (``end_time == start_time``) and the column adds
+    visual noise. Drill via ``tos visit show <id>`` for full detail.
+    """
+    from rich.table import Table
+
+    if not visits:
+        console.print(title)
+        console.print("  (no vitjanir on file)")
+        return
+
+    table = Table(title=title)
+    table.add_column("id", justify="right")
+    table.add_column("start")
+    table.add_column("type")
+    table.add_column("reasons")
+    table.add_column("participants")
+    table.add_column("done")
+    table.add_column("work (first line)")
+
+    for v in visits:
+        vid = v.get("id")
+        start = (v.get("start_time") or "")[:10]
+        vtype = v.get("maintenance_type") or "—"
+        type_color = "green" if vtype == "on_site" else "blue"
+        vtype_cell = f"[{type_color}]{vtype}[/{type_color}]"
+        reasons = (v.get("reason") or "").replace(",", ", ") or "—"
+        participants = v.get("participants_names") or v.get("participants") or "—"
+        completed = v.get("completed")
+        if completed is True:
+            done_cell = "[green]yes[/green]"
+        elif completed is False:
+            done_cell = "[yellow]open[/yellow]"
+        else:
+            done_cell = "—"
+        work = (v.get("work") or "").splitlines()
+        work_first = (work[0] if work else "") or "—"
+        if len(work_first) > 60:
+            work_first = work_first[:57] + "..."
+        table.add_row(
+            str(vid) if vid is not None else "?",
+            start,
+            vtype_cell,
+            reasons,
+            str(participants),
+            done_cell,
+            work_first,
+        )
+    console.print(table)
+
+
+def _render_visit_detail(console, visit: Dict[str, Any]) -> None:
+    """Render one vitjun's full detail (the `show` verb output).
+
+    Header (id / type / dates / completed / participants / reasons) +
+    a free-text panel (work / comment / remaining) + the
+    ``maintenance_attribute_values`` rows with each row's
+    ``id_maintenance_attribute_value`` (needed by the writer for
+    updates).
+
+    The detail endpoint doesn't carry ``id_entity`` or a flat
+    ``reason`` / ``work`` / ``comment`` / ``remaining`` field —
+    everything except the header columns lives in
+    ``maintenance_attribute_values``. We source from there.
+    """
+    from rich.table import Table
+
+    vid = visit.get("id_maintenance") or visit.get("id")
+    vtype = visit.get("maintenance_type") or "—"
+    start = visit.get("start_time") or "—"
+    end = visit.get("end_time") or "—"
+    completed = visit.get("completed")
+    completed_label = (
+        "yes" if completed is True else "open" if completed is False else "—"
+    )
+    completed_color = (
+        "green" if completed is True else "yellow" if completed is False else ""
+    )
+
+    # Build a code → (id_av, value) lookup from the attribute_value rows.
+    # This is the only place ``work`` / ``comment`` / ``remaining`` /
+    # ``reason_*`` actually live in the detail payload.
+    av_rows: List[Dict[str, Any]] = visit.get("maintenance_attribute_values") or []
+    by_code: Dict[str, Dict[str, Any]] = {
+        (av.get("code") or ""): av for av in av_rows if av.get("code")
+    }
+
+    # Active reason codes — booleans on the attribute_value rows.
+    active_reasons = [
+        code[len("reason_") :]
+        for code, av in by_code.items()
+        if code.startswith("reason_") and str(av.get("value")).lower() == "true"
+    ]
+    reasons_display = (
+        ", ".join(MAINTENANCE_REASON_DISPLAY.get(c, c) for c in active_reasons) or "—"
+    )
+
+    header = Table(title=f"Vitjun {vid}", show_header=False)
+    header.add_column("field", style="bold")
+    header.add_column("value")
+    header.add_row("id_maintenance", str(vid) if vid is not None else "?")
+    header.add_row(
+        "maintenance_type",
+        f"[{'green' if vtype == 'on_site' else 'blue'}]{vtype}[/]",
+    )
+    header.add_row("start_time", str(start))
+    header.add_row("end_time", str(end))
+    header.add_row(
+        "completed",
+        (
+            f"[{completed_color}]{completed_label}[/]"
+            if completed_color
+            else completed_label
+        ),
+    )
+    header.add_row(
+        "participants",
+        str(visit.get("participants_names") or visit.get("participants") or "—"),
+    )
+    header.add_row("reasons", reasons_display)
+    console.print(header)
+
+    # Free-text fields, sourced from attribute_value rows. Always render
+    # so the operator sees which slots exist on a vitjun at a glance,
+    # even when empty.
+    text_table = Table(title="Notes", show_header=False)
+    text_table.add_column("field", style="bold")
+    text_table.add_column("text")
+    for code in ("work", "comment", "remaining"):
+        av = by_code.get(code) or {}
+        val = av.get("value") or "—"
+        text_table.add_row(code, str(val))
+    console.print()
+    console.print(text_table)
+
+    # Raw attribute_value rows — same shape the writer needs for
+    # updates. Always shown (low-cost; the writer-to-be will copy
+    # id_maintenance_attribute_value values from here).
+    if av_rows:
+        av_table = Table(title=f"maintenance_attribute_values — {len(av_rows)} row(s)")
+        av_table.add_column("id_av", justify="right")
+        av_table.add_column("code")
+        av_table.add_column("value")
+        for av in av_rows:
+            av_table.add_row(
+                str(av.get("id_maintenance_attribute_value") or "?"),
+                str(av.get("code") or "?"),
+                str(av.get("value") or "—"),
+            )
+        console.print()
+        console.print(av_table)
 
 
 def _fleet_main(argv):
@@ -7255,6 +7808,13 @@ def _print_top_level_help() -> None:
         "               contact show --id N     One contact record.\n"
         "               contact list --station S  Contacts for a station.\n"
         "\n"
+        "  visit      Inspect TOS vitjun (visit / maintenance) records.\n"
+        "               visit list --station S         Vitjanir for a station.\n"
+        "               visit list --device <id>       Vitjanir for a device.\n"
+        "               visit show <id_maintenance>    One vitjun's full detail.\n"
+        "             Filters: --type, --reason, --since, --participants,\n"
+        "                      --open / --completed.\n"
+        "\n"
         "  fleet      Fleet-wide orchestrators (loop station verbs over\n"
         "             every GNSS station in stations.cfg ~173 sites).\n"
         "               fleet status            Bulk verify oracle —\n"
@@ -7324,6 +7884,8 @@ def main(argv=None):
             return _contact_main(rest)
         if subcmd == "fleet":
             return _fleet_main(rest)
+        if subcmd == "visit":
+            return _visit_main(rest)
     print(f"tos: unknown subcommand {argv[0]!r}\n", file=sys.stderr)
     _print_top_level_help()
     return 2

--- a/tests/test_station_show.py
+++ b/tests/test_station_show.py
@@ -16,12 +16,20 @@ from tostools.tos import _station_show_main
 
 
 def _show_args(**overrides):
-    """Namespace matching the `tos station show` argparser defaults."""
+    """Namespace matching the `tos station show` argparser defaults.
+
+    Note: ``no_visits`` defaults to True in this helper so the existing
+    test suite (written before Phase A.2 of the vitjanir expansion)
+    doesn't need a per-test ``TOSClient.list_maintenance_visits`` patch.
+    New visit-aware tests pass ``no_visits=False`` explicitly and patch
+    the method themselves.
+    """
     defaults = {
         "station": "HEDI",
         "show_all": False,
         "device_mode": False,
         "attributes_only": False,
+        "no_visits": True,
         "json": False,
         "server": "vi-api.vedur.is",
         "port": 443,
@@ -855,3 +863,173 @@ def test_show_empty_payload_returns_1(capsys):
     assert rc == 1
     err = capsys.readouterr().err
     assert "id_entity=4257 returned no history payload" in err
+
+
+# ---------------------------------------------------------------------------
+# Phase A.2 — aggregated vitjanir section
+# ---------------------------------------------------------------------------
+
+
+def _visit(id, *, start, completed=True, reason="Viðgerð", work="—"):
+    """Compact vitjun row matching the list-endpoint shape."""
+    return {
+        "id": id,
+        "maintenance_type": "on_site",
+        "start_time": f"{start}T10:00:00",
+        "end_time": f"{start}T11:00:00",
+        "reason": reason,
+        "participants": "bgo@vedur.is",
+        "participants_names": "Benedikt G. Ófeigsson",
+        "work": work,
+        "remaining": None,
+        "completed": completed,
+    }
+
+
+def test_show_visits_aggregates_station_plus_joined_devices(capsys):
+    """Default view (no_visits=False) renders the Recent vitjanir
+    section with rows from BOTH the station and each currently-joined
+    device, with attribution labels distinguishing them. This is the
+    forward-compat hook for Phase C lifecycle-tracker vitjanir."""
+    station_visits = [_visit(5490, start="2026-05-22", work="skipti um kapal")]
+    device_visits = {
+        21197: [_visit(9001, start="2025-12-10", work="firmware 3.00 → 3.01")],
+    }
+
+    def fake_list_visits(self_, eid):
+        if eid == 4257:
+            return station_visits
+        return device_visits.get(eid, [])
+
+    with (
+        patch("tostools.tos._resolve_parent_id", return_value=4257),
+        patch.object(
+            TOSClient,
+            "get_entity_history",
+            side_effect=_fake_get_entity_history_factory(4257),
+        ),
+        patch.object(TOSClient, "get_contacts", return_value=[]),
+        patch.object(
+            TOSClient,
+            "list_maintenance_visits",
+            autospec=True,
+            side_effect=fake_list_visits,
+        ),
+    ):
+        rc = _station_show_main(_show_args(no_visits=False))
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    # Section title shows the aggregate count + joined-device count.
+    assert "Recent vitjanir" in out
+    # The "(aggregated from station + 1 joined device(s))" line is a
+    # plain console.print, not the Rich table title — survives non-TTY
+    # console-width truncation.
+    assert "aggregated from station + 1 joined device(s)" in out
+    # Both ids surface (Rich may wrap long labels, so check ids only).
+    assert "5490" in out
+    assert "9001" in out
+    # Attribution column present (Rich wraps the cell content, so
+    # check the column header + the per-source kind separately).
+    assert "source" in out
+    assert "station" in out
+    assert "21197" in out
+
+
+def test_show_no_visits_suppresses_section_and_skips_http(capsys):
+    """--no-visits suppresses the section AND avoids the
+    list_maintenance_visits roundtrips entirely (relevant on slow
+    links / when the operator only wants identity + attributes)."""
+    with (
+        patch("tostools.tos._resolve_parent_id", return_value=4257),
+        patch.object(
+            TOSClient,
+            "get_entity_history",
+            side_effect=_fake_get_entity_history_factory(4257),
+        ),
+        patch.object(TOSClient, "get_contacts", return_value=[]),
+        patch.object(
+            TOSClient, "list_maintenance_visits", autospec=True
+        ) as list_visits,
+    ):
+        rc = _station_show_main(_show_args(no_visits=True))
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Recent vitjanir" not in out
+    list_visits.assert_not_called()
+
+
+def test_show_visits_trims_to_open_plus_last_3_closed_by_default(capsys):
+    """Default trim: every open visit + 3 most-recent closed.
+    --all (show_all=True) extends to full history."""
+    # 1 open + 5 closed on the station, none on the device.
+    station_visits = [
+        _visit(1, start="2024-01-01", completed=False),  # open
+        _visit(2, start="2026-05-22", completed=True),
+        _visit(3, start="2025-12-15", completed=True),
+        _visit(4, start="2023-05-17", completed=True),
+        _visit(5, start="2018-02-06", completed=True),
+        _visit(6, start="2015-08-08", completed=True),
+    ]
+
+    def fake_list_visits(self_, eid):
+        if eid == 4257:
+            return station_visits
+        return []
+
+    # Default — open + 3 closed = 4 rendered, 2 hidden
+    with (
+        patch("tostools.tos._resolve_parent_id", return_value=4257),
+        patch.object(
+            TOSClient,
+            "get_entity_history",
+            side_effect=_fake_get_entity_history_factory(4257),
+        ),
+        patch.object(TOSClient, "get_contacts", return_value=[]),
+        patch.object(
+            TOSClient,
+            "list_maintenance_visits",
+            autospec=True,
+            side_effect=fake_list_visits,
+        ),
+    ):
+        rc = _station_show_main(_show_args(no_visits=False))
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Recent vitjanir — 4 record(s)" in out
+    assert "2 more closed" in out
+    assert "--all" in out
+
+
+def test_show_json_includes_visits(capsys):
+    """JSON payload carries an `visits` array with __source_label per row."""
+    station_visits = [_visit(5490, start="2026-05-22")]
+
+    def fake_list_visits(self_, eid):
+        return station_visits if eid == 4257 else []
+
+    with (
+        patch("tostools.tos._resolve_parent_id", return_value=4257),
+        patch.object(
+            TOSClient,
+            "get_entity_history",
+            side_effect=_fake_get_entity_history_factory(4257),
+        ),
+        patch.object(TOSClient, "get_contacts", return_value=[]),
+        patch.object(
+            TOSClient,
+            "list_maintenance_visits",
+            autospec=True,
+            side_effect=fake_list_visits,
+        ),
+    ):
+        rc = _station_show_main(_show_args(no_visits=False, json=True))
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert "visits" in payload
+    assert len(payload["visits"]) == 1
+    assert payload["visits"][0]["id"] == 5490
+    assert payload["visits"][0]["__source_label"] == "station HEDI"
+    assert payload["visits"][0]["__source_kind"] == "station"

--- a/tests/test_tos_client.py
+++ b/tests/test_tos_client.py
@@ -82,7 +82,13 @@ def test_get_parent_history_tolerates_missing_time_from():
 
 
 def _show_args(**overrides):
-    """Build an argparse.Namespace shaped like `tos device show`'s parser."""
+    """Build an argparse.Namespace shaped like `tos device show`'s parser.
+
+    Note: ``no_visits`` defaults to True so the pre-Phase-A.2 tests
+    don't need a per-test ``list_maintenance_visits`` patch. New
+    visit-aware tests pass ``no_visits=False`` explicitly and supply
+    their own patch.
+    """
     from argparse import Namespace
 
     defaults = {
@@ -92,6 +98,7 @@ def _show_args(**overrides):
         "server": "vi-api.vedur.is",
         "port": 443,
         "json": False,
+        "no_visits": True,
         # Section flags (mutually exclusive at parse time; default all False
         # = "print all sections").
         "section_list": False,
@@ -1290,3 +1297,316 @@ def test_apply_visit_filters_tolerates_missing_args_attrs():
     rows = [_visit(id=1)]
     bare_ns = Namespace()
     assert apply_visit_filters(rows, bare_ns) == rows
+
+
+def test_maintenance_reason_display_pins_known_translations():
+    """The English-code → Icelandic-display map MUST stay accurate.
+    `change` / `repairs` / `improvements` were empirically verified
+    against live TOS 2026-05-30. `inspection` / `other` are best-
+    guesses (unused in the current GPS fleet) — if anyone "fixes" them
+    without confirming against live data this test should fail loudly
+    rather than silently break the --reason filter."""
+    from tostools.tos import MAINTENANCE_REASON_CODES, MAINTENANCE_REASON_DISPLAY
+
+    # Map must cover every code accepted by the filter / writer.
+    assert set(MAINTENANCE_REASON_DISPLAY.keys()) == set(MAINTENANCE_REASON_CODES)
+
+    # Empirically-verified translations (live TOS, 2026-05-30).
+    assert MAINTENANCE_REASON_DISPLAY["change"] == "Breyting"
+    assert MAINTENANCE_REASON_DISPLAY["repairs"] == "Viðgerð"
+    assert MAINTENANCE_REASON_DISPLAY["improvements"] == "Endurbætur"
+
+    # Best-guess translations — keep flagged in the docstring on the
+    # constant. Update both the constant AND this test together when
+    # live data reveals the true strings.
+    assert MAINTENANCE_REASON_DISPLAY["inspection"] == "Skoðun"
+    assert MAINTENANCE_REASON_DISPLAY["other"] == "Annað"
+
+
+# ---------------------------------------------------------------------------
+# _visit_main — dispatcher / end-to-end shape for `tos visit list / show`
+# ---------------------------------------------------------------------------
+
+
+def test_visit_list_station_resolves_marker_and_renders(capsys):
+    """`tos visit list --station HEDI` resolves the marker, fetches the
+    station's visits, sorts most-recent first, renders the Rich table."""
+    from tostools.tos import _visit_main
+
+    visits = [
+        _visit(id=1, start_time="2018-02-06T09:30:00"),  # older
+        _visit(id=2, start_time="2026-05-22T15:00:00"),  # newer
+    ]
+    with (
+        patch("tostools.tos._resolve_parent_id", return_value=4316),
+        patch.object(
+            TOSClient, "list_maintenance_visits", autospec=True, return_value=visits
+        ) as lmv,
+    ):
+        rc = _visit_main(["list", "--station", "HEDI"])
+
+    assert rc == 0
+    lmv.assert_called_once()
+    # Second positional arg is the resolved id_entity.
+    assert lmv.call_args.args[1] == 4316
+    out = capsys.readouterr().out
+    assert "Vitjanir — 2 record(s) for HEDI" in out
+    # Both ids surface.
+    assert " 1 " in out
+    assert " 2 " in out
+
+
+def test_visit_list_device_skips_resolver(capsys):
+    """`tos visit list --device <id>` takes id_entity directly — no
+    marker resolution. Pinned because Phase C lifecycle-tracker writes
+    will lean on this path."""
+    from tostools.tos import _visit_main
+
+    with (
+        patch("tostools.tos._resolve_parent_id") as resolver,
+        patch.object(
+            TOSClient, "list_maintenance_visits", autospec=True, return_value=[]
+        ) as lmv,
+    ):
+        rc = _visit_main(["list", "--device", "21044"])
+
+    assert rc == 0
+    resolver.assert_not_called()
+    assert lmv.call_args.args[1] == 21044
+    out = capsys.readouterr().out
+    assert "device 21044" in out
+    assert "(no vitjanir on file)" in out
+
+
+def test_visit_list_entity_target(capsys):
+    """`--entity <id>` is the generic escape hatch."""
+    from tostools.tos import _visit_main
+
+    with (
+        patch.object(
+            TOSClient, "list_maintenance_visits", autospec=True, return_value=[]
+        ) as lmv,
+    ):
+        rc = _visit_main(["list", "--entity", "4300"])
+
+    assert rc == 0
+    assert lmv.call_args.args[1] == 4300
+    assert "entity 4300" in capsys.readouterr().out
+
+
+def test_visit_list_target_mutually_exclusive():
+    """argparse must reject --station + --device on the same call."""
+    import pytest
+
+    from tostools.tos import _visit_main
+
+    # argparse exits with SystemExit(2) on mutually-exclusive violation.
+    with pytest.raises(SystemExit) as exc:
+        _visit_main(["list", "--station", "HEDI", "--device", "4316"])
+    assert exc.value.code == 2
+
+
+def test_visit_list_reason_filter_applies_translation(capsys):
+    """The --reason CLI flag should translate operator codes to the
+    Icelandic display strings and filter; verifying the dispatcher
+    wires it through (filter unit-tested separately)."""
+    from tostools.tos import _visit_main
+
+    visits = [
+        _visit(id=10, reason="Viðgerð"),
+        _visit(id=11, reason="Breyting"),
+    ]
+    with (
+        patch("tostools.tos._resolve_parent_id", return_value=4316),
+        patch.object(
+            TOSClient, "list_maintenance_visits", autospec=True, return_value=visits
+        ),
+    ):
+        rc = _visit_main(["list", "--station", "HEDI", "--reason", "change"])
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    # Only the Breyting row survives.
+    assert " 11 " in out
+    assert " 10 " not in out
+
+
+def test_visit_list_unresolvable_station_returns_1(capsys):
+    from tostools.tos import _visit_main
+
+    with patch("tostools.tos._resolve_parent_id", return_value=None):
+        rc = _visit_main(["list", "--station", "XXXX"])
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "No station found for marker 'XXXX'" in err
+
+
+def test_visit_show_renders_detail_from_attribute_values(capsys):
+    """The detail endpoint doesn't carry top-level `work` / `comment`
+    / `reason` — those live in `maintenance_attribute_values`. Pin
+    that the renderer sources them from there (we caught this as a
+    real bug during smoke-test of the initial Phase A.1 implementation)."""
+    from tostools.tos import _visit_main
+
+    detail = {
+        "id_maintenance": 5490,
+        "maintenance_type": "on_site",
+        "start_time": "2026-05-22T15:00:00",
+        "end_time": "2026-05-22T00:00:00",
+        "participants": "bgo@vedur.is",
+        "completed": True,
+        "maintenance_attribute_values": [
+            {
+                "id_maintenance_attribute_value": 67567,
+                "code": "reason_change",
+                "value": "false",
+            },
+            {
+                "id_maintenance_attribute_value": 67569,
+                "code": "reason_repairs",
+                "value": "true",
+            },
+            {
+                "id_maintenance_attribute_value": 67570,
+                "code": "work",
+                "value": "skipti um loftnetskapal",
+            },
+        ],
+    }
+    with patch.object(
+        TOSClient, "get_maintenance_visit", autospec=True, return_value=detail
+    ):
+        rc = _visit_main(["show", "5490"])
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Vitjun 5490" in out
+    assert "skipti um loftnetskapal" in out
+    # Reason booleans → Icelandic display via MAINTENANCE_REASON_DISPLAY.
+    assert "Viðgerð" in out
+    # Raw attribute_value table includes the id_av for writer/update use.
+    assert "67567" in out
+    assert "reason_change" in out
+
+
+def test_visit_show_missing_returns_1(capsys):
+    from tostools.tos import _visit_main
+
+    with patch.object(
+        TOSClient, "get_maintenance_visit", autospec=True, return_value=None
+    ):
+        rc = _visit_main(["show", "99999999"])
+
+    assert rc == 1
+    assert "No vitjun found for id_maintenance=99999999" in capsys.readouterr().err
+
+
+def test_visit_show_json_emits_raw_detail(capsys):
+    import json as _json
+
+    from tostools.tos import _visit_main
+
+    detail = {"id_maintenance": 5490, "maintenance_type": "on_site"}
+    with patch.object(
+        TOSClient, "get_maintenance_visit", autospec=True, return_value=detail
+    ):
+        rc = _visit_main(["show", "5490", "--json"])
+
+    assert rc == 0
+    assert _json.loads(capsys.readouterr().out) == detail
+
+
+# ---------------------------------------------------------------------------
+# Device-show Phase A.2 — visits section
+# ---------------------------------------------------------------------------
+
+
+def test_device_show_visits_section_renders_when_default(capsys):
+    """Default view (no --no-visits, no section flag): the "Recent
+    vitjanir" section renders below the parent-history table."""
+    from tostools.tos import _device_show_main
+
+    fake_history = {
+        "id_entity": 21044,
+        "code_entity_subtype": "thermometer_platinum",
+        "attributes": [],
+    }
+    visits = [_visit(id=5367, start_time="2026-02-24T08:00:00")]
+
+    with (
+        patch("tostools.devices.find_device", return_value=fake_history),
+        patch.object(TOSClient, "get_parent_history", return_value=[]),
+        patch.object(
+            TOSClient, "list_maintenance_visits", autospec=True, return_value=visits
+        ) as lmv,
+    ):
+        rc = _device_show_main(_show_args(id_entity=21044, no_visits=False))
+
+    assert rc == 0
+    lmv.assert_called_once()
+    assert lmv.call_args.args[1] == 21044
+    out = capsys.readouterr().out
+    assert "Recent vitjanir — 1 record(s) for device 21044" in out
+    assert "5367" in out
+
+
+def test_device_show_no_visits_suppresses_and_skips_http(capsys):
+    """--no-visits suppresses the section AND avoids the HTTP."""
+    from tostools.tos import _device_show_main
+
+    with (
+        patch("tostools.devices.find_device", return_value={"id_entity": 4830}),
+        patch.object(TOSClient, "get_parent_history", return_value=[]),
+        patch.object(TOSClient, "list_maintenance_visits", autospec=True) as lmv,
+    ):
+        rc = _device_show_main(_show_args(id_entity=4830, no_visits=True))
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Recent vitjanir" not in out
+    lmv.assert_not_called()
+
+
+def test_device_show_section_flag_suppresses_visits(capsys):
+    """Section flags (--list / --attributes / --attributes-history) put
+    the device-show into single-section mode. Visits should not render
+    in that mode even when --no-visits wasn't passed."""
+    from tostools.tos import _device_show_main
+
+    with (
+        patch("tostools.devices.find_device", return_value={"id_entity": 4830}),
+        patch.object(TOSClient, "get_parent_history", return_value=[]),
+        patch.object(TOSClient, "list_maintenance_visits", autospec=True) as lmv,
+    ):
+        rc = _device_show_main(
+            _show_args(id_entity=4830, section_list=True, no_visits=False)
+        )
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Recent vitjanir" not in out
+    lmv.assert_not_called()
+
+
+def test_device_show_json_includes_visits(capsys):
+    """JSON payload carries the `visits` array regardless of --no-visits."""
+    import json as _json
+
+    from tostools.tos import _device_show_main
+
+    visits = [_visit(id=5367, start_time="2026-02-24T08:00:00")]
+
+    with (
+        patch("tostools.devices.find_device", return_value={"id_entity": 21044}),
+        patch.object(TOSClient, "get_parent_history", return_value=[]),
+        patch.object(
+            TOSClient, "list_maintenance_visits", autospec=True, return_value=visits
+        ),
+    ):
+        rc = _device_show_main(_show_args(id_entity=21044, json=True))
+
+    assert rc == 0
+    payload = _json.loads(capsys.readouterr().out)
+    assert "visits" in payload
+    assert payload["visits"] == visits

--- a/tests/test_tos_client.py
+++ b/tests/test_tos_client.py
@@ -1096,3 +1096,197 @@ def test_device_show_attributes_suspicious_only_cleanup_artifact_rows(capsys):
     # model (2007-09-07) suppressed — value AND code label both absent.
     assert "TRIMBLE NETR9" not in out
     assert "model" not in out
+
+
+# ---------------------------------------------------------------------------
+# apply_visit_filters — pins the read-side vitjun-filter semantics
+# ---------------------------------------------------------------------------
+def _visit(**overrides):
+    """Build a vitjun row matching the shape from
+    :meth:`TOSClient.list_maintenance_visits`."""
+    defaults = {
+        "id": 1000,
+        "maintenance_type": "on_site",
+        "start_time": "2024-06-15T10:00:00",
+        "end_time": "2024-06-15T11:30:00",
+        "reason": "Viðgerð",
+        "participants": "bgo@vedur.is",
+        "participants_names": "Benedikt G. Ófeigsson",
+        "work": "—",
+        "remaining": None,
+        "completed": True,
+    }
+    defaults.update(overrides)
+    return defaults
+
+
+def _visit_filter_args(**overrides):
+    from argparse import Namespace
+
+    defaults = {
+        "visit_type": None,
+        "reasons": None,
+        "since": None,
+        "participants": None,
+        "open_only": False,
+        "completed_only": False,
+    }
+    defaults.update(overrides)
+    return Namespace(**defaults)
+
+
+def test_apply_visit_filters_no_constraints_passes_through():
+    from tostools.tos import apply_visit_filters
+
+    rows = [_visit(id=1), _visit(id=2, maintenance_type="remote")]
+    assert apply_visit_filters(rows, _visit_filter_args()) == rows
+
+
+def test_apply_visit_filters_visit_type_exact_match():
+    from tostools.tos import apply_visit_filters
+
+    rows = [
+        _visit(id=1, maintenance_type="on_site"),
+        _visit(id=2, maintenance_type="remote"),
+    ]
+    out = apply_visit_filters(rows, _visit_filter_args(visit_type="on_site"))
+    assert [r["id"] for r in out] == [1]
+
+
+def test_apply_visit_filters_reason_translates_to_icelandic_display():
+    """--reason takes English codes; matches against the Icelandic
+    display strings TOS emits on the list endpoint."""
+    from tostools.tos import apply_visit_filters
+
+    rows = [
+        _visit(id=1, reason="Breyting"),
+        _visit(id=2, reason="Viðgerð"),
+        _visit(id=3, reason="Endurbætur"),
+    ]
+    out = apply_visit_filters(rows, _visit_filter_args(reasons=["repairs"]))
+    assert [r["id"] for r in out] == [2]
+    out = apply_visit_filters(
+        rows, _visit_filter_args(reasons=["change", "improvements"])
+    )
+    assert [r["id"] for r in out] == [1, 3]
+
+
+def test_apply_visit_filters_reason_substring_match_within_comma_joined():
+    """Rows with multiple active reasons get comma-joined display
+    strings — the filter should still match on substring."""
+    from tostools.tos import apply_visit_filters
+
+    rows = [_visit(id=1, reason="Breyting, Viðgerð")]
+    assert apply_visit_filters(rows, _visit_filter_args(reasons=["repairs"])) == rows
+
+
+def test_apply_visit_filters_since_lex_compare_yyyy_mm_dd():
+    from tostools.tos import apply_visit_filters
+
+    rows = [
+        _visit(id=1, start_time="2023-01-15T08:00:00"),
+        _visit(id=2, start_time="2026-05-22T15:00:00"),
+        _visit(id=3, start_time="2018-02-06T09:30:00"),
+    ]
+    out = apply_visit_filters(rows, _visit_filter_args(since="2023-01-01"))
+    assert sorted(r["id"] for r in out) == [1, 2]
+
+
+def test_apply_visit_filters_since_excludes_rows_with_missing_start():
+    """A row that has no start_time can't be range-compared — drop
+    rather than silently pass through."""
+    from tostools.tos import apply_visit_filters
+
+    rows = [_visit(id=1, start_time=None)]
+    assert apply_visit_filters(rows, _visit_filter_args(since="2023-01-01")) == []
+
+
+def test_apply_visit_filters_participants_matches_names_or_emails():
+    """--participants is case-insensitive substring against either the
+    resolved names OR the raw email list (whichever has a value)."""
+    from tostools.tos import apply_visit_filters
+
+    rows = [
+        _visit(
+            id=1,
+            participants="bgo@vedur.is",
+            participants_names="Benedikt G. Ófeigsson",
+        ),
+        _visit(
+            id=2,
+            participants="bhb@vedur.is",
+            participants_names="Bergur Hermanns Bergsson",
+        ),
+    ]
+    # Email substring
+    out = apply_visit_filters(rows, _visit_filter_args(participants="bgo"))
+    assert [r["id"] for r in out] == [1]
+    # Name substring (case-insensitive)
+    out = apply_visit_filters(rows, _visit_filter_args(participants="bergur"))
+    assert [r["id"] for r in out] == [2]
+
+
+def test_apply_visit_filters_open_vs_completed():
+    from tostools.tos import apply_visit_filters
+
+    rows = [
+        _visit(id=1, completed=True),
+        _visit(id=2, completed=False),
+        _visit(id=3, completed=None),
+    ]
+    assert [
+        r["id"] for r in apply_visit_filters(rows, _visit_filter_args(open_only=True))
+    ] == [2, 3]
+    assert [
+        r["id"]
+        for r in apply_visit_filters(rows, _visit_filter_args(completed_only=True))
+    ] == [1]
+
+
+def test_apply_visit_filters_combines_with_and():
+    from tostools.tos import apply_visit_filters
+
+    rows = [
+        _visit(
+            id=1,
+            maintenance_type="on_site",
+            reason="Viðgerð",
+            completed=True,
+            start_time="2023-05-17T08:00:00",
+        ),
+        _visit(
+            id=2,
+            maintenance_type="remote",
+            reason="Viðgerð",
+            completed=True,
+            start_time="2023-05-17T08:00:00",
+        ),
+        _visit(
+            id=3,
+            maintenance_type="on_site",
+            reason="Breyting",
+            completed=True,
+            start_time="2023-05-17T08:00:00",
+        ),
+    ]
+    out = apply_visit_filters(
+        rows,
+        _visit_filter_args(
+            visit_type="on_site",
+            reasons=["repairs"],
+            completed_only=True,
+        ),
+    )
+    assert [r["id"] for r in out] == [1]
+
+
+def test_apply_visit_filters_tolerates_missing_args_attrs():
+    """Behaves as "no constraint" when the args namespace lacks visit
+    filter attrs (e.g. helper invoked outside the standard CLI path)."""
+    from argparse import Namespace
+
+    from tostools.tos import apply_visit_filters
+
+    rows = [_visit(id=1)]
+    bare_ns = Namespace()
+    assert apply_visit_filters(rows, bare_ns) == rows


### PR DESCRIPTION
Phase A of the vitjanir CLI expansion (planned in the scoping turn). Pure-read foundation — no writes, no auth required. Reachable via `TOSClient.list_maintenance_visits` / `get_maintenance_visit` (new public-read methods mirroring the auth-gated writer copies; duplication noted per memory `project_tos_client_writer_read_duplication`).

## Phase A.1 — `tos visit list / show` + shared filter set
Commit `3620729`.

New verbs at the entity layer:
```
tos visit list --station S | --device <id> | --entity <id>
tos visit show <id_maintenance>
```

Filter set on `list` (mirrors `add_device_filter_arguments` /
`add_attribute_filter_arguments`):
- `--type {on_site,remote}`
- `--reason CODE` (repeatable; `change` / `repairs` / `inspection` / `improvements` / `other`)
- `--since DATE`, `--participants SUBSTR`, `--open` / `--completed`

The `--reason` filter takes English codes and translates through `MAINTENANCE_REASON_DISPLAY` (`change → Breyting`, `repairs → Viðgerð`, `improvements → Endurbætur`, `inspection → Skoðun`, `other → Annað`) to match the Icelandic strings TOS emits on the list endpoint. The first three are empirically verified against live data; the last two are best-guesses (unused in current GPS fleet) — flagged in the constant's docstring + pinned by a test that fails loudly if anyone changes them without re-verifying.

The detail-view renderer sources `work` / `comment` / `remaining` + per-reason booleans from `maintenance_attribute_values` rows (where they actually live) rather than the top-level dict — caught during live smoke-test of an earlier draft.

10 filter-semantics tests.

## Phase A.2 — Station/device show + 18 tests
Commit `8895623`.

`tos station show <STN>` gains a "Recent vitjanir" section that **aggregates** vitjanir from the station + currently-joined devices. Each row carries a `source` column for attribution ("station HEDI" vs "device 21044 (thermometer_platinum)"). Forward-compatible with Phase C: when device-attached vitjanir start landing on GPS receivers / antennas via the lifecycle tracker, they surface here automatically without extra plumbing.

`tos device show --id <id>` gets its own visits section (own device only, asymmetric per the data flow).

Both:
- Default trim: all open + 3 most-recent closed; hidden-count hint when there are more
- `--no-visits` suppresses the section AND skips the HTTP
- `--all` on station show extends to full history
- JSON payload includes the `visits` array (always-on in JSON)

Shared helpers:
- `_render_visits_table(source_label_col=...)` — optional attribution column
- `_trim_visits_for_show(visits, show_all=...)` — returns `(visible, hidden)`
- Section titles moved out of Rich Table titles (which hard-wrap to content width) and into preceding `console.print()` lines so the section header survives non-TTY width truncation in tests

18 new tests covering: aggregation + attribution columns, --no-visits suppression of HTTP, default trim with hidden hint, JSON shape including `__source_label` / `__source_kind`, device-show all the same paths, plus 7 `_visit_main` dispatcher tests (target group mutual exclusion, --reason code-translation pass-through, --entity escape hatch, lookup failures, detail render from attribute_values), plus the MAINTENANCE_REASON_DISPLAY pin-test.

## Empirical findings
Confirmed during this work (relevant for Phase B / C / D scoping):
- Vitjanir attach to **both stations and devices** in TOS — schema is generic on `id_entity`. In GPS data 100% are station-attached today; device-attached vitjanir exist exclusively on meteorological sensors (`datalogger`, `thermometer_platinum`, `barometer_digital`, etc.).
- 65 of 1300 probed entity ids carry vitjanir; sample IDs documented inline in the scoping conversation.
- TOS list endpoint flattens per-code booleans into a single `reason` string with comma-joined Icelandic display strings — codes only available via the detail endpoint.

## Test plan
- [x] `pytest tests/` — 902 passed, 2 skipped
- [x] `ruff check` — clean
- [x] `black --check` — clean
- [x] Live smoke-test on HEDI (4 vitjanir), HOFN, SAVI; meteorological device 21044 (3 vitjanir, no participants for some); GPS receiver 4830 (no vitjanir).
- [x] Live smoke-test of every filter: --type, --reason (all 5 codes), --since, --participants, --open, --completed, combinations.
- [x] Live smoke-test of station show aggregation and --no-visits suppression.
- [ ] Confirm Phase B / C / D phase ordering still holds (advisor next turn).

## Next
- Phase B: `tos visit add` (record-forward write verb)
- Phase C: device lifecycle tracker (auto-paired vitjanir on routine device ops — the new driver the operator added during scoping)
- Phase D: `tos audit visit-coverage` (invariant audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)