### PR TITLE
feat(tos): tos visit add — record-forward write verb (Phase B)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -313,6 +313,7 @@ tos device show --id <id>          # device detail (with Recent vitjanir)
 tos visit list --station <STN>     # vitjanir attached to a station
 tos visit list --device <id>       # vitjanir attached to a device
 tos visit show <id_maintenance>    # one vitjun, full detail
+tos visit add  --station <STN> --start DATE [opts]  # new vitjun (dry-run default)
 tos audit apply <triage_file>      # dry-run; --apply to commit
 tos fleet status                   # bulk verify oracle (exit 0/1/2)
 tos fleet triage                   # generate per-station triage files
@@ -353,6 +354,16 @@ closed. Station show aggregates from the station + currently-joined
 devices with a `source` column for attribution (forward-compatible
 with Phase C). `--no-visits` suppresses the section (and skips the
 HTTP); `--all` on station show extends to full visit history.
+
+**`tos visit add`** (Phase B — record-forward write verb):
+
+  * `tos visit add --station S --start DATE [--end DATE] [--type {on_site,remote}] [--participants EMAIL ...] [--reason CODE ...] [--work TEXT] [--comment TEXT] [--remaining TEXT] [--no-completed] [--no-dry-run]`
+  * Dry-run by default — payloads are logged but no writes are sent (matches `tos device add`). `--no-dry-run` commits (requires TOS credentials).
+  * Target: `--station S` (resolved via marker), `--device <id>` (direct id_entity, semantically a device — the Phase C lifecycle tracker's main path), or `--entity <id>` (escape hatch).
+  * Validation: `--reason` choices restricted to `MAINTENANCE_REASON_CODES`; argparse rejects bad codes before the writer. The writer additionally validates `maintenance_type` and date format; on `ValueError` the CLI exits 1 with the writer's message.
+  * `--participants` is repeatable (joined comma-separated for TOS). `--reason` is repeatable (multiple reasons true on one vitjun).
+  * `--no-completed` marks the visit open (long-running repair / ongoing investigation).
+  * Implementation wraps `TOSWriter.add_maintenance_visit` (the existing 3-call POST + GET + PUT flow that handles auto-seeded `maintenance_attribute_value` rows).
 
 ## Architecture
 

--- a/src/tostools/tos.py
+++ b/src/tostools/tos.py
@@ -3482,12 +3482,21 @@ def _visit_main(argv):
       ``show <id_maintenance>``
                             One vitjun's full detail, including the
                             ``maintenance_attribute_values`` rows.
+      ``add --station S | --device <id> | --entity <id>
+              --start DATE [--end DATE] [--type {on_site,remote}]
+              [--participants EMAIL ...] [--reason CODE ...]
+              [--work TEXT] [--comment TEXT] [--remaining TEXT]
+              [--no-completed] [--no-dry-run]``
+                            Create a new vitjun. Dry-run by default;
+                            ``--no-dry-run`` commits.
 
-    Exit codes: 0 success, 1 lookup miss / no records, 2 usage error.
+    Exit codes: 0 success, 1 lookup miss / no records / writer error,
+    2 usage error.
     """
     import json as _json
 
     from .api.tos_client import TOSClient
+    from .api.tos_writer import TOSWriter
 
     p = argparse.ArgumentParser(
         prog="tos visit",
@@ -3584,6 +3593,132 @@ def _visit_main(argv):
     )
     p_show.add_argument("--port", type=int, default=443)
 
+    p_add = sub.add_parser(
+        "add",
+        help="Create a new vitjun on an entity (station / device).",
+        description=(
+            "Create a new vitjun (visit / maintenance record). Three-call "
+            "flow: POST /maintenances/id_entity/<id> → GET to discover "
+            "auto-seeded attribute-value rows → PUT to fill them in.\n\n"
+            "Dry-run by default — payloads are logged but not sent. Pass "
+            "--no-dry-run to commit (requires TOS credentials: "
+            "TOS_USERNAME/TOS_PASSWORD env vars, or the [tos] section in "
+            "~/.config/database.cfg, or an interactive prompt).\n\n"
+            "Target: --station S (resolves marker → id_entity), "
+            "--device <id> (direct id_entity, semantically a device), "
+            "--entity <id> (escape hatch — any id_entity)."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    add_target_group = p_add.add_mutually_exclusive_group(required=True)
+    add_target_group.add_argument(
+        "--station",
+        default=None,
+        help="Station marker (e.g. HEDI) or display name. Primary affordance.",
+    )
+    add_target_group.add_argument(
+        "--device",
+        dest="device_id",
+        type=int,
+        default=None,
+        help="Device id_entity. Device-attached vitjun (lifecycle tracker use).",
+    )
+    add_target_group.add_argument(
+        "--entity",
+        dest="entity_id",
+        type=int,
+        default=None,
+        help="Escape hatch — any id_entity directly.",
+    )
+    p_add.add_argument(
+        "--start",
+        required=True,
+        help=(
+            "Visit start. ISO datetime or YYYY-MM-DD (promoted to "
+            "midnight). Example: --start 2026-05-30."
+        ),
+    )
+    p_add.add_argument(
+        "--end",
+        default=None,
+        help=(
+            "Visit end. Defaults to --start (instantaneous visit). "
+            "Same date / datetime format as --start."
+        ),
+    )
+    p_add.add_argument(
+        "--type",
+        dest="visit_type",
+        choices=["on_site", "remote"],
+        default="on_site",
+        help="on_site (Staðarvitjun, default) or remote (Fjarvitjun).",
+    )
+    p_add.add_argument(
+        "--participants",
+        action="append",
+        dest="participants",
+        default=None,
+        metavar="EMAIL",
+        help=(
+            "Participant email (e.g. bgo@vedur.is). Repeatable; joined "
+            "comma-separated for TOS. TOS resolves to "
+            "participants_names on read."
+        ),
+    )
+    p_add.add_argument(
+        "--reason",
+        action="append",
+        dest="reasons",
+        choices=sorted(MAINTENANCE_REASON_CODES),
+        help=(
+            "Reason code (change / repairs / inspection / improvements "
+            "/ other). Repeatable; multiple reasons can be true on one "
+            "vitjun."
+        ),
+    )
+    p_add.add_argument(
+        "--work",
+        default=None,
+        help='Free-text "Framkvæmt" / "Vinna" description.',
+    )
+    p_add.add_argument(
+        "--comment",
+        default=None,
+        help='Free-text "Athugasemdir".',
+    )
+    p_add.add_argument(
+        "--remaining",
+        default=None,
+        help='Free-text "Útistandandi" outstanding work.',
+    )
+    p_add.add_argument(
+        "--no-completed",
+        dest="no_completed",
+        action="store_true",
+        help=(
+            "Mark the visit as open (completed=False). Use for long-"
+            "running repairs / ongoing investigations. Default: closed."
+        ),
+    )
+    p_add.add_argument(
+        "--no-dry-run",
+        dest="no_dry_run",
+        action="store_true",
+        help=(
+            "Actually commit the writes. Without this flag, payloads "
+            "are logged only (dry-run, default — matches `tos device add`)."
+        ),
+    )
+    p_add.add_argument(
+        "--json", action="store_true", help="Emit structured JSON summary."
+    )
+    p_add.add_argument(
+        "--server",
+        default="vi-api.vedur.is",
+        help="TOS API host (default: vi-api.vedur.is).",
+    )
+    p_add.add_argument("--port", type=int, default=443)
+
     args = p.parse_args(argv)
 
     scheme = "https" if args.port == 443 else "http"
@@ -3662,6 +3797,102 @@ def _visit_main(argv):
 
         console = Console()
         _render_visit_detail(console, visit)
+        return 0
+
+    if args.verb == "add":
+        # Resolve target via the same three-way affordance as `list`.
+        if args.station is not None:
+            id_entity = _resolve_parent_id(client, station_marker=args.station)
+            if id_entity is None:
+                print(
+                    f"No station found for marker {args.station!r}",
+                    file=sys.stderr,
+                )
+                return 1
+            target_label = f"station {args.station}"
+        elif args.device_id is not None:
+            id_entity = args.device_id
+            target_label = f"device {id_entity}"
+        else:
+            id_entity = args.entity_id
+            target_label = f"entity {id_entity}"
+
+        # Writer setup. Dry-run by default — matches `tos device add`.
+        dry_run = not args.no_dry_run
+        writer = TOSWriter(base_url=base_url, dry_run=dry_run)
+
+        # Participants: TOS expects comma-joined emails. CLI accepts
+        # repeatable --participants for ergonomics.
+        participants_str = ",".join(args.participants) if args.participants else ""
+
+        # Dry-run preview before invoking the writer — surfaces what
+        # would be POSTed even when the writer's own log is muted.
+        if dry_run and not args.json:
+            print(
+                f"DRY RUN: would add vitjun on {target_label} "
+                f"(id_entity={id_entity})"
+            )
+            print(f"         start_time      = {args.start}")
+            print(f"         end_time        = {args.end or args.start}")
+            print(f"         maintenance_type= {args.visit_type}")
+            print(
+                f"         reasons         = "
+                f"{','.join(args.reasons) if args.reasons else '(none)'}"
+            )
+            print(f"         participants    = {participants_str or '(none)'}")
+            print(f"         work            = {args.work or '(none)'}")
+            print(f"         comment         = {args.comment or '(none)'}")
+            print(f"         remaining       = {args.remaining or '(none)'}")
+            print(f"         completed       = {not args.no_completed}")
+            print()
+
+        # Writer validates reason codes + maintenance_type + dates;
+        # surface ValueError as exit 1 with the writer's message.
+        try:
+            result = writer.add_maintenance_visit(
+                id_entity,
+                start_time=args.start,
+                end_time=args.end,
+                maintenance_type=args.visit_type,
+                participants=participants_str,
+                reasons=args.reasons,
+                work=args.work,
+                comment=args.comment,
+                remaining=args.remaining,
+                completed=not args.no_completed,
+            )
+        except ValueError as exc:
+            print(f"add_maintenance_visit failed: {exc}", file=sys.stderr)
+            return 1
+
+        new_id = result.get("id_maintenance")
+        if args.json:
+            payload = {
+                "id_entity": id_entity,
+                "target": target_label,
+                "dry_run": dry_run,
+                "id_maintenance": new_id,
+                "params": {
+                    "start_time": args.start,
+                    "end_time": args.end or args.start,
+                    "maintenance_type": args.visit_type,
+                    "participants": participants_str,
+                    "reasons": args.reasons or [],
+                    "work": args.work,
+                    "comment": args.comment,
+                    "remaining": args.remaining,
+                    "completed": not args.no_completed,
+                },
+                "result": result,
+            }
+            print(_json.dumps(payload, ensure_ascii=False, indent=2, default=str))
+            return 0
+
+        suffix = " (dry-run)" if dry_run else ""
+        id_str = new_id if new_id else "<would be assigned>"
+        print(f"Created vitjun id_maintenance={id_str} on {target_label}{suffix}")
+        if not dry_run and isinstance(new_id, int):
+            print(f"Drill: tos visit show {new_id}")
         return 0
 
     return 2
@@ -7971,12 +8202,15 @@ def _print_top_level_help() -> None:
         "               contact show --id N     One contact record.\n"
         "               contact list --station S  Contacts for a station.\n"
         "\n"
-        "  visit      Inspect TOS vitjun (visit / maintenance) records.\n"
+        "  visit      Inspect or create TOS vitjun (visit / maintenance) records.\n"
         "               visit list --station S         Vitjanir for a station.\n"
         "               visit list --device <id>       Vitjanir for a device.\n"
         "               visit show <id_maintenance>    One vitjun's full detail.\n"
-        "             Filters: --type, --reason, --since, --participants,\n"
-        "                      --open / --completed.\n"
+        "               visit add  --station S --start DATE [opts]\n"
+        "                                              Create a new vitjun (dry-run\n"
+        "                                              default; --no-dry-run commits).\n"
+        "             Filters (list): --type, --reason, --since, --participants,\n"
+        "                             --open / --completed.\n"
         "\n"
         "  fleet      Fleet-wide orchestrators (loop station verbs over\n"
         "             every GNSS station in stations.cfg ~173 sites).\n"

--- a/tests/test_tos_client.py
+++ b/tests/test_tos_client.py
@@ -1518,6 +1518,309 @@ def test_visit_show_json_emits_raw_detail(capsys):
 
 
 # ---------------------------------------------------------------------------
+# `tos visit add` — Phase B write verb
+# ---------------------------------------------------------------------------
+
+
+def test_visit_add_dry_run_does_not_call_writer_post(capsys):
+    """Default (dry-run): TOSWriter still gets instantiated with
+    dry_run=True, but the writer itself short-circuits mutating
+    requests. From the CLI's perspective we verify the writer was
+    constructed correctly and `add_maintenance_visit` got called with
+    the right kwargs."""
+    from tostools.api.tos_writer import TOSWriter
+    from tostools.tos import _visit_main
+
+    with (
+        patch("tostools.tos._resolve_parent_id", return_value=4316),
+        patch.object(
+            TOSWriter,
+            "add_maintenance_visit",
+            autospec=True,
+            return_value={
+                "id_maintenance": "<dry-run>",
+                "created": None,
+                "updated": None,
+            },
+        ) as add_visit,
+    ):
+        rc = _visit_main(["add", "--station", "HEDI", "--start", "2026-05-30"])
+
+    assert rc == 0
+    # Writer.add_maintenance_visit called once with id_entity=4316.
+    add_visit.assert_called_once()
+    call = add_visit.call_args
+    assert call.args[1] == 4316  # id_entity positional after self
+    # Defaults flowed through correctly.
+    assert call.kwargs["start_time"] == "2026-05-30"
+    assert call.kwargs["end_time"] is None  # writer defaults to start
+    assert call.kwargs["maintenance_type"] == "on_site"
+    assert call.kwargs["participants"] == ""
+    assert call.kwargs["reasons"] is None
+    assert call.kwargs["completed"] is True
+    # Dry-run preview surfaced.
+    out = capsys.readouterr().out
+    assert "DRY RUN: would add vitjun on station HEDI" in out
+    assert "id_maintenance=<dry-run>" in out
+    assert "(dry-run)" in out
+
+
+def test_visit_add_no_dry_run_commits(capsys):
+    """--no-dry-run instantiates the writer with dry_run=False (no
+    short-circuit). The writer call returns a real id_maintenance which
+    the CLI surfaces with a drill hint."""
+    from tostools.api.tos_writer import TOSWriter
+    from tostools.tos import _visit_main
+
+    real_result = {
+        "id_maintenance": 5491,
+        "created": {"id_maintenance": 5491},
+        "updated": {"updated": True},
+    }
+    with (
+        patch("tostools.tos._resolve_parent_id", return_value=4316),
+        patch.object(
+            TOSWriter, "add_maintenance_visit", autospec=True, return_value=real_result
+        ) as add_visit,
+        # Don't actually authenticate.
+        patch.object(TOSWriter, "_ensure_authenticated", autospec=True),
+    ):
+        rc = _visit_main(
+            [
+                "add",
+                "--station",
+                "HEDI",
+                "--start",
+                "2026-05-30",
+                "--no-dry-run",
+            ]
+        )
+
+    assert rc == 0
+    add_visit.assert_called_once()
+    out = capsys.readouterr().out
+    # No DRY RUN preamble.
+    assert "DRY RUN" not in out
+    # Real id surfaced + drill hint.
+    assert "id_maintenance=5491" in out
+    assert "Drill: tos visit show 5491" in out
+
+
+def test_visit_add_repeatable_participants_and_reasons_passed_to_writer():
+    """--participants is repeatable and joined comma-separated for TOS.
+    --reason is repeatable and passed as a list."""
+    from tostools.api.tos_writer import TOSWriter
+    from tostools.tos import _visit_main
+
+    with (
+        patch("tostools.tos._resolve_parent_id", return_value=4316),
+        patch.object(
+            TOSWriter,
+            "add_maintenance_visit",
+            autospec=True,
+            return_value={"id_maintenance": "<dry-run>"},
+        ) as add_visit,
+    ):
+        rc = _visit_main(
+            [
+                "add",
+                "--station",
+                "HEDI",
+                "--start",
+                "2026-05-30",
+                "--participants",
+                "bgo@vedur.is",
+                "--participants",
+                "bhb@vedur.is",
+                "--reason",
+                "repairs",
+                "--reason",
+                "change",
+            ]
+        )
+
+    assert rc == 0
+    call = add_visit.call_args
+    assert call.kwargs["participants"] == "bgo@vedur.is,bhb@vedur.is"
+    assert call.kwargs["reasons"] == ["repairs", "change"]
+
+
+def test_visit_add_no_completed_passes_false():
+    """--no-completed → completed=False for the long-running-repair use case."""
+    from tostools.api.tos_writer import TOSWriter
+    from tostools.tos import _visit_main
+
+    with (
+        patch("tostools.tos._resolve_parent_id", return_value=4316),
+        patch.object(
+            TOSWriter,
+            "add_maintenance_visit",
+            autospec=True,
+            return_value={"id_maintenance": "<dry-run>"},
+        ) as add_visit,
+    ):
+        rc = _visit_main(
+            [
+                "add",
+                "--station",
+                "HEDI",
+                "--start",
+                "2026-05-30",
+                "--no-completed",
+                "--remaining",
+                "vendor diagnosing",
+            ]
+        )
+
+    assert rc == 0
+    call = add_visit.call_args
+    assert call.kwargs["completed"] is False
+    assert call.kwargs["remaining"] == "vendor diagnosing"
+
+
+def test_visit_add_device_skips_resolver(capsys):
+    """--device <id> takes id_entity directly — no marker resolution.
+    Primary use case for the Phase C lifecycle tracker."""
+    from tostools.api.tos_writer import TOSWriter
+    from tostools.tos import _visit_main
+
+    with (
+        patch("tostools.tos._resolve_parent_id") as resolver,
+        patch.object(
+            TOSWriter,
+            "add_maintenance_visit",
+            autospec=True,
+            return_value={"id_maintenance": "<dry-run>"},
+        ) as add_visit,
+    ):
+        rc = _visit_main(["add", "--device", "21044", "--start", "2026-05-30"])
+
+    assert rc == 0
+    resolver.assert_not_called()
+    assert add_visit.call_args.args[1] == 21044
+    assert "DRY RUN: would add vitjun on device 21044" in capsys.readouterr().out
+
+
+def test_visit_add_unresolvable_station_returns_1(capsys):
+    from tostools.tos import _visit_main
+
+    with patch("tostools.tos._resolve_parent_id", return_value=None):
+        rc = _visit_main(["add", "--station", "XYXYZ", "--start", "2026-05-30"])
+
+    assert rc == 1
+    assert "No station found for marker 'XYXYZ'" in capsys.readouterr().err
+
+
+def test_visit_add_target_mutually_exclusive():
+    """argparse must reject --station + --device on the same call."""
+    import pytest
+
+    from tostools.tos import _visit_main
+
+    with pytest.raises(SystemExit) as exc:
+        _visit_main(
+            [
+                "add",
+                "--station",
+                "HEDI",
+                "--device",
+                "4316",
+                "--start",
+                "2026-05-30",
+            ]
+        )
+    assert exc.value.code == 2
+
+
+def test_visit_add_unknown_reason_rejected_by_argparse():
+    """argparse choices=MAINTENANCE_REASON_CODES rejects bad reasons
+    before the writer ever sees them."""
+    import pytest
+
+    from tostools.tos import _visit_main
+
+    with pytest.raises(SystemExit) as exc:
+        _visit_main(
+            [
+                "add",
+                "--station",
+                "HEDI",
+                "--start",
+                "2026-05-30",
+                "--reason",
+                "fixme",
+            ]
+        )
+    assert exc.value.code == 2
+
+
+def test_visit_add_writer_value_error_returns_1(capsys):
+    """Writer raises ValueError (e.g. bad date format slipped past
+    argparse) → exit 1, message surfaced on stderr."""
+    from tostools.api.tos_writer import TOSWriter
+    from tostools.tos import _visit_main
+
+    with (
+        patch("tostools.tos._resolve_parent_id", return_value=4316),
+        patch.object(
+            TOSWriter,
+            "add_maintenance_visit",
+            autospec=True,
+            side_effect=ValueError("bad date"),
+        ),
+    ):
+        rc = _visit_main(["add", "--station", "HEDI", "--start", "not-a-date"])
+
+    assert rc == 1
+    assert "add_maintenance_visit failed: bad date" in capsys.readouterr().err
+
+
+def test_visit_add_json_includes_id_maintenance_and_params(capsys):
+    """JSON output carries the new id_maintenance + the params dict +
+    dry_run flag — useful for downstream automation."""
+    import json as _json
+
+    from tostools.api.tos_writer import TOSWriter
+    from tostools.tos import _visit_main
+
+    with (
+        patch("tostools.tos._resolve_parent_id", return_value=4316),
+        patch.object(
+            TOSWriter,
+            "add_maintenance_visit",
+            autospec=True,
+            return_value={
+                "id_maintenance": "<dry-run>",
+                "created": None,
+                "updated": None,
+            },
+        ),
+    ):
+        rc = _visit_main(
+            [
+                "add",
+                "--station",
+                "HEDI",
+                "--start",
+                "2026-05-30",
+                "--reason",
+                "repairs",
+                "--json",
+            ]
+        )
+
+    assert rc == 0
+    payload = _json.loads(capsys.readouterr().out)
+    assert payload["id_entity"] == 4316
+    assert payload["target"] == "station HEDI"
+    assert payload["dry_run"] is True
+    assert payload["id_maintenance"] == "<dry-run>"
+    assert payload["params"]["start_time"] == "2026-05-30"
+    assert payload["params"]["reasons"] == ["repairs"]
+    assert payload["params"]["completed"] is True
+
+
+# ---------------------------------------------------------------------------
 # Device-show Phase A.2 — visits section
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Phase B of the vitjanir CLI expansion (PR #36 was Phase A).

Adds the write half: operators can log a vitjun from the CLI, dry-run by default matching the `tos device add` convention.

## What lands

```
tos visit add --station HEDI --start 2026-05-30 \
    [--end DATE] [--type {on_site,remote}] \
    [--participants EMAIL ...] \
    [--reason CODE ...] \
    [--work TEXT] [--comment TEXT] [--remaining TEXT] \
    [--no-completed]    # mark open for long-running repairs
    [--no-dry-run]      # commit (default dry-run)
    [--json]
```

Target group mirrors `tos visit list`:
- `--station S` → resolves marker via `_resolve_parent_id`
- `--device <id>` → direct id_entity (Phase C lifecycle-tracker primary path)
- `--entity <id>` → escape hatch for any id_entity

## Implementation

Wraps the existing `TOSWriter.add_maintenance_visit` (3-call POST + GET + PUT flow). Dry-run mode short-circuits the POST at the writer layer; the CLI explicitly logs the planned payload before invoking the writer so operators see what would land even without a writer-side debug log.

- Argparse `choices=MAINTENANCE_REASON_CODES` catches bad reasons before the writer
- Writer ValueError (`maintenance_type`, date format) → exit 1 with the writer's message
- `--participants` repeatable, joined comma-separated for TOS
- `--reason` repeatable; multiple reasons can be true on one vitjun (TOS stores each as a `reason_<code>` boolean)

## Intentionally skipped

`--triage` / `--placeholder` — `tos device add` has these to substitute a newly-created id_entity into a waiting triage file, but no triage ACTION verb currently references an `id_maintenance`. The eventual Phase E `update-visit` ACTION would; the substitution lands then.

## Tests (10 new)

- Dry-run: writer constructed dry_run=True, kwargs verified, preview on stdout, "(dry-run)" suffix
- `--no-dry-run`: real commit path, drill-hint includes new `id_maintenance`
- `--participants` comma-joining (repeatable → "em1,em2")
- `--reason` list pass-through to writer
- `--no-completed` → completed=False
- `--device` skips `_resolve_parent_id` entirely
- Unresolvable station → exit 1
- Target group mutually exclusive (argparse exit 2)
- Unknown reason → argparse rejects (exit 2)
- Writer ValueError → exit 1 with message
- `--json` shape (id_maintenance + dry_run + params dict + result)

## Smoke-tested live (dry-run only — no writes committed)

- `tos visit add --station HEDI --start 2026-05-30 --reason repairs --reason change --work "test entry" --participants bgo@vedur.is --participants bhb@vedur.is` → resolves HEDI → id_entity=4316, preview output correct
- `tos visit add --station XYXYZ --start 2026-05-30` → exit 1, "No station found"
- `tos visit add --station HEDI --device 4316 --start 2026-05-30` → argparse rejects (mutual exclusion)
- `tos visit add --device 21044 --start 2026-05-30 --no-completed --remaining "vendor diagnosing"` → completed=False, remaining surfaced

## Test plan
- [x] `pytest tests/` — 912 passed, 2 skipped
- [x] `ruff check` — clean
- [x] `black --check` — clean
- [x] Live smoke-test of every target + flag path in dry-run mode
- [ ] Live `--no-dry-run` smoke-test deferred — needs operator-curated test station to avoid polluting real vitjun history

## Next: Phase C — device lifecycle tracker

The new driver: auto-paired vitjanir on device state changes (firmware bump, move-to-B9, sent-for-repair, fixed, back-from-repair). Phase C will:
- Add `--with-visit` to `tos audit apply` ACTION verbs that touch devices (`move`, `decommission`, `create-join`, `add-attribute firmware_version`, etc.)
- Auto-template the `reason` + `comment` from the operation diff
- Add `add-visit` triage ACTION for batching

🤖 Generated with [Claude Code](https://claude.com/claude-code)