### PR TITLE
feat(tos): add-visit ACTION verb — device lifecycle tracker v1 (Phase C)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -365,6 +365,54 @@ HTTP); `--all` on station show extends to full visit history.
   * `--no-completed` marks the visit open (long-running repair / ongoing investigation).
   * Implementation wraps `TOSWriter.add_maintenance_visit` (the existing 3-call POST + GET + PUT flow that handles auto-seeded `maintenance_attribute_value` rows).
 
+**`add-visit` ACTION verb** (Phase C — device lifecycle tracker, v1):
+
+Triage-file integration for the lifecycle workflow. Operators chain
+vitjun creation next to `move` / `decommission` / `add-attribute`
+ACTIONs in the same file so a single `tos audit apply` commits
+metadata changes + the audit trail of physical interventions
+together.
+
+Syntax: `ACTION <id_entity> add-visit <reasons_csv> <date> <work_text> [open|closed]`
+
+  * `<reasons_csv>`: one or more reason codes, comma-separated (no
+    spaces — shlex keeps the token intact, dispatcher splits
+    internally). Each code validated against
+    `MAINTENANCE_REASON_CODES` BEFORE the writer call.
+  * `<date>`: `YYYY-MM-DD` or `now` / `start` tokens (same resolver
+    as `add-attribute`).
+  * `<work_text>`: free-text description, quote with `'` or `"` to
+    contain spaces (shlex).
+  * 4th positional: `open` or `closed`, defaults `closed`. Use
+    `open` for the start of a long-running repair cycle.
+
+Defaults (cannot be overridden from triage v1): `maintenance_type=on_site`,
+`participants=""`, `comment=None`, `remaining=None`. Operators needing
+those fields use `tos visit add --no-dry-run` directly. Phase C.5
+follow-ups: participants auto-fill from `[tos] username`,
+`comment`/`remaining` slots, `--with-visit` modifier on other verbs,
+auto-template from operation diff.
+
+Worked lifecycle-tracker example — sent for repair → fixed →
+back from repair:
+
+```
+# device 4830 (SAVI POLARX2) sent to vendor 2026-05-30 for cable damage
+ACTION 4830 move 4 2026-05-30                           # → warehouse B9
+ACTION 4830 add-visit repairs 2026-05-30 "sent for repair: cable damage" open
+
+# vendor sent device back 2026-06-15
+ACTION 4830 add-visit repairs 2026-06-15 "vendor diagnosed; cable replaced"
+
+# re-deployed at HEDI 2026-06-20 with firmware bump
+ACTION 4830 move 4316 2026-06-20                        # → HEDI station
+ACTION 4830 patch-attribute-value firmware_version 2026-06-20 "3.01"
+ACTION 4830 add-visit change,repairs 2026-06-20 "back from vendor; firmware bumped to 3.01"
+```
+
+Three vitjanir document the three operator-visible states; the move +
+patch ACTIONs reflect the underlying TOS state changes.
+
 ## Architecture
 
 ### Current Structure

--- a/docs/tutorials/station-triage-tutorial.md
+++ b/docs/tutorials/station-triage-tutorial.md
@@ -301,6 +301,7 @@ stations take a long time on a cold cache.
 | Verb | Shape | Use |
 |---|---|---|
 | `add-attribute` | `<id> add-attribute <code> <value> <date_from>` | Set a missing attribute |
+| `add-visit` | `<id> add-visit <reasons_csv> <date> "<work>" [open\|closed]` | Log a vitjun on an entity (lifecycle tracker — see CLAUDE.md) |
 | `patch-attribute-date` | `<id> patch-attribute-date <code> <old_date> <new_date>` | Backdate (e.g. 2014-10-17 → install date) |
 | `patch-attribute-value` | `<id> patch-attribute-value <code> <date_anchor> <new_value>` | Fix a wrong value (history-destructive) |
 | `move` | `<id> move <to_parent_id> <date>` | Close open join + open new (e.g. device moves to warehouse) |

--- a/src/tostools/tos.py
+++ b/src/tostools/tos.py
@@ -5706,6 +5706,7 @@ class ParseError:
 
 _SUPPORTED_VERBS = (
     "add-attribute",
+    "add-visit",
     "change-subtype",
     "create-join",
     "decommission",
@@ -6651,6 +6652,174 @@ def _dispatch_add_attribute(writer, action: ParsedAction) -> ActionResult:
     )
 
 
+def _dispatch_add_visit(writer, action: ParsedAction) -> ActionResult:
+    """Create a vitjun on an entity from a triage ACTION line.
+
+    Action shape: ``ACTION <id_entity> add-visit <reasons_csv> <date>
+    <work_text> [open|closed]``.
+
+    Lifecycle-tracker use case: operators chain ACTION lines next to
+    ``move`` / ``decommission`` / ``add-attribute`` to leave an audit
+    trail of physical interventions ("sent for repair: cable damage",
+    "back from vendor; firmware updated"). See CLAUDE.md "Device
+    lifecycle tracker" section.
+
+    Arguments
+    ---------
+    reasons_csv
+        Comma-separated reason codes (e.g. ``repairs`` or
+        ``repairs,change``). Each code is validated against
+        :data:`MAINTENANCE_REASON_CODES` BEFORE the writer call —
+        unknown codes return a ``failed`` ActionResult so the runner
+        keeps going.
+    date
+        ISO date (``YYYY-MM-DD``) or token (``now`` / ``start``).
+        Used as both ``start_time`` and ``end_time`` (instantaneous
+        visit — matches the writer default).
+    work_text
+        Free-text "Framkvæmt" / "Vinna" description (shlex-quoted in
+        the triage file so it can contain spaces).
+    open|closed (optional)
+        Default ``closed`` (``completed=True``). ``open`` marks the
+        visit as in-progress (``completed=False``) — use for "sent for
+        repair" entries that close later with another ``add-visit``
+        line for "back from repair".
+
+    Defaults: ``maintenance_type=on_site``, ``participants=""``,
+    ``comment=None``, ``remaining=None``. Operators who need to set
+    these directly use ``tos visit add --no-dry-run``. Auto-filling
+    participants from the ``[tos] username`` is a Phase C.5 follow-up.
+
+    Pre-flight checks
+    -----------------
+    * ``<FILL_*>`` placeholders in any positional → refuse (operator
+      didn't fill the template).
+    * Unknown reason code → refuse without calling the writer.
+    * Date token resolution failure → refuse.
+    * Unknown 4th positional → refuse (must be ``open`` or ``closed``).
+    """
+    if len(action.args) < 3 or len(action.args) > 4:
+        return ActionResult(
+            action=action,
+            status="failed",
+            detail=(
+                "add-visit: expected 3 or 4 positional args "
+                "(<reasons_csv> <date> <work_text> [open|closed]), "
+                f"got {len(action.args)}"
+            ),
+        )
+    reasons_raw = action.args[0]
+    date_raw = action.args[1]
+    work_text = action.args[2]
+    status_raw = action.args[3] if len(action.args) >= 4 else "closed"
+
+    # Placeholder rejection — same convention as _dispatch_add_attribute.
+    # Refusing here is cheaper than POSTing a literal "<FILL_VALUE>" to TOS.
+    for label, val in (
+        ("reasons", reasons_raw),
+        ("date", date_raw),
+        ("work", work_text),
+    ):
+        if val.startswith("<") and val.endswith(">"):
+            return ActionResult(
+                action=action,
+                status="failed",
+                detail=(
+                    f"add-visit: {label} placeholder {val!r} not replaced "
+                    "— fill in the value before applying"
+                ),
+            )
+
+    # Reason validation BEFORE writer call. The writer also validates
+    # but surfaces ValueError; doing it here returns a clean failed
+    # ActionResult and avoids the noisy stack trace path.
+    reasons = [c.strip() for c in reasons_raw.split(",") if c.strip()]
+    if not reasons:
+        return ActionResult(
+            action=action,
+            status="failed",
+            detail="add-visit: reasons_csv must contain at least one code",
+        )
+    unknown = [c for c in reasons if c not in MAINTENANCE_REASON_CODES]
+    if unknown:
+        return ActionResult(
+            action=action,
+            status="failed",
+            detail=(
+                f"add-visit: unknown reason code(s) {unknown!r} — allowed: "
+                f"{sorted(MAINTENANCE_REASON_CODES)}"
+            ),
+        )
+
+    # 4th positional: open/closed → completed boolean.
+    status_norm = status_raw.lower()
+    if status_norm not in ("open", "closed"):
+        return ActionResult(
+            action=action,
+            status="failed",
+            detail=(
+                f"add-visit: 4th positional must be 'open' or 'closed' "
+                f"(got {status_raw!r})"
+            ),
+        )
+    completed = status_norm == "closed"
+
+    # Resolve `now` / `start` tokens.
+    resolved, err = _resolve_date_token(date_raw, action.id_entity, writer)
+    if err is not None:
+        return ActionResult(
+            action=action,
+            status="failed",
+            detail=f"add-visit: {err}",
+        )
+    date_resolved = resolved or date_raw
+
+    # Date format check — same YYYY-MM-DD contract as add-attribute.
+    date_yyyy_mm_dd = date_resolved[:10]
+    if (
+        len(date_yyyy_mm_dd) != 10
+        or date_yyyy_mm_dd[4] != "-"
+        or date_yyyy_mm_dd[7] != "-"
+    ):
+        return ActionResult(
+            action=action,
+            status="failed",
+            detail=(f"add-visit: date must be YYYY-MM-DD " f"(got {date_resolved!r})"),
+        )
+
+    try:
+        response = writer.add_maintenance_visit(
+            action.id_entity,
+            start_time=date_yyyy_mm_dd,
+            end_time=None,  # writer defaults to start_time
+            maintenance_type="on_site",
+            participants="",
+            reasons=reasons,
+            work=work_text,
+            comment=None,
+            remaining=None,
+            completed=completed,
+        )
+    except Exception as exc:  # noqa: BLE001
+        return ActionResult(
+            action=action,
+            status="failed",
+            detail=f"add_maintenance_visit raised: {exc}",
+        )
+
+    new_id = response.get("id_maintenance") if isinstance(response, dict) else None
+    state_label = "completed" if completed else "open"
+    return ActionResult(
+        action=action,
+        status="ok",
+        detail=(
+            f"POST /maintenances/id_entity/{action.id_entity} "
+            f"reasons={reasons!r} date={date_yyyy_mm_dd} {state_label} "
+            f"— id_maintenance={new_id!r}"
+        ),
+    )
+
+
 def _dispatch_patch_attribute_value(writer, action: ParsedAction) -> ActionResult:
     """Correct a wrong attribute value in-place (Pattern 1 / Pattern 4).
 
@@ -7061,6 +7230,8 @@ def _dispatch_action(
         return _dispatch_delete_join(writer, action)
     if action.verb == "add-attribute":
         return _dispatch_add_attribute(writer, action)
+    if action.verb == "add-visit":
+        return _dispatch_add_visit(writer, action)
     if action.verb == "change-subtype":
         code = action.args[0]
         mapping = subtype_id_by_code or {}

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -2131,3 +2131,211 @@ def test_dispatch_add_attribute_fails_when_start_unresolvable():
     assert result.status == "failed"
     assert "start" in result.detail
     writer.add_attribute_value.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _dispatch_add_visit — Phase C lifecycle-tracker ACTION verb
+# ---------------------------------------------------------------------------
+
+
+def test_parse_action_file_keeps_csv_reasons_as_one_token():
+    """shlex.split must NOT split on commas — `repairs,change` is one
+    token, the dispatcher splits internally. Pinning this so a future
+    parser refactor can't silently break add-visit's reason CSV."""
+    text = 'ACTION 4316 add-visit repairs,change 2026-05-30 "sent for repair"\n'
+    actions, errors = _parse_action_file(text)
+    assert errors == []
+    assert len(actions) == 1
+    a = actions[0]
+    assert a.verb == "add-visit"
+    assert a.args == ["repairs,change", "2026-05-30", "sent for repair"]
+
+
+def test_dispatch_add_visit_happy_path_closed_default():
+    """Default 3-arg form: closed (completed=True), single reason."""
+    writer = MagicMock()
+    writer.add_maintenance_visit.return_value = {"id_maintenance": 5500}
+    result = _dispatch_action(
+        writer,
+        _make_action(4316, "add-visit", "repairs", "2026-05-30", "sent for repair"),
+    )
+    assert result.status == "ok"
+    writer.add_maintenance_visit.assert_called_once()
+    kwargs = writer.add_maintenance_visit.call_args.kwargs
+    assert writer.add_maintenance_visit.call_args.args == (4316,)
+    assert kwargs["reasons"] == ["repairs"]
+    assert kwargs["start_time"] == "2026-05-30"
+    assert kwargs["end_time"] is None  # writer defaults to start
+    assert kwargs["work"] == "sent for repair"
+    assert kwargs["completed"] is True
+    assert kwargs["maintenance_type"] == "on_site"
+    assert kwargs["participants"] == ""
+    assert "id_maintenance=5500" in result.detail
+    assert "completed" in result.detail
+
+
+def test_dispatch_add_visit_open_positional_marks_open():
+    """4th positional `open` → completed=False (long-running repair start)."""
+    writer = MagicMock()
+    writer.add_maintenance_visit.return_value = {"id_maintenance": 5501}
+    result = _dispatch_action(
+        writer,
+        _make_action(
+            4316, "add-visit", "repairs", "2026-05-30", "sent for repair", "open"
+        ),
+    )
+    assert result.status == "ok"
+    assert writer.add_maintenance_visit.call_args.kwargs["completed"] is False
+    assert " open" in result.detail
+
+
+def test_dispatch_add_visit_csv_reasons_split_and_validated():
+    """Comma-separated reasons split into a list; each validated."""
+    writer = MagicMock()
+    writer.add_maintenance_visit.return_value = {"id_maintenance": 5502}
+    result = _dispatch_action(
+        writer,
+        _make_action(
+            4316, "add-visit", "repairs,change", "2026-06-15", "back from vendor"
+        ),
+    )
+    assert result.status == "ok"
+    assert writer.add_maintenance_visit.call_args.kwargs["reasons"] == [
+        "repairs",
+        "change",
+    ]
+
+
+def test_dispatch_add_visit_unknown_reason_fails_without_writer_call():
+    """Unknown reason → 'failed' (runner continues with remaining
+    actions). Cheaper than a writer ValueError + stack trace."""
+    writer = MagicMock()
+    result = _dispatch_action(
+        writer,
+        _make_action(4316, "add-visit", "fixme", "2026-05-30", "bad reason"),
+    )
+    assert result.status == "failed"
+    assert "unknown reason code" in result.detail
+    assert "fixme" in result.detail
+    writer.add_maintenance_visit.assert_not_called()
+
+
+def test_dispatch_add_visit_rejects_fill_placeholders():
+    """<FILL_*> placeholders in reasons/date/work are operator
+    forgot-to-fill errors — refuse rather than POST literal templates."""
+    writer = MagicMock()
+    for pos, args in enumerate(
+        [
+            ["<FILL_REASON>", "2026-05-30", "work"],
+            ["repairs", "<FILL_DATE>", "work"],
+            ["repairs", "2026-05-30", "<FILL_WORK>"],
+        ]
+    ):
+        result = _dispatch_action(writer, _make_action(4316, "add-visit", *args))
+        assert result.status == "failed", f"variant {pos}"
+        assert "placeholder" in result.detail, f"variant {pos}"
+        assert "not replaced" in result.detail, f"variant {pos}"
+    writer.add_maintenance_visit.assert_not_called()
+
+
+def test_dispatch_add_visit_now_token_resolved_via_resolver():
+    """`now` resolves to today's UTC date — same path as add-attribute."""
+    writer = MagicMock()
+    writer.add_maintenance_visit.return_value = {"id_maintenance": 5503}
+    result = _dispatch_action(
+        writer,
+        _make_action(4316, "add-visit", "inspection", "now", "post-check"),
+    )
+    assert result.status == "ok"
+    resolved_date = writer.add_maintenance_visit.call_args.kwargs["start_time"]
+    # Today's UTC date in YYYY-MM-DD.
+    import datetime as _dt
+
+    expected = _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%d")
+    assert resolved_date == expected
+
+
+def test_dispatch_add_visit_start_token_uses_earliest_known():
+    """`start` resolves via writer._get_earliest_known — same as
+    other date-token-aware verbs."""
+    writer = MagicMock()
+    writer._get_earliest_known.return_value = "2006-06-29"
+    writer.add_maintenance_visit.return_value = {"id_maintenance": 5504}
+    result = _dispatch_action(
+        writer,
+        _make_action(4316, "add-visit", "change", "start", "founded"),
+    )
+    assert result.status == "ok"
+    assert writer.add_maintenance_visit.call_args.kwargs["start_time"] == "2006-06-29"
+
+
+def test_dispatch_add_visit_bad_status_positional_rejected():
+    """4th positional must be 'open' or 'closed' — anything else fails
+    before the writer call."""
+    writer = MagicMock()
+    result = _dispatch_action(
+        writer,
+        _make_action(4316, "add-visit", "repairs", "2026-05-30", "work", "maybe"),
+    )
+    assert result.status == "failed"
+    assert "open" in result.detail and "closed" in result.detail
+    writer.add_maintenance_visit.assert_not_called()
+
+
+def test_dispatch_add_visit_wrong_arg_count_rejected():
+    """Too few / too many positional args → failed with clear message."""
+    writer = MagicMock()
+    # Too few — just 2.
+    result_few = _dispatch_action(
+        writer,
+        _make_action(4316, "add-visit", "repairs", "2026-05-30"),
+    )
+    assert result_few.status == "failed"
+    assert "expected 3 or 4 positional args" in result_few.detail
+    # Too many — 5.
+    result_many = _dispatch_action(
+        writer,
+        _make_action(4316, "add-visit", "repairs", "2026-05-30", "w", "open", "extra"),
+    )
+    assert result_many.status == "failed"
+    assert "expected 3 or 4 positional args" in result_many.detail
+    writer.add_maintenance_visit.assert_not_called()
+
+
+def test_dispatch_add_visit_writer_exception_captured_as_failed():
+    """A writer crash (e.g. network failure) becomes a 'failed' result,
+    not a raised exception — runner continues."""
+    writer = MagicMock()
+    writer.add_maintenance_visit.side_effect = RuntimeError("simulated 500")
+    result = _dispatch_action(
+        writer,
+        _make_action(4316, "add-visit", "repairs", "2026-05-30", "work"),
+    )
+    assert result.status == "failed"
+    assert "simulated 500" in result.detail
+
+
+def test_dispatch_add_visit_bad_date_format_rejected_after_token_resolution():
+    """Garbage date that doesn't resolve to a token AND isn't
+    YYYY-MM-DD → failed."""
+    writer = MagicMock()
+    result = _dispatch_action(
+        writer,
+        _make_action(4316, "add-visit", "repairs", "yesterday", "work"),
+    )
+    assert result.status == "failed"
+    assert "YYYY-MM-DD" in result.detail
+    writer.add_maintenance_visit.assert_not_called()
+
+
+def test_dispatch_add_visit_empty_csv_reasons_rejected():
+    """An empty/whitespace-only reasons_csv would otherwise sneak past
+    the per-code validation — pin the explicit refusal."""
+    writer = MagicMock()
+    result = _dispatch_action(
+        writer,
+        _make_action(4316, "add-visit", ",", "2026-05-30", "work"),
+    )
+    assert result.status == "failed"
+    assert "at least one code" in result.detail
+    writer.add_maintenance_visit.assert_not_called()


### PR DESCRIPTION
Phase C v1 of the vitjanir CLI expansion. Triage-file integration for the lifecycle workflow you described during scoping (firmware bumps, sent-for-repair, fixed, back-from-repair).

## What lands

New ACTION verb for `tos audit apply`:

```
ACTION <id_entity> add-visit <reasons_csv> <date> <work_text> [open|closed]
```

Operators chain `add-visit` lines next to existing `move` / `decommission` / `add-attribute` ACTIONs so **one apply commits metadata changes + the audit trail of physical interventions together**.

## Worked example — repair cycle

```
# device 4830 sent to vendor 2026-05-30 for cable damage
ACTION 4830 move 4 2026-05-30                           # → warehouse B9
ACTION 4830 add-visit repairs 2026-05-30 "sent for repair: cable damage" open

# vendor finished 2026-06-15
ACTION 4830 add-visit repairs 2026-06-15 "vendor diagnosed; cable replaced"

# re-deployed 2026-06-20 with firmware bump
ACTION 4830 move 4316 2026-06-20                        # → HEDI station
ACTION 4830 patch-attribute-value firmware_version 2026-06-20 "3.01"
ACTION 4830 add-visit change,repairs 2026-06-20 "back from vendor; fw 3.01"
```

Three vitjanir document the three operator-visible states; the move + patch ACTIONs reflect the underlying TOS state changes.

## Design choices (per advisor)

- **Explicit verb, not `--with-visit` modifier**. Easier to test, easier to document, composable with existing ACTIONs. The `--with-visit` modifier on other verbs is deferred to Phase C.5 — wait to see if the explicit form is too verbose in practice.
- **4th positional `[open|closed]`** for the lifecycle workflow (open = sent-for-repair start; closed = default for instantaneous visits).
- **Defenses copy `_dispatch_add_attribute`**: `<FILL_*>` placeholder rejection in all three primary positionals, reason-code validation BEFORE writer call (cheap + clean error), writer exceptions captured as `ActionResult(failed)` so the runner continues.
- **CSV reasons** — `repairs,change` is one shlex token (verified by pinning test); dispatcher splits internally. Multiple reasons can be true on one vitjun.

## Deferred to Phase C.5 (documented as known follow-ups)

- Participants auto-fill from `[tos] username` — the user mentioned this in scoping
- `comment` / `remaining` slots in triage shape — minimal verb in v1; needed-now flow uses `tos visit add --no-dry-run`
- `--with-visit` modifier on existing verbs (auto-pair)
- Auto-template comments from the operation diff
- `tos audit visit-coverage` invariant audit (was Phase D in original scope)

## Tests (13 new)

- Parser pin: shlex keeps `repairs,change` as one token
- Happy path (closed default), `open` positional, CSV reasons split, `now` + `start` token resolution
- Unknown reason / `<FILL_*>` in any positional / bad 4th positional / wrong arg count / empty reasons_csv — all `failed` without writer call
- Writer exception captured as `failed` (runner keeps going)
- Bad date format rejected post-resolution

## Smoke-tested live (dry-run only)

- Three-line happy-path triage file → all `ok`, distinct reason / completed states surfaced in detail
- Four-line error-path triage file → all `failed` with clear messages, no writes attempted, summary line `0 ok, 0 deferred, 4 failed`

## Test plan
- [x] `pytest tests/` — 925 passed, 2 skipped
- [x] `ruff check` — clean
- [x] `black --check` — clean
- [x] Live smoke-test via `tos audit apply /tmp/visit_smoke.txt` (dry-run): all paths correct
- [ ] Live `--apply` smoke-test deferred — would commit real vitjanir to live TOS; needs operator-curated test target

🤖 Generated with [Claude Code](https://claude.com/claude-code)