### PR TITLE
feat(tos): contact↔station relationship writes (full CRUD)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,6 +314,11 @@ tos visit list --station <STN>     # vitjanir attached to a station
 tos visit list --device <id>       # vitjanir attached to a device
 tos visit show <id_maintenance>    # one vitjun, full detail
 tos visit add  --station <STN> --start DATE [opts]  # new vitjun (dry-run default)
+tos contact show --id <id>         # contact entity detail
+tos contact list --station <STN>   # contacts mapped to a station
+tos contact patch-relationship <id_rel> --time-from DATE  # fix relationship date (dry-run default)
+tos contact assign --station <STN> --contact <id> --role owner --from DATE
+tos contact remove <id_rel>        # delete a relationship (dry-run default)
 tos audit apply <triage_file>      # dry-run; --apply to commit
 tos fleet status                   # bulk verify oracle (exit 0/1/2)
 tos fleet triage                   # generate per-station triage files
@@ -441,6 +446,47 @@ Integrates as opt-in third audit in the verify oracle / fleet status:
 Off by default to avoid the first-run noise problem: until operators have used `add-visit` enough to establish a baseline, every station looks broken. SUPPRESS file at `data/audit_suppressions/visit_coverage.txt` (key shape: `SUPPRESS <device_id> <event_date>`) lets operators silence pre-vitjun-era findings as they triage.
 
 Triage emitter generates one commented `#ACTION <device_id> add-visit change <event_date> "<FILL_WORK>"` per violation + a SUPPRESS hint per line. Operator replaces `<FILL_WORK>` with what actually happened, uncomments the line, runs `tos audit apply`.
+
+### `tos contact` — contact↔station relationship writes
+
+A contact (`id_contact`, e.g. 1256 = Veðurstofa) is mapped to a
+station/device by a relationship row in its own namespace
+(`id_contact_entity_relationship`). The raw admin row is
+`{id, id_contact, id_entity, role, time_from, time_to}` — structurally
+identical to an entity_connection. Endpoints (discovered 2026-05-31 by
+read-only probing; see `docs/architecture/contact-write-api.md`):
+`GET/PUT/DELETE /admin_contact_entity_relationship_row/{id}`,
+`POST /contact_joins` (create).
+
+Read verbs (`tos contact show / list`) are unchanged. **Write verbs**
+(dry-run by default, `--no-dry-run` commits — same as `tos visit add`):
+
+  * `tos contact patch-relationship <id_rel> --time-from DATE [--time-to DATE] [--role R]`
+    — the primary use: backdate a `time_from` that is a TOS-migration
+    artifact (the relationship row was created when the contact was
+    loaded into the new TOS, not when ownership actually started).
+  * `tos contact assign --station S --contact <id> --role owner --from DATE` — open a new relationship.
+  * `tos contact remove <id_rel>` — delete a relationship (destructive;
+    prefer `patch-relationship --time-to DATE` to end one).
+
+**ACTION verbs** (triage-file form — batch with metadata fixes in one
+`tos audit apply`, get the git provenance trail):
+
+  * `ACTION <id_entity> patch-contact-relationship <id_rel> <field> <value>` — field ∈ {time_from, time_to, role}
+  * `ACTION <id_entity> assign-contact <id_contact> <role> <time_from>`
+  * `ACTION <id_entity> delete-contact-relationship <id_rel>`
+
+The `id_entity` slot is the **station** (so the `start` date-token
+resolves against the station's earliest_known — exactly the founding
+date you backdate a migration artifact to). The migration-date fix is
+literally `ACTION <station> patch-contact-relationship <id_rel>
+time_from start`.
+
+`patch_contact_relationship` GET-merges-PUTs (the admin endpoint is
+PUT-replace): reads the current row, overlays the changed field, writes
+the full row back. Follow-ups (not built): `tos audit contact-dates`
+fleet-wide migration-artifact audit; contact-entity edits via
+`PUT /contact/{id}/` (fleet-global blast radius, deferred).
 
 ## Architecture
 

--- a/docs/architecture/contact-write-api.md
+++ b/docs/architecture/contact-write-api.md
@@ -1,6 +1,8 @@
 # Contact-write API — design / scope
 
-**Status:** planned, blocked on endpoint discovery (Phase 0).
+**Status:** relationship CRUD implemented (dry-run validated; **no live
+write executed yet** — see verification note under Phase 0). Phases 4-5
+(audit + contact-entity writes) not built.
 **Flagged:** 2026-05-31, during the vitjanir CLI expansion follow-up.
 
 ## Motivation
@@ -46,73 +48,111 @@ Each is a different TOS object, likely a different endpoint:
 3. **Contact entity attributes** — name / phone / address /
    `start_date` on `id_contact` itself.
 
-## Phase 0 — endpoint discovery (HARD BLOCKER)
+## Phase 0 — endpoint discovery (RESOLVED 2026-05-31)
 
-The documented write endpoints (`docs/architecture/tos-write-api.md`)
-cover entity-connections (`/joins`, `/join/{id}`), attribute_values
-(`/attribute_value/{id}`), and vitjanir (`/maintenances/...`). **None
-touch `id_contact_entity_relationship`.** The read side uses
-`entity_contacts/{id}/` + `contact/{id_contact}/`; the write endpoints
-are undiscovered.
+Discovered by **read-only probing** (GET + OPTIONS only — no mutating
+requests against live TOS). The `admin_*_row` family mirrors
+`admin_entity_connection_row` / `admin_entity_row` exactly.
 
-By analogy with the join pattern (`/joins` POST, `/join/{id}` PATCH)
-it's *probably* `PATCH /contact_entity_relationship/{id}` or an
-`/admin_contact_..._row/{id}` form — but this MUST be verified, not
-guessed, against live TOS.
+**Relationship endpoints** (`id_contact_entity_relationship`):
 
-**Discovery method (recommended):** edit a contact's date in the TOS
-web UI with browser dev-tools open; capture the PATCH/POST URL +
-payload from the Network tab. This is an operator task (authenticated
-TOS web session). The postgres-tos-readonly MCP could confirm the
-table/column shape but not the HTTP endpoint, and was unavailable at
-scoping time.
+| Op | Endpoint | Method |
+|----|----------|--------|
+| Read one row | `/admin_contact_entity_relationship_row/{id}` | GET |
+| Edit (PUT-replace) | `/admin_contact_entity_relationship_row/{id}` | PUT |
+| Delete | `/admin_contact_entity_relationship_row/{id}` | DELETE |
+| Create | `/contact_joins` | POST |
 
-Until Phase 0 lands, Phases 1-4 cannot be implemented.
+OPTIONS on the row returns `GET, HEAD, DELETE, PUT, OPTIONS`. The
+**raw** admin row uses `time_from` / `time_to` (the joined read-view
+`entity_contacts/{id}/` renames them `per_time_from` / `per_time_to`):
 
-## Phase 1 — writer methods
+```json
+{ "id": 5018, "id_contact": 1256, "id_entity": 4316,
+  "role": "owner", "time_from": "2025-02-04T15:32:38", "time_to": null }
+```
 
-Mirror the existing `patch_entity_connection` pattern in
+**Contact-entity endpoints** (`id_contact`), discovered alongside,
+NOT yet wired (Phase 5):
+
+| Op | Endpoint | Method |
+|----|----------|--------|
+| List | `/contacts` | GET |
+| Create | `/contacts` | POST |
+| Read | `/contact/{id}/` | GET |
+| Edit | `/contact/{id}/` | PUT |
+
+Note `/contact/{id}/` allows PUT — contact-entity edits (phone /
+address / name) are reachable, but they're **fleet-global** (one
+contact serves many stations), so they're deferred to Phase 5 with a
+louder confirmation path.
+
+> **Verification status (2026-05-31):** endpoints discovered by
+> read-only GET/OPTIONS probing; writer methods + verbs validated in
+> **dry-run only** (27 unit tests mock `_request` — they pin payload
+> *construction*, not TOS *acceptance*). **No live write has been
+> executed against any of these three endpoints.** The
+> `POST /contact_joins` body in particular is **inferred** from the
+> `/joins` analogy — `/joins` takes `id_entity_parent`/`id_entity_child`
+> while we send `id_contact`/`id_entity`; this is the most likely to
+> 400 on first real use. First live write should be the HEDI rel-5018
+> date fix (the operator's actual need) with a re-GET diff to confirm
+> the PUT contract + that the GET response is the complete row (not a
+> projection that PUT-replace would null).
+
+## Phase 1 — writer methods (implemented; live-write unverified)
+
 `src/tostools/api/tos_writer.py`:
 
 ```python
-def patch_contact_relationship(self, id_rel, *, time_from=None, time_to=None):
-    # PATCH <discovered endpoint>/{id_rel}; _tos_date-normalise dates
+def get_contact_relationship(self, id_relationship):
+    # GET /admin_contact_entity_relationship_row/{id}
+def patch_contact_relationship(self, id_relationship, *, time_from=None, time_to=None, role=None):
+    # GET-merge-PUT (admin endpoint is PUT-replace, not PATCH)
 def create_contact_relationship(self, id_contact, id_entity, role, time_from, time_to=None):
-    # POST <discovered endpoint>
-def patch_contact_attribute(self, id_contact, field, value):
-    # contact-entity field edits (name/phone/address/start_date)
+    # POST /contact_joins
+def delete_contact_relationship(self, id_relationship):
+    # DELETE /admin_contact_entity_relationship_row/{id}
 ```
 
-Dry-run by default (every writer method respects `self.dry_run`).
-Tests against mocked `_request` — no live TOS in unit tests.
+`patch_contact_relationship` GET-merges-PUTs because the admin endpoint
+replaces the whole row: it reads the current row, overlays the changed
+fields, writes the full row back. Dry-run respects `self.dry_run` (the
+GET still runs — reads are safe; only the PUT/POST/DELETE is held).
+Dates normalised via `_tos_date`.
 
-## Phase 2 — CLI verbs
+## Phase 2 — ACTION verbs (implemented; live-write unverified)
 
-Extend the `tos contact` subcommand (currently `show` / `list`):
+Triage-file forms so contact corrections batch with metadata fixes in
+one `tos audit apply` (the retrospective-writes-provenance pattern —
+the committed triage file is the audit trail). The `id_entity` slot
+holds the **station** (so the `start` date-token resolves against the
+station's earliest_known — exactly the founding date you backdate a
+migration artifact to); the relationship / contact id is the first
+positional arg, same convention as `patch-join-date`:
 
 ```
-tos contact patch-relationship <id_rel> time_from <date> [--no-dry-run]
-tos contact assign --station S --contact <id> --role owner --from <date>
+ACTION <id_entity> patch-contact-relationship <id_rel> <field> <value>  # field ∈ {time_from,time_to,role}
+ACTION <id_entity> assign-contact <id_contact> <role> <time_from>
+ACTION <id_entity> delete-contact-relationship <id_rel>
+```
+
+`start` / `now` date tokens, `<FILL_*>` placeholder rejection, field
+whitelist, and writer-exception-as-failed all match the other ACTION
+verbs.
+
+## Phase 3 — standalone CLI verbs (implemented; live-write unverified)
+
+```
+tos contact patch-relationship <id_rel> --time-from DATE [--time-to DATE] [--role R] [--no-dry-run]
+tos contact assign --station S --contact <id> --role owner --from DATE [--no-dry-run]
+tos contact remove <id_rel> [--no-dry-run]
 ```
 
 Dry-run default + `--no-dry-run` to commit, matching `tos device add`
-/ `tos visit add`.
+/ `tos visit add`. `--json` on all three.
 
-## Phase 3 — ACTION verb (optional)
-
-Triage-file form so contact corrections batch with metadata fixes in
-one `tos audit apply`:
-
-```
-ACTION <id_rel> patch-contact-date time_from <date>
-```
-
-Note: the ACTION dispatcher keys on `id_entity` today; the contact
-relationship is `id_contact_entity_relationship`, a different
-namespace. The dispatcher would need to tolerate a relationship-id in
-the id slot for this verb (or a distinct parse path). Minor but real.
-
-## Phase 4 — audit (migration-artifact pattern)
+## Phase 4 — audit (migration-artifact pattern, NOT YET BUILT)
 
 Operator confirmed the `per_time_from` migration-date is wrong
 fleet-wide. Parallel to `tos audit attribute-dates`:
@@ -126,19 +166,29 @@ relationship's `per_time_from` clustered around a single migration
 date (like 2014-10-17 for attributes), or a date range? Probe
 `entity_contacts/` across the fleet to find the signature, then the
 audit flags + the triage emitter suggests backdating to the station's
-`earliest_known` (the same anchor `start` resolves to elsewhere).
+`earliest_known` (the same anchor `start` resolves to elsewhere). The
+emitter would write `#ACTION <station> patch-contact-relationship
+<id_rel> time_from start` lines.
+
+## Phase 5 — contact-entity writes (NOT YET BUILT)
+
+`PUT /contact/{id}/` edits the contact entity (name / phone / address
+/ start_date). **Fleet-global** — one contact serves many stations —
+so it needs a louder confirmation than the per-station relationship
+edits. `POST /contacts` creates a new contact entity. Deferred until
+there's a concrete need; the relationship edits cover the immediate
+migration-date problem.
 
 ## Effort
 
-| Phase | Work | Blocked on |
+| Phase | Work | Status |
 |---|---|---|
-| 0 | Endpoint discovery (dev-tools capture) | **operator** |
-| 1 | Writer methods + mock tests | Phase 0 |
-| 2 | `tos contact patch-relationship` / `assign` | Phase 1 |
-| 3 | `patch-contact-date` ACTION verb | Phase 2 |
-| 4 | `tos audit contact-dates` + triage emitter | Phase 0 + fleet probe |
-
-~1-2 days for Phases 1-3 once the endpoint is known.
+| 0 | Endpoint discovery | ✅ done (read-only probing) |
+| 1 | Writer methods + mock tests | ✅ shipped |
+| 2 | ACTION verbs | ✅ shipped |
+| 3 | Standalone `tos contact` verbs | ✅ shipped |
+| 4 | `tos audit contact-dates` + triage emitter | ⏳ follow-up (fleet probe first) |
+| 5 | Contact-entity writes (`PUT /contact/{id}/`) | ⏳ deferred (fleet-global blast radius) |
 
 ## Cross-references
 

--- a/docs/architecture/tos-write-api.md
+++ b/docs/architecture/tos-write-api.md
@@ -49,6 +49,9 @@ Base URL: `https://vi-api.vedur.is/tos/v1`
 | GET | `/maintenances/id_entity/{id_entity}` | None | List vitjun records for an entity (flat web-UI shape) |
 | GET | `/maintenance/id_maintenance/{id}` | None | One vitjun's full detail incl. `maintenance_attribute_values[]` with each row's `id_maintenance_attribute_value` |
 | PUT | `/maintenance/id_maintenance/{id}` | JWT | Fill in vitjun details: `participants`, dates, `completed`, list of `{id_maintenance_attribute_value, value}` |
+| GET/PUT/DELETE | `/admin_contact_entity_relationship_row/{id}` | JWT | Read / edit (PUT-replace) / delete one contact↔entity relationship row `{id, id_contact, id_entity, role, time_from, time_to}` |
+| POST | `/contact_joins` | JWT | Create a contact↔entity relationship (mirrors `/joins`) |
+| GET/PUT | `/contact/{id_contact}/` | JWT (PUT) | Read / edit a contact entity (name, phone, address, start_date) — fleet-global |
 
 ## Python Client
 

--- a/src/tostools/api/tos_writer.py
+++ b/src/tostools/api/tos_writer.py
@@ -1232,6 +1232,149 @@ class TOSWriter:
             "DELETE", f"/admin_attribute_value_row/{id_attribute_value}"
         )
 
+    # ------------------------------------------------------------------
+    # Contact↔entity relationships
+    # ------------------------------------------------------------------
+    # A contact (id_contact) is mapped to a station/device (id_entity) by a
+    # relationship row in its own namespace: id_contact_entity_relationship.
+    # The raw admin row is ``{id, id_contact, id_entity, role, time_from,
+    # time_to}`` — structurally identical to an entity_connection. Endpoints
+    # discovered 2026-05-31 by read-only GET/OPTIONS probing:
+    #   GET/PUT/DELETE  /admin_contact_entity_relationship_row/{id}
+    #   POST            /contact_joins   (create, mirrors /joins)
+    # The joined read-view (entity_contacts/{id}/) renames time_from/time_to
+    # to per_time_from/per_time_to — the RAW row uses time_from/time_to.
+
+    def get_contact_relationship(
+        self, id_relationship: int
+    ) -> Optional[Dict[str, Any]]:
+        """Read one raw contact↔entity relationship row.
+
+        Wraps ``GET /admin_contact_entity_relationship_row/{id}``. Returns
+        ``{id, id_contact, id_entity, role, time_from, time_to}`` or
+        ``None`` on lookup failure. Needed by :meth:`patch_contact_relationship`
+        for the GET-merge-PUT cycle (the admin endpoint is PUT-replace, so we
+        read the current row, overlay the changed fields, and write it back).
+        """
+        result = self._request(
+            "GET", f"/admin_contact_entity_relationship_row/{id_relationship}"
+        )
+        return result if isinstance(result, dict) else None
+
+    def patch_contact_relationship(
+        self,
+        id_relationship: int,
+        *,
+        time_from: Optional[str] = None,
+        time_to: Optional[str] = None,
+        role: Optional[str] = None,
+    ) -> Any:
+        """Correct a contact↔entity relationship's period or role.
+
+        The primary use case is backdating a ``time_from`` that is a
+        TOS-migration artifact (the relationship row was created when the
+        contact was loaded into the new TOS, not when the contact actually
+        started owning/operating the station). See
+        ``docs/architecture/contact-write-api.md``.
+
+        The admin endpoint is **PUT-replace**, not PATCH, so this method
+        GET-merges-PUTs: it reads the current row, overlays the provided
+        fields, and writes the full row back. At least one of
+        ``time_from`` / ``time_to`` / ``role`` must be given.
+
+        Date fields are normalised through :meth:`_tos_date` (bare
+        ``YYYY-MM-DD`` promoted to midnight — TOS rejects date-only on
+        join-style endpoints with HTTP 400).
+
+        In dry-run mode the GET still happens (reads are safe) but the PUT
+        is intercepted and a :class:`DryRunResult` is returned.
+        """
+        if time_from is None and time_to is None and role is None:
+            raise ValueError(
+                "patch_contact_relationship: at least one of time_from / "
+                "time_to / role must be provided"
+            )
+        current = self.get_contact_relationship(id_relationship)
+        if current is None:
+            raise ValueError(
+                f"patch_contact_relationship: no relationship row with "
+                f"id={id_relationship}"
+            )
+        payload = {
+            "id_contact": current.get("id_contact"),
+            "id_entity": current.get("id_entity"),
+            "role": role if role is not None else current.get("role"),
+            "time_from": (
+                self._tos_date(time_from)
+                if time_from is not None
+                else current.get("time_from")
+            ),
+            "time_to": (
+                self._tos_date(time_to)
+                if time_to is not None
+                else current.get("time_to")
+            ),
+        }
+        return self._request(
+            "PUT",
+            f"/admin_contact_entity_relationship_row/{id_relationship}",
+            data=payload,
+        )
+
+    def create_contact_relationship(
+        self,
+        id_contact: int,
+        id_entity: int,
+        role: str,
+        time_from: str,
+        time_to: Optional[str] = None,
+    ) -> Any:
+        """Assign a contact to a station/device (open a new relationship).
+
+        Wraps ``POST /contact_joins`` — the create endpoint mirrors
+        ``/joins`` for entity connections. Body shape follows the raw
+        relationship row: ``id_contact``, ``id_entity``, ``role``,
+        ``time_from``, ``time_to``.
+
+        Args:
+            id_contact: The contact entity (e.g. 1256 = Veðurstofa).
+            id_entity: The station / device the contact is mapped to.
+            role: TOS role string (``"owner"`` = Eigandi stöðvar,
+                ``"operator"`` = Rekstraraðili, ...).
+            time_from: ISO start of the relationship. Bare ``YYYY-MM-DD``
+                promoted to midnight.
+            time_to: ISO end, or ``None`` for currently active.
+        """
+        return self._request(
+            "POST",
+            "/contact_joins",
+            data={
+                "id_contact": id_contact,
+                "id_entity": id_entity,
+                "role": role,
+                "time_from": self._tos_date(time_from),
+                "time_to": self._tos_date(time_to) if time_to is not None else None,
+            },
+        )
+
+    def delete_contact_relationship(self, id_relationship: int) -> Any:
+        """Permanently remove a contact↔entity relationship row.
+
+        .. warning::
+
+           Destructive admin endpoint. Use only for cleaning up a wrong
+           mapping (contact assigned to the wrong station, duplicate
+           relationship). To END a relationship that was genuinely valid,
+           prefer :meth:`patch_contact_relationship` with ``time_to`` set —
+           that preserves the history. Deletion erases it.
+
+        Uses ``DELETE /admin_contact_entity_relationship_row/{id}``.
+        """
+        return self._request(
+            "DELETE",
+            f"/admin_contact_entity_relationship_row/{id_relationship}",
+        )
+
     def transition_attribute_value(
         self,
         id_entity: int,

--- a/src/tostools/tos.py
+++ b/src/tostools/tos.py
@@ -3295,6 +3295,124 @@ def _contact_main(argv):
     )
     p_list.add_argument("--port", type=int, default=443)
 
+    # ---- Write verbs (dry-run default; mirror tos visit add) -----------
+    p_patch = sub.add_parser(
+        "patch-relationship",
+        help="Correct a contact↔station relationship's period or role.",
+        description=(
+            "Edit the time_from / time_to / role of one contact↔station "
+            "relationship row (id_contact_entity_relationship). Primary "
+            "use: backdate a time_from that is a TOS-migration artifact "
+            "(the relationship row was created when the contact was "
+            "loaded into the new TOS, not when ownership actually "
+            "started).\n\n"
+            "Dry-run by default — the payload is logged but not sent. "
+            "--no-dry-run commits (needs TOS credentials).\n\n"
+            "The id_rel is the 'id' from the raw relationship row — get "
+            "it from `tos contact list --station S --json` "
+            "(id_contact_entity_relationship field)."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p_patch.add_argument(
+        "id_rel",
+        type=int,
+        help="The relationship row id (id_contact_entity_relationship).",
+    )
+    p_patch.add_argument(
+        "--time-from",
+        dest="time_from",
+        default=None,
+        help="New time_from (YYYY-MM-DD). The migration-artifact fix.",
+    )
+    p_patch.add_argument(
+        "--time-to",
+        dest="time_to",
+        default=None,
+        help="New time_to (YYYY-MM-DD), or empty to leave open.",
+    )
+    p_patch.add_argument(
+        "--role",
+        default=None,
+        help="New role string (owner / operator / ...).",
+    )
+    p_patch.add_argument(
+        "--no-dry-run",
+        dest="no_dry_run",
+        action="store_true",
+        help="Commit the write. Default: dry-run (payload logged only).",
+    )
+    p_patch.add_argument("--json", action="store_true", help="Structured output.")
+    p_patch.add_argument("--server", default="vi-api.vedur.is")
+    p_patch.add_argument("--port", type=int, default=443)
+
+    p_assign = sub.add_parser(
+        "assign",
+        help="Assign a contact to a station (open a new relationship).",
+        description=(
+            "Create a new contact↔station relationship (POST "
+            "/contact_joins). Dry-run by default; --no-dry-run commits."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p_assign.add_argument(
+        "--station", required=True, help="Station marker (e.g. HEDI) or name."
+    )
+    p_assign.add_argument(
+        "--contact",
+        dest="id_contact",
+        type=int,
+        required=True,
+        help="The contact entity id (from `tos contact list`).",
+    )
+    p_assign.add_argument(
+        "--role",
+        required=True,
+        help="Role string (owner / operator / ...).",
+    )
+    p_assign.add_argument(
+        "--from",
+        dest="time_from",
+        required=True,
+        help="Relationship start (YYYY-MM-DD).",
+    )
+    p_assign.add_argument(
+        "--no-dry-run",
+        dest="no_dry_run",
+        action="store_true",
+        help="Commit the write. Default: dry-run.",
+    )
+    p_assign.add_argument("--json", action="store_true", help="Structured output.")
+    p_assign.add_argument("--server", default="vi-api.vedur.is")
+    p_assign.add_argument("--port", type=int, default=443)
+
+    p_remove = sub.add_parser(
+        "remove",
+        help="Delete a contact↔station relationship (destructive).",
+        description=(
+            "Permanently delete one relationship row (DELETE "
+            "/admin_contact_entity_relationship_row/{id}). Erases "
+            "history — to END a valid relationship prefer "
+            "`patch-relationship <id> --time-to <date>`. Dry-run by "
+            "default; --no-dry-run commits."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p_remove.add_argument(
+        "id_rel",
+        type=int,
+        help="The relationship row id (id_contact_entity_relationship).",
+    )
+    p_remove.add_argument(
+        "--no-dry-run",
+        dest="no_dry_run",
+        action="store_true",
+        help="Commit the delete. Default: dry-run.",
+    )
+    p_remove.add_argument("--json", action="store_true", help="Structured output.")
+    p_remove.add_argument("--server", default="vi-api.vedur.is")
+    p_remove.add_argument("--port", type=int, default=443)
+
     args = p.parse_args(argv)
 
     scheme = "https" if args.port == 443 else "http"
@@ -3409,6 +3527,136 @@ def _contact_main(argv):
 
         console = Console()
         _render_station_contacts(console, contacts)
+        return 0
+
+    if args.verb in ("patch-relationship", "assign", "remove"):
+        return _contact_write_main(args, base_url)
+
+    return 2
+
+
+def _contact_write_main(args, base_url: str) -> int:
+    """Handle the contact-relationship write verbs (patch / assign / remove).
+
+    Split out from :func:`_contact_main` so the read path stays on the
+    unauthenticated client. All three are dry-run by default
+    (``--no-dry-run`` commits), mirroring ``tos visit add`` /
+    ``tos device add``.
+    """
+    import json as _json
+
+    from .api.tos_writer import TOSWriter
+
+    dry_run = not args.no_dry_run
+    writer = TOSWriter(base_url=base_url, dry_run=dry_run)
+
+    if args.verb == "assign":
+        # Resolve the station marker → id_entity (the relationship's
+        # entity side). The contact id is supplied directly.
+        from .api.tos_client import TOSClient
+
+        client = TOSClient(base_url=base_url)
+        id_entity = _resolve_parent_id(client, station_marker=args.station)
+        if id_entity is None:
+            print(f"No station found for marker {args.station!r}", file=sys.stderr)
+            return 1
+        try:
+            result = writer.create_contact_relationship(
+                args.id_contact,
+                id_entity,
+                args.role,
+                args.time_from,
+            )
+        except ValueError as exc:
+            print(f"assign failed: {exc}", file=sys.stderr)
+            return 1
+        suffix = " (dry-run)" if dry_run else ""
+        if args.json:
+            print(
+                _json.dumps(
+                    {
+                        "verb": "assign",
+                        "id_contact": args.id_contact,
+                        "id_entity": id_entity,
+                        "role": args.role,
+                        "time_from": args.time_from,
+                        "dry_run": dry_run,
+                        "result": str(result),
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                )
+            )
+        else:
+            print(
+                f"Assigned contact {args.id_contact} → station {args.station} "
+                f"(id_entity={id_entity}) role={args.role!r} "
+                f"from {args.time_from}{suffix}"
+            )
+        return 0
+
+    if args.verb == "patch-relationship":
+        if args.time_from is None and args.time_to is None and args.role is None:
+            print(
+                "tos contact patch-relationship: at least one of "
+                "--time-from / --time-to / --role is required",
+                file=sys.stderr,
+            )
+            return 2
+        kwargs: Dict[str, Any] = {}
+        if args.time_from is not None:
+            kwargs["time_from"] = args.time_from
+        if args.time_to is not None:
+            kwargs["time_to"] = args.time_to
+        if args.role is not None:
+            kwargs["role"] = args.role
+        try:
+            result = writer.patch_contact_relationship(args.id_rel, **kwargs)
+        except ValueError as exc:
+            print(f"patch-relationship failed: {exc}", file=sys.stderr)
+            return 1
+        suffix = " (dry-run)" if dry_run else ""
+        if args.json:
+            print(
+                _json.dumps(
+                    {
+                        "verb": "patch-relationship",
+                        "id_rel": args.id_rel,
+                        "changes": kwargs,
+                        "dry_run": dry_run,
+                        "result": str(result),
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                )
+            )
+        else:
+            changes = ", ".join(f"{k}={v}" for k, v in kwargs.items())
+            print(f"Patched relationship {args.id_rel}: {changes}{suffix}")
+        return 0
+
+    if args.verb == "remove":
+        try:
+            result = writer.delete_contact_relationship(args.id_rel)
+        except ValueError as exc:
+            print(f"remove failed: {exc}", file=sys.stderr)
+            return 1
+        suffix = " (dry-run)" if dry_run else ""
+        if args.json:
+            print(
+                _json.dumps(
+                    {
+                        "verb": "remove",
+                        "id_rel": args.id_rel,
+                        "dry_run": dry_run,
+                        "result": str(result),
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                )
+            )
+        else:
+            print(f"Removed relationship {args.id_rel}{suffix}")
         return 0
 
     return 2
@@ -5913,16 +6161,19 @@ class ParseError:
 _SUPPORTED_VERBS = (
     "add-attribute",
     "add-visit",
+    "assign-contact",
     "change-subtype",
     "create-join",
     "decommission",
     "defer",
     "delete-attribute-value",
+    "delete-contact-relationship",
     "delete-join",
     "fill-gap",
     "move",
     "patch-attribute-date",
     "patch-attribute-value",
+    "patch-contact-relationship",
     "patch-join-date",
 )
 
@@ -7286,6 +7537,259 @@ def _dispatch_patch_join_date(writer, action: ParsedAction) -> ActionResult:
     )
 
 
+#: Editable fields on a contact↔entity relationship via
+#: ``patch-contact-relationship``. ``role`` is a string; the two date
+#: fields go through the date-token resolver + YYYY-MM-DD check.
+_PATCH_CONTACT_FIELDS = ("time_from", "time_to", "role")
+
+
+def _dispatch_patch_contact_relationship(writer, action: ParsedAction) -> ActionResult:
+    """Correct a contact↔entity relationship's period or role.
+
+    Action shape: ``ACTION <id_entity> patch-contact-relationship
+    <id_relationship> <field> <value>`` where
+    ``field ∈ {time_from, time_to, role}``.
+
+    Primary use case: backdate a ``time_from`` that is a TOS-migration
+    artifact (the contact↔station relationship row was created when the
+    contact was loaded into the new TOS, not when the contact actually
+    started owning the station). See
+    ``docs/architecture/contact-write-api.md``.
+
+    The ``id_entity`` slot is the STATION the contact is mapped to —
+    same convention as ``patch-join-date`` (device in the id slot,
+    connection id in args[0]). Keeping the station there means the
+    ``start`` date-token resolves against the station's earliest_known,
+    which is exactly the anchor you want when backdating a migration
+    date to founding.
+
+    For ``field=role`` the value is a bare string (``owner`` /
+    ``operator`` / ...) — no date resolution. For the date fields,
+    ``now`` / ``start`` tokens resolve and the result is format-checked.
+    """
+    if len(action.args) != 3:
+        return ActionResult(
+            action=action,
+            status="failed",
+            detail=(
+                "patch-contact-relationship: expected 3 args "
+                "(<id_relationship> <field> <value>), got "
+                f"{len(action.args)}"
+            ),
+        )
+    rel_token, field, value = action.args[0], action.args[1], action.args[2]
+
+    try:
+        id_relationship = int(rel_token)
+    except ValueError:
+        return ActionResult(
+            action=action,
+            status="failed",
+            detail=(
+                "patch-contact-relationship requires integer "
+                f"id_relationship, got {rel_token!r}"
+            ),
+        )
+
+    if field not in _PATCH_CONTACT_FIELDS:
+        return ActionResult(
+            action=action,
+            status="failed",
+            detail=(
+                "patch-contact-relationship: field must be one of "
+                f"{', '.join(_PATCH_CONTACT_FIELDS)} (got {field!r})"
+            ),
+        )
+
+    if value.startswith("<") and value.endswith(">"):
+        return ActionResult(
+            action=action,
+            status="failed",
+            detail=(
+                f"patch-contact-relationship: value placeholder {value!r} "
+                "not replaced — fill it in before applying"
+            ),
+        )
+
+    kwargs: Dict[str, Any] = {}
+    if field == "role":
+        kwargs["role"] = value
+    else:
+        # Date field — resolve now/start, then YYYY-MM-DD check.
+        resolved, err = _resolve_date_token(value, action.id_entity, writer)
+        if err is not None:
+            return ActionResult(
+                action=action,
+                status="failed",
+                detail=f"patch-contact-relationship: {err}",
+            )
+        value = resolved or value
+        date_prefix = value[:10]
+        if len(date_prefix) != 10 or date_prefix[4] != "-" or date_prefix[7] != "-":
+            return ActionResult(
+                action=action,
+                status="failed",
+                detail=(
+                    "patch-contact-relationship: date must be YYYY-MM-DD "
+                    f"(got {value!r})"
+                ),
+            )
+        kwargs[field] = value
+
+    try:
+        response = writer.patch_contact_relationship(id_relationship, **kwargs)
+    except Exception as exc:  # noqa: BLE001
+        return ActionResult(
+            action=action,
+            status="failed",
+            detail=f"patch_contact_relationship raised: {exc}",
+        )
+
+    return ActionResult(
+        action=action,
+        status="ok",
+        detail=(
+            f"PUT /admin_contact_entity_relationship_row/{id_relationship} "
+            f"{field}={value} (station={action.id_entity}) — {response!r}"
+        ),
+    )
+
+
+def _dispatch_assign_contact(writer, action: ParsedAction) -> ActionResult:
+    """Assign a contact to a station/device (open a new relationship).
+
+    Action shape: ``ACTION <id_entity> assign-contact <id_contact>
+    <role> <time_from>``. The ``id_entity`` is the station/device the
+    contact is mapped to; ``id_contact`` is the contact entity (e.g.
+    1256 = Veðurstofa).
+
+    ``time_from`` accepts ``now`` / ``start`` tokens (``start`` =
+    the station's earliest_known).
+    """
+    if len(action.args) != 3:
+        return ActionResult(
+            action=action,
+            status="failed",
+            detail=(
+                "assign-contact: expected 3 args (<id_contact> <role> "
+                f"<time_from>), got {len(action.args)}"
+            ),
+        )
+    contact_token, role, time_from = (
+        action.args[0],
+        action.args[1],
+        action.args[2],
+    )
+
+    try:
+        id_contact = int(contact_token)
+    except ValueError:
+        return ActionResult(
+            action=action,
+            status="failed",
+            detail=f"assign-contact requires integer id_contact, got {contact_token!r}",
+        )
+
+    if role.startswith("<") and role.endswith(">"):
+        return ActionResult(
+            action=action,
+            status="failed",
+            detail=f"assign-contact: role placeholder {role!r} not replaced",
+        )
+
+    resolved, err = _resolve_date_token(time_from, action.id_entity, writer)
+    if err is not None:
+        return ActionResult(
+            action=action,
+            status="failed",
+            detail=f"assign-contact: {err}",
+        )
+    time_from = resolved or time_from
+    date_prefix = time_from[:10]
+    if len(date_prefix) != 10 or date_prefix[4] != "-" or date_prefix[7] != "-":
+        return ActionResult(
+            action=action,
+            status="failed",
+            detail=f"assign-contact: time_from must be YYYY-MM-DD (got {time_from!r})",
+        )
+
+    try:
+        response = writer.create_contact_relationship(
+            id_contact, action.id_entity, role, time_from
+        )
+    except Exception as exc:  # noqa: BLE001
+        return ActionResult(
+            action=action,
+            status="failed",
+            detail=f"create_contact_relationship raised: {exc}",
+        )
+
+    return ActionResult(
+        action=action,
+        status="ok",
+        detail=(
+            f"POST /contact_joins id_contact={id_contact} "
+            f"id_entity={action.id_entity} role={role!r} "
+            f"time_from={time_from} — {response!r}"
+        ),
+    )
+
+
+def _dispatch_delete_contact_relationship(writer, action: ParsedAction) -> ActionResult:
+    """Permanently DELETE a contact↔entity relationship row.
+
+    Action shape: ``ACTION <id_entity> delete-contact-relationship
+    <id_relationship>``.
+
+    Destructive — erases history. To END a genuinely-valid relationship
+    prefer ``patch-contact-relationship <id> time_to <date>`` (preserves
+    history). Use delete only for a wrong mapping / duplicate.
+
+    Trust model: ``id_relationship`` is trusted without verifying it
+    belongs to ``id_entity`` (same precedent as
+    :func:`_dispatch_delete_join`). Pre-flight + dry-run is the safety net.
+    """
+    if len(action.args) != 1:
+        return ActionResult(
+            action=action,
+            status="failed",
+            detail=(
+                "delete-contact-relationship: expected 1 arg "
+                f"(<id_relationship>), got {len(action.args)}"
+            ),
+        )
+    (rel_token,) = (action.args[0],)
+    try:
+        id_relationship = int(rel_token)
+    except ValueError:
+        return ActionResult(
+            action=action,
+            status="failed",
+            detail=(
+                "delete-contact-relationship requires integer "
+                f"id_relationship, got {rel_token!r}"
+            ),
+        )
+
+    try:
+        response = writer.delete_contact_relationship(id_relationship)
+    except Exception as exc:  # noqa: BLE001
+        return ActionResult(
+            action=action,
+            status="failed",
+            detail=f"delete_contact_relationship raised: {exc}",
+        )
+
+    return ActionResult(
+        action=action,
+        status="ok",
+        detail=(
+            f"DELETE /admin_contact_entity_relationship_row/{id_relationship} "
+            f"(station={action.id_entity}) — {response!r}"
+        ),
+    )
+
+
 def _dispatch_delete_attribute_value(writer, action: ParsedAction) -> ActionResult:
     """Permanently DELETE an attribute_value row from TOS.
 
@@ -7438,6 +7942,12 @@ def _dispatch_action(
         return _dispatch_add_attribute(writer, action)
     if action.verb == "add-visit":
         return _dispatch_add_visit(writer, action)
+    if action.verb == "patch-contact-relationship":
+        return _dispatch_patch_contact_relationship(writer, action)
+    if action.verb == "assign-contact":
+        return _dispatch_assign_contact(writer, action)
+    if action.verb == "delete-contact-relationship":
+        return _dispatch_delete_contact_relationship(writer, action)
     if action.verb == "change-subtype":
         code = action.args[0]
         mapping = subtype_id_by_code or {}
@@ -8679,6 +9189,11 @@ def _print_top_level_help() -> None:
         "  contact    Inspect TOS contact records (id_contact namespace).\n"
         "               contact show --id N     One contact record.\n"
         "               contact list --station S  Contacts for a station.\n"
+        "               contact patch-relationship <id_rel> --time-from DATE\n"
+        "                                       Correct a contact↔station\n"
+        "                                       relationship date/role (dry-run\n"
+        "                                       default; --no-dry-run commits).\n"
+        "               contact assign / remove   Open / delete a relationship.\n"
         "\n"
         "  visit      Inspect or create TOS vitjun (visit / maintenance) records.\n"
         "               visit list --station S         Vitjanir for a station.\n"

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -2339,3 +2339,162 @@ def test_dispatch_add_visit_empty_csv_reasons_rejected():
     assert result.status == "failed"
     assert "at least one code" in result.detail
     writer.add_maintenance_visit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _dispatch contact-relationship verbs (patch / assign / delete)
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_patch_contact_relationship_happy_path():
+    writer = MagicMock()
+    writer.patch_contact_relationship.return_value = {"ok": True}
+    result = _dispatch_action(
+        writer,
+        _make_action(
+            4316, "patch-contact-relationship", "5018", "time_from", "2006-06-29"
+        ),
+    )
+    assert result.status == "ok"
+    writer.patch_contact_relationship.assert_called_once_with(
+        5018, time_from="2006-06-29"
+    )
+    assert "PUT /admin_contact_entity_relationship_row/5018" in result.detail
+
+
+def test_dispatch_patch_contact_relationship_start_token_resolves_against_station():
+    """`start` resolves against the id_entity slot (the station), NOT the
+    relationship id — that's why the station goes in the id slot."""
+    writer = MagicMock()
+    writer._get_earliest_known.return_value = "2006-06-29"
+    writer.patch_contact_relationship.return_value = {"ok": True}
+    result = _dispatch_action(
+        writer,
+        _make_action(4316, "patch-contact-relationship", "5018", "time_from", "start"),
+    )
+    assert result.status == "ok"
+    writer._get_earliest_known.assert_called_once_with(4316)
+    writer.patch_contact_relationship.assert_called_once_with(
+        5018, time_from="2006-06-29"
+    )
+
+
+def test_dispatch_patch_contact_relationship_role_field_no_date_check():
+    writer = MagicMock()
+    writer.patch_contact_relationship.return_value = {"ok": True}
+    result = _dispatch_action(
+        writer,
+        _make_action(4316, "patch-contact-relationship", "5018", "role", "operator"),
+    )
+    assert result.status == "ok"
+    writer.patch_contact_relationship.assert_called_once_with(5018, role="operator")
+
+
+def test_dispatch_patch_contact_relationship_bad_field_rejected():
+    writer = MagicMock()
+    result = _dispatch_action(
+        writer,
+        _make_action(4316, "patch-contact-relationship", "5018", "bogus", "x"),
+    )
+    assert result.status == "failed"
+    assert "field must be one of" in result.detail
+    writer.patch_contact_relationship.assert_not_called()
+
+
+def test_dispatch_patch_contact_relationship_placeholder_rejected():
+    writer = MagicMock()
+    result = _dispatch_action(
+        writer,
+        _make_action(
+            4316, "patch-contact-relationship", "5018", "time_from", "<FILL_DATE>"
+        ),
+    )
+    assert result.status == "failed"
+    assert "placeholder" in result.detail
+    writer.patch_contact_relationship.assert_not_called()
+
+
+def test_dispatch_patch_contact_relationship_non_int_id_rejected():
+    writer = MagicMock()
+    result = _dispatch_action(
+        writer,
+        _make_action(
+            4316, "patch-contact-relationship", "abc", "time_from", "2006-06-29"
+        ),
+    )
+    assert result.status == "failed"
+    assert "integer id_relationship" in result.detail
+    writer.patch_contact_relationship.assert_not_called()
+
+
+def test_dispatch_patch_contact_relationship_writer_exception_captured():
+    writer = MagicMock()
+    writer._get_earliest_known.return_value = "2006-06-29"
+    writer.patch_contact_relationship.side_effect = RuntimeError("simulated 500")
+    result = _dispatch_action(
+        writer,
+        _make_action(
+            4316, "patch-contact-relationship", "5018", "time_from", "2006-06-29"
+        ),
+    )
+    assert result.status == "failed"
+    assert "simulated 500" in result.detail
+
+
+def test_dispatch_assign_contact_happy_path():
+    writer = MagicMock()
+    writer.create_contact_relationship.return_value = {"id": 6000}
+    result = _dispatch_action(
+        writer,
+        _make_action(4316, "assign-contact", "1256", "operator", "2020-01-01"),
+    )
+    assert result.status == "ok"
+    writer.create_contact_relationship.assert_called_once_with(
+        1256, 4316, "operator", "2020-01-01"
+    )
+    assert "POST /contact_joins" in result.detail
+
+
+def test_dispatch_assign_contact_non_int_contact_rejected():
+    writer = MagicMock()
+    result = _dispatch_action(
+        writer,
+        _make_action(4316, "assign-contact", "notanint", "operator", "2020-01-01"),
+    )
+    assert result.status == "failed"
+    assert "integer id_contact" in result.detail
+    writer.create_contact_relationship.assert_not_called()
+
+
+def test_dispatch_assign_contact_bad_date_rejected():
+    writer = MagicMock()
+    result = _dispatch_action(
+        writer,
+        _make_action(4316, "assign-contact", "1256", "operator", "not-a-date"),
+    )
+    assert result.status == "failed"
+    assert "YYYY-MM-DD" in result.detail
+    writer.create_contact_relationship.assert_not_called()
+
+
+def test_dispatch_delete_contact_relationship_happy_path():
+    writer = MagicMock()
+    writer.delete_contact_relationship.return_value = None
+    result = _dispatch_action(
+        writer,
+        _make_action(4316, "delete-contact-relationship", "5018"),
+    )
+    assert result.status == "ok"
+    writer.delete_contact_relationship.assert_called_once_with(5018)
+    assert "DELETE /admin_contact_entity_relationship_row/5018" in result.detail
+
+
+def test_dispatch_delete_contact_relationship_non_int_rejected():
+    writer = MagicMock()
+    result = _dispatch_action(
+        writer,
+        _make_action(4316, "delete-contact-relationship", "xyz"),
+    )
+    assert result.status == "failed"
+    assert "integer id_relationship" in result.detail
+    writer.delete_contact_relationship.assert_not_called()

--- a/tests/test_contact.py
+++ b/tests/test_contact.py
@@ -432,3 +432,165 @@ def test_station_show_drill_hint_includes_contact_id_when_present(capsys):
     assert rc == 0
     out = capsys.readouterr().out
     assert "tos contact show --id 1256" in out
+
+
+# ---------------------------------------------------------------------------
+# Write verbs — patch-relationship / assign / remove (dry-run default)
+# ---------------------------------------------------------------------------
+
+
+def test_contact_patch_relationship_dry_run_default(capsys):
+    """`tos contact patch-relationship <id> --time-from DATE` constructs
+    the writer dry-run by default and calls patch_contact_relationship."""
+    from tostools.api.tos_writer import DryRunResult, TOSWriter
+
+    with patch.object(
+        TOSWriter,
+        "patch_contact_relationship",
+        autospec=True,
+        return_value=DryRunResult("PUT", "/x", {}),
+    ) as pcr:
+        rc = tos_main(
+            ["contact", "patch-relationship", "5018", "--time-from", "2006-06-29"]
+        )
+
+    assert rc == 0
+    pcr.assert_called_once()
+    # Writer instance is dry_run=True (no --no-dry-run).
+    assert pcr.call_args.args[0].dry_run is True
+    assert pcr.call_args.args[1] == 5018
+    assert pcr.call_args.kwargs == {"time_from": "2006-06-29"}
+    out = capsys.readouterr().out
+    assert "Patched relationship 5018" in out
+    assert "(dry-run)" in out
+
+
+def test_contact_patch_relationship_no_dry_run_commits(capsys):
+    from tostools.api.tos_writer import TOSWriter
+
+    with (
+        patch.object(
+            TOSWriter,
+            "patch_contact_relationship",
+            autospec=True,
+            return_value={"ok": 1},
+        ) as pcr,
+        patch.object(TOSWriter, "_ensure_authenticated", autospec=True),
+    ):
+        rc = tos_main(
+            [
+                "contact",
+                "patch-relationship",
+                "5018",
+                "--time-from",
+                "2006-06-29",
+                "--no-dry-run",
+            ]
+        )
+
+    assert rc == 0
+    assert pcr.call_args.args[0].dry_run is False
+    out = capsys.readouterr().out
+    assert "(dry-run)" not in out
+
+
+def test_contact_patch_relationship_requires_a_field(capsys):
+    rc = tos_main(["contact", "patch-relationship", "5018"])
+    assert rc == 2
+    assert "at least one of" in capsys.readouterr().err
+
+
+def test_contact_patch_relationship_json(capsys):
+    from tostools.api.tos_writer import DryRunResult, TOSWriter
+
+    with patch.object(
+        TOSWriter,
+        "patch_contact_relationship",
+        autospec=True,
+        return_value=DryRunResult("PUT", "/x", {}),
+    ):
+        rc = tos_main(
+            ["contact", "patch-relationship", "5018", "--role", "operator", "--json"]
+        )
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["verb"] == "patch-relationship"
+    assert payload["id_rel"] == 5018
+    assert payload["changes"] == {"role": "operator"}
+    assert payload["dry_run"] is True
+
+
+def test_contact_assign_resolves_station_and_creates(capsys):
+    from tostools.api.tos_writer import DryRunResult, TOSWriter
+
+    with (
+        patch("tostools.tos._resolve_parent_id", return_value=4316),
+        patch.object(
+            TOSWriter,
+            "create_contact_relationship",
+            autospec=True,
+            return_value=DryRunResult("POST", "/contact_joins", {}),
+        ) as ccr,
+    ):
+        rc = tos_main(
+            [
+                "contact",
+                "assign",
+                "--station",
+                "HEDI",
+                "--contact",
+                "1256",
+                "--role",
+                "operator",
+                "--from",
+                "2020-01-01",
+            ]
+        )
+
+    assert rc == 0
+    ccr.assert_called_once()
+    # (self, id_contact, id_entity, role, time_from)
+    assert ccr.call_args.args[1:] == (1256, 4316, "operator", "2020-01-01")
+    out = capsys.readouterr().out
+    assert "Assigned contact 1256" in out
+    assert "(dry-run)" in out
+
+
+def test_contact_assign_unresolvable_station_returns_1(capsys):
+    with patch("tostools.tos._resolve_parent_id", return_value=None):
+        rc = tos_main(
+            [
+                "contact",
+                "assign",
+                "--station",
+                "XXXX",
+                "--contact",
+                "1256",
+                "--role",
+                "owner",
+                "--from",
+                "2020-01-01",
+            ]
+        )
+    assert rc == 1
+    assert "No station found for marker 'XXXX'" in capsys.readouterr().err
+
+
+def test_contact_remove_dry_run_default(capsys):
+    from tostools.api.tos_writer import DryRunResult, TOSWriter
+
+    with patch.object(
+        TOSWriter,
+        "delete_contact_relationship",
+        autospec=True,
+        return_value=DryRunResult("DELETE", "/x", None),
+    ) as dcr:
+        rc = tos_main(["contact", "remove", "5018"])
+
+    assert rc == 0
+    dcr.assert_called_once()
+    assert dcr.call_args.args[0].dry_run is True
+    assert dcr.call_args.args[1] == 5018
+    out = capsys.readouterr().out
+    assert "Removed relationship 5018" in out
+    assert "(dry-run)" in out

--- a/tests/test_tos_writer.py
+++ b/tests/test_tos_writer.py
@@ -1897,3 +1897,129 @@ def test_update_maintenance_visit_dry_run_still_returns_merge():
     }
     assert av_by_code[80001] == "true"  # reason_change
     assert av_by_code[80006] == "test edit"
+
+
+# ---------------------------------------------------------------------------
+# TOSWriter — contact↔entity relationship writes (Phase: contact writes)
+# ---------------------------------------------------------------------------
+
+
+def _rel_row(**overrides):
+    """A raw admin contact-relationship row as TOS returns it."""
+    row = {
+        "id": 5018,
+        "id_contact": 1256,
+        "id_entity": 4316,
+        "role": "owner",
+        "time_from": "2025-02-04T15:32:38",
+        "time_to": None,
+    }
+    row.update(overrides)
+    return row
+
+
+def test_patch_contact_relationship_requires_a_field():
+    w = _logged_in_writer()
+    with pytest.raises(ValueError, match="at least one of"):
+        w.patch_contact_relationship(5018)
+
+
+def test_patch_contact_relationship_missing_row_raises():
+    w = _logged_in_writer(dry_run=False)
+    with patch.object(w, "_request", return_value=None):
+        with pytest.raises(ValueError, match="no relationship row"):
+            w.patch_contact_relationship(99999, time_from="2006-06-29")
+
+
+def test_patch_contact_relationship_get_merge_put_preserves_other_fields():
+    """The admin endpoint is PUT-replace, so the writer GET-merges-PUTs:
+    only the changed field differs; id_contact / id_entity / role and the
+    untouched date are carried over from the current row."""
+    w = _logged_in_writer(dry_run=False)
+    calls = []
+
+    def fake_request(method, endpoint, data=None, **kw):
+        calls.append((method, endpoint, data))
+        if method == "GET":
+            return _rel_row()
+        return {"ok": True}
+
+    with patch.object(w, "_request", side_effect=fake_request):
+        w.patch_contact_relationship(5018, time_from="2006-06-29")
+
+    get_call, put_call = calls
+    assert get_call[0] == "GET"
+    assert put_call[0] == "PUT"
+    assert put_call[1] == "/admin_contact_entity_relationship_row/5018"
+    payload = put_call[2]
+    assert payload["time_from"] == "2006-06-29T00:00:00"  # changed + promoted
+    assert payload["id_contact"] == 1256  # preserved
+    assert payload["id_entity"] == 4316  # preserved
+    assert payload["role"] == "owner"  # preserved
+    assert payload["time_to"] is None  # preserved
+
+
+def test_patch_contact_relationship_role_only():
+    w = _logged_in_writer(dry_run=False)
+
+    def fake_request(method, endpoint, data=None, **kw):
+        return _rel_row() if method == "GET" else {"ok": True}
+
+    with patch.object(w, "_request", side_effect=fake_request) as mock_req:
+        w.patch_contact_relationship(5018, role="operator")
+    put_payload = mock_req.call_args.kwargs["data"]
+    assert put_payload["role"] == "operator"
+    assert put_payload["time_from"] == "2025-02-04T15:32:38"  # unchanged
+
+
+def test_patch_contact_relationship_respects_dry_run():
+    from tostools.api.tos_writer import DryRunResult
+
+    w = _logged_in_writer(dry_run=True)
+
+    # GET still happens in dry-run (reads are safe); only the PUT is held.
+    def fake_request(method, endpoint, data=None, _force_send=False, **kw):
+        if method == "GET":
+            return _rel_row()
+        # Mimic the real _request dry-run interception for mutating calls.
+        return DryRunResult(method=method, endpoint=endpoint, payload=data)
+
+    with patch.object(w, "_request", side_effect=fake_request):
+        result = w.patch_contact_relationship(5018, time_from="2006-06-29")
+    assert isinstance(result, DryRunResult)
+    assert result.method == "PUT"
+
+
+def test_create_contact_relationship_posts_to_contact_joins():
+    w = _logged_in_writer(dry_run=False)
+    with patch.object(w, "_request") as mock_req:
+        mock_req.return_value = {"id": 6000}
+        w.create_contact_relationship(1256, 4316, "operator", "2020-01-01")
+    call = mock_req.call_args
+    assert call.args[0] == "POST"
+    assert call.args[1] == "/contact_joins"
+    payload = call.kwargs["data"]
+    assert payload == {
+        "id_contact": 1256,
+        "id_entity": 4316,
+        "role": "operator",
+        "time_from": "2020-01-01T00:00:00",  # bare date promoted
+        "time_to": None,
+    }
+
+
+def test_delete_contact_relationship_uses_admin_row_endpoint():
+    w = _logged_in_writer(dry_run=False)
+    with patch.object(w, "_request") as mock_req:
+        w.delete_contact_relationship(5018)
+    call = mock_req.call_args
+    assert call.args[0] == "DELETE"
+    assert call.args[1] == "/admin_contact_entity_relationship_row/5018"
+
+
+def test_get_contact_relationship_returns_row_or_none():
+    w = _logged_in_writer()
+    with patch.object(w, "_request", return_value=_rel_row()):
+        assert w.get_contact_relationship(5018)["id_contact"] == 1256
+    with patch.object(w, "_request", return_value=None):
+        assert w.get_contact_relationship(5018) is None


### PR DESCRIPTION
`tos contact` was read-only. Adds write support for the contact↔station relationship — primarily to backdate a `time_from` that is a **TOS-migration artifact** (the relationship row is created when a contact is loaded into the new TOS, not when ownership started; same flavor as the 2014-10-17 attribute pattern). Operator confirmed (this session) HEDI's owner date `2025-02-04` should be backdated.

## ⚠ Verification status — READ THIS

**Validated in dry-run only.** The 27 new tests mock `_request` — they pin payload *construction*, not TOS *acceptance*. **No live write has hit any of these three brand-new endpoints.** Unlike prior phases (which wrapped writer methods live-tested in earlier sessions), these four methods are new and the endpoints were inferred from GET/OPTIONS probing.

- `POST /contact_joins` body is **inferred** from the `/joins` analogy — `/joins` takes `id_entity_parent`/`id_entity_child` while we send `id_contact`/`id_entity`. Most likely to 400 on first real use. `assign` is the least-needed of the three verbs.
- `patch_contact_relationship` GET-merge-PUTs assuming the GET returns the **complete** row. If the admin GET is a projection (missing columns) and PUT is replace-semantics, unseen columns could null. The HEDI live test surfaces this immediately via re-GET diff.

The code is **safe to merge** (dry-run default), but it should not be called "done" until one real write lands. The natural verification is the HEDI rel-5018 date fix — the operator's actual need — which both proves the PUT contract and fixes the real problem.

## Endpoints (discovered by read-only GET/OPTIONS probing — no live mutations)

| Op | Endpoint | Method |
|---|---|---|
| Read / Edit / Delete relationship | `/admin_contact_entity_relationship_row/{id}` | GET / PUT / DELETE |
| Create relationship | `/contact_joins` | POST (body inferred) |

Raw row: `{id, id_contact, id_entity, role, time_from, time_to}` — structurally identical to an entity_connection. Mirrors the `admin_*_row` family (`admin_entity_connection_row`, `admin_entity_row`).

## Surface

**Writer** (`tos_writer.py`): `get_contact_relationship`, `patch_contact_relationship` (GET-merge-PUT), `create_contact_relationship`, `delete_contact_relationship`. Dry-run respected.

**ACTION verbs** (triage-file form — git provenance trail):
```
ACTION <id_entity> patch-contact-relationship <id_rel> <field> <value>   # field ∈ {time_from,time_to,role}
ACTION <id_entity> assign-contact <id_contact> <role> <time_from>
ACTION <id_entity> delete-contact-relationship <id_rel>
```
`id_entity` slot = the station, so `start` resolves against its earliest_known. The migration-date fix is literally `patch-contact-relationship <id_rel> time_from start` → resolves to 2006-06-29 (HEDI founding).

**Standalone verbs** (dry-run default, `--no-dry-run` commits):
```
tos contact patch-relationship <id_rel> --time-from DATE [--time-to] [--role]
tos contact assign --station S --contact <id> --role R --from DATE
tos contact remove <id_rel>
```

## Tests (27 new)
- 8 writer: GET-merge-PUT preserves untouched fields, role-only edit, dry-run holds PUT, POST body shape, DELETE endpoint, missing-row raises
- 12 ACTION dispatcher: happy paths, `start` resolves against station, field whitelist, placeholder/non-int rejection, writer-exception-as-failed
- 7 standalone CLI: dry-run default, --no-dry-run commits, --json, assign station-resolution, unresolvable-station exit 1

966 tests pass, ruff + black clean.

## Test plan
- [x] `pytest tests/` — 966 passed
- [x] `ruff` + `black` clean
- [x] Live dry-run smoke test (patch / assign / remove + ACTION forms) on HEDI rel 5018
- [ ] **Live write unverified** — HEDI rel-5018 date fix with re-GET diff (operator-authorized; the verification + the real fix in one)

## Follow-ups
- `tos audit contact-dates` — fleet-wide migration-artifact audit (probe the date signature first)
- Contact-entity writes via `PUT /contact/{id}/` — fleet-global blast radius, deferred

🤖 Generated with [Claude Code](https://claude.com/claude-code)