### PR TITLE
feat(tos): tos audit contact-dates — migration-artifact relationship audit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -484,9 +484,24 @@ time_from start`.
 
 `patch_contact_relationship` GET-merges-PUTs (the admin endpoint is
 PUT-replace): reads the current row, overlays the changed field, writes
-the full row back. Follow-ups (not built): `tos audit contact-dates`
-fleet-wide migration-artifact audit; contact-entity edits via
-`PUT /contact/{id}/` (fleet-global blast radius, deferred).
+the full row back. All three relationship write paths (PUT/POST/DELETE)
+are live-verified against production TOS.
+
+**`tos audit contact-dates <STN>`** — flags relationships whose
+`per_time_from` is a TOS-migration artifact. The signal is a
+**non-midnight time-of-day** (genuine ownership-start dates are at
+`T00:00:00`; migration bulk-loads carry a real clock time, identical
+within each batch — e.g. 26 relationships all at `2025-02-04T15:32:38`).
+`--triage` emits commented `#ACTION <station>
+patch-contact-relationship <id_rel> time_from start` lines (backdate to
+the station's earliest_known). SUPPRESS file
+`data/audit_suppressions/contact_dates.txt` (key `SUPPRESS
+<id_relationship>`). Standalone cleanup audit — migration artifacts are
+a one-time fixup, so it's not in the recurring verify oracle.
+
+Follow-up (not built): contact-ENTITY edits via `PUT /contact/{id}/`
+(name/phone/address — fleet-global blast radius, deferred) and creating
+new contact entities via `POST /contacts`.
 
 ## Architecture
 

--- a/docs/architecture/contact-write-api.md
+++ b/docs/architecture/contact-write-api.md
@@ -164,23 +164,39 @@ tos contact remove <id_rel> [--no-dry-run]
 Dry-run default + `--no-dry-run` to commit, matching `tos device add`
 / `tos visit add`. `--json` on all three.
 
-## Phase 4 — audit (migration-artifact pattern, NOT YET BUILT)
-
-Operator confirmed the `per_time_from` migration-date is wrong
-fleet-wide. Parallel to `tos audit attribute-dates`:
+## Phase 4 — `tos audit contact-dates` (SHIPPED)
 
 ```
-tos audit contact-dates <STN>   # flag per_time_from == <migration date pattern>
+tos audit contact-dates <STN> [--triage path.txt] [--no-suppressions] [--json]
 ```
 
-First task here: characterise the artifact. Is every contact
-relationship's `per_time_from` clustered around a single migration
-date (like 2014-10-17 for attributes), or a date range? Probe
-`entity_contacts/` across the fleet to find the signature, then the
-audit flags + the triage emitter suggests backdating to the station's
-`earliest_known` (the same anchor `start` resolves to elsewhere). The
-emitter would write `#ACTION <station> patch-contact-relationship
-<id_rel> time_from start` lines.
+**Artifact signature** (fleet probe 2026-05-31, 77 relationships across
+71 stations): migration bulk-loads cluster on a few instants, each
+shared *identically* across the batch —
+`2025-02-04T15:32:38 ×26`, `2025-02-05T11:19:42 ×8`,
+`2025-09-12T09:41:14 ×4`. The discriminator is **a non-midnight
+time-of-day**: genuine ownership-start dates are recorded at
+`T00:00:00` (33 of 38 real-date relationships in the probe); the
+bulk-loads all carry a real clock time. So the rule —
+
+> flag a relationship whose `per_time_from` has a non-midnight time
+> component —
+
+auto-catches every migration batch without a hardcoded date list, and
+is robust to future loads. False positives (a genuine relationship
+with a clock time) go in the SUPPRESS file
+(`data/audit_suppressions/contact_dates.txt`, key `SUPPRESS
+<id_relationship>`); every emitted ACTION is commented for review.
+
+Module `src/tostools/audit_contact_dates.py` mirrors
+`audit_visit_coverage` (report dataclass + suppression loader +
+`format_triage_file`). The triage emitter writes
+`#ACTION <station> patch-contact-relationship <id_rel> time_from start`
+per violation — `start` resolves at apply time to the station's
+earliest_known (founding date for VÍ-owned sites). Standalone cleanup
+audit (not in the recurring verify oracle — migration artifacts are a
+one-time fixup, not ongoing drift). Pinned by
+`tests/test_audit_contact_dates.py`.
 
 ## Phase 5 — contact-entity writes (NOT YET BUILT)
 

--- a/src/tostools/audit_contact_dates.py
+++ b/src/tostools/audit_contact_dates.py
@@ -1,0 +1,383 @@
+"""Flag contact↔station relationships with a migration-artifact date.
+
+When TOS contacts were bulk-loaded into the new system, each
+contact↔station relationship row got a ``time_from`` set to the
+*moment of the load*, not the date the contact actually started
+owning/operating the station. Fleet probe (2026-05-31) found these
+cluster on a handful of bulk-load instants, each shared identically
+across dozens of relationships:
+
+    2025-02-04T15:32:38  ×26    2025-02-05T11:19:42  ×8
+    2025-09-12T09:41:14  ×4
+
+The tell-tale signal: a **non-midnight time-of-day**. Genuine
+ownership-start dates are recorded at ``T00:00:00`` (33 of 38 real-date
+relationships in the probe); the migration bulk-loads all carry a real
+clock time (and within a batch, the *identical* instant — 26
+relationships cannot independently start at exactly 15:32:38).
+
+So the audit rule is::
+
+    Flag a relationship whose per_time_from has a non-midnight time
+    component (the HH:MM:SS part is not 00:00:00).
+
+This auto-catches every migration batch without a hardcoded date list,
+and is robust to future bulk loads. False positives (a genuine
+relationship that happens to carry a clock time) are handled by the
+SUPPRESS file + the fact that every emitted ACTION is commented for
+operator review.
+
+The suggested fix backdates ``time_from`` to the station's
+``earliest_known`` (the ``start`` token, resolved at apply time) —
+same anchor the attribute / visit audits use. For VÍ-owned sites
+that's effectively the station founding date.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from .api.tos_client import TOSClient
+from .audit import _resolve_station_entity
+from .audit_attribute_dates import (
+    SuppressionParseError,
+    _station_display_name,
+)
+
+# id_contact_entity_relationship is globally unique, so the suppression
+# key is a 1-tuple (just the relationship id) — no date anchor needed.
+ContactDateSuppressionKey = int
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+DEFAULT_CONTACT_DATES_SUPPRESSIONS_PATH = (
+    _REPO_ROOT / "data" / "audit_suppressions" / "contact_dates.txt"
+)
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ContactDateViolation:
+    """One contact↔station relationship with a migration-artifact date.
+
+    Carries enough context for triage emission + a readable report:
+    ``id_relationship`` is the ``id_contact_entity_relationship`` the
+    ACTION targets, ``per_time_from`` is the suspect timestamp,
+    ``contact_label`` is the contact's name/organization, ``role`` is
+    its role on the station.
+    """
+
+    id_relationship: int
+    id_contact: Optional[int]
+    contact_label: Optional[str]
+    role: Optional[str]
+    per_time_from: str
+
+
+@dataclass(frozen=True)
+class SuppressedContactDate:
+    """A contact-date hit that was filtered by the suppression file."""
+
+    violation: ContactDateViolation
+    suppressions_path: Path
+    line_no: int
+
+
+@dataclass
+class StationContactDatesReport:
+    """Result of :func:`audit_station_contact_dates`."""
+
+    station_id: int
+    station_name: Optional[str]
+    audited_relationships: int = 0
+    violations: List[ContactDateViolation] = field(default_factory=list)
+    suppressed: List[SuppressedContactDate] = field(default_factory=list)
+    suppressions_path: Optional[Path] = None
+    suppressions_errors: List[SuppressionParseError] = field(default_factory=list)
+    suppressions_disabled: bool = False
+
+    @property
+    def has_violations(self) -> bool:
+        return bool(self.violations)
+
+    @property
+    def suppressed_count(self) -> int:
+        return len(self.suppressed)
+
+
+# ---------------------------------------------------------------------------
+# Suppression file (SUPPRESS <id_relationship>)
+# ---------------------------------------------------------------------------
+
+
+def load_contact_dates_suppressions(
+    path: Optional[Path] = None,
+) -> Tuple[Dict[ContactDateSuppressionKey, int], List[SuppressionParseError], Path]:
+    """Parse a SUPPRESS-style file for the contact-dates audit.
+
+    Format: one ``SUPPRESS <id_relationship>`` per known-good
+    relationship (a genuine non-midnight date the operator confirms is
+    correct). Comments start with ``#``, blank lines ignored.
+
+    Returns ``(suppressions, errors, resolved_path)``. File-not-found
+    is silent — the suppression file is opt-in.
+    """
+    if path is None:
+        path = DEFAULT_CONTACT_DATES_SUPPRESSIONS_PATH
+
+    suppressions: Dict[ContactDateSuppressionKey, int] = {}
+    errors: List[SuppressionParseError] = []
+
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return suppressions, errors, path
+
+    for i, line in enumerate(text.splitlines(), 1):
+        raw = line
+        if "#" in line:
+            line = line.split("#", 1)[0]
+        line = line.strip()
+        if not line:
+            continue
+
+        tokens = line.split()
+        if tokens[0] != "SUPPRESS":
+            errors.append(
+                SuppressionParseError(
+                    line_no=i,
+                    message=f"expected line to start with 'SUPPRESS' (got {tokens[0]!r})",
+                    raw=raw,
+                )
+            )
+            continue
+        if len(tokens) < 2:
+            errors.append(
+                SuppressionParseError(
+                    line_no=i,
+                    message="SUPPRESS line requires 1 argument: <id_relationship>",
+                    raw=raw,
+                )
+            )
+            continue
+        try:
+            id_relationship = int(tokens[1])
+        except ValueError:
+            errors.append(
+                SuppressionParseError(
+                    line_no=i,
+                    message=f"id_relationship must be an integer (got {tokens[1]!r})",
+                    raw=raw,
+                )
+            )
+            continue
+        suppressions[id_relationship] = i
+
+    return suppressions, errors, path
+
+
+# ---------------------------------------------------------------------------
+# Migration-artifact detection
+# ---------------------------------------------------------------------------
+
+
+def _is_migration_artifact(per_time_from: Optional[str]) -> bool:
+    """True iff the timestamp carries a non-midnight time-of-day.
+
+    Genuine ownership-start dates are recorded at ``T00:00:00``; TOS
+    migration bulk-loads carry a real clock time (and an identical
+    instant per batch). A non-midnight time component is the signal.
+
+    Empty / malformed / date-only timestamps are NOT flagged (no time
+    component to be suspicious of).
+    """
+    if not per_time_from or "T" not in per_time_from:
+        return False
+    time_part = per_time_from.split("T", 1)[1][:8]
+    if len(time_part) < 8:
+        return False
+    return time_part != "00:00:00"
+
+
+# ---------------------------------------------------------------------------
+# Main audit entry point
+# ---------------------------------------------------------------------------
+
+
+def audit_station_contact_dates(
+    client: TOSClient,
+    *,
+    name: Optional[str] = None,
+    id_entity: Optional[int] = None,
+    suppressions_path: Optional[Path] = None,
+    use_suppressions: bool = True,
+) -> StationContactDatesReport:
+    """Flag a station's contact relationships with migration-artifact dates.
+
+    Parameters
+    ----------
+    client
+        Unauthenticated :class:`TOSClient`. One HTTP:
+        ``get_contacts(station_id)`` for the relationship list.
+    name / id_entity
+        Station identifier — pass one or the other.
+    suppressions_path
+        Override the suppression file location.
+    use_suppressions
+        When False, skip the SUPPRESS file entirely.
+
+    Returns
+    -------
+    StationContactDatesReport
+
+    Raises
+    ------
+    LookupError
+        Station not found.
+    ValueError
+        Neither ``name`` nor ``id_entity`` set.
+    """
+    if use_suppressions:
+        suppressions, supp_errors, supp_path = load_contact_dates_suppressions(
+            suppressions_path
+        )
+    else:
+        suppressions = {}
+        supp_errors = []
+        supp_path = suppressions_path or DEFAULT_CONTACT_DATES_SUPPRESSIONS_PATH
+
+    station_history = _resolve_station_entity(client, name=name, id_entity=id_entity)
+    station_id = int(station_history["id_entity"])
+    station_name = _station_display_name(station_history, name)
+
+    report = StationContactDatesReport(
+        station_id=station_id,
+        station_name=station_name,
+        suppressions_path=supp_path,
+        suppressions_errors=supp_errors,
+        suppressions_disabled=not use_suppressions,
+    )
+
+    relationships = client.get_contacts(station_id) or []
+    for rel in relationships:
+        report.audited_relationships += 1
+        per_time_from = rel.get("per_time_from")
+        if not _is_migration_artifact(per_time_from):
+            continue
+
+        id_rel_raw = rel.get("id_contact_entity_relationship")
+        if id_rel_raw is None:
+            # Can't emit a patch without the relationship id — skip.
+            continue
+        try:
+            id_relationship = int(id_rel_raw)
+        except (TypeError, ValueError):
+            continue
+
+        violation = ContactDateViolation(
+            id_relationship=id_relationship,
+            id_contact=rel.get("id_contact"),
+            contact_label=rel.get("name") or rel.get("organization"),
+            role=rel.get("role"),
+            per_time_from=str(per_time_from),
+        )
+
+        supp_line = suppressions.get(id_relationship)
+        if supp_line is not None:
+            report.suppressed.append(
+                SuppressedContactDate(
+                    violation=violation,
+                    suppressions_path=supp_path,
+                    line_no=supp_line,
+                )
+            )
+        else:
+            report.violations.append(violation)
+
+    report.violations.sort(key=lambda v: v.id_relationship)
+    return report
+
+
+# ---------------------------------------------------------------------------
+# Triage emitter
+# ---------------------------------------------------------------------------
+
+
+def format_triage_file(
+    report: StationContactDatesReport,
+    *,
+    audit_command: Optional[str] = None,
+    generated_at: Optional[str] = None,
+) -> str:
+    """Render a contact-dates report as an operator-editable action file.
+
+    Each violation becomes a commented ``#ACTION <station_id>
+    patch-contact-relationship <id_rel> time_from start`` line. The
+    ``start`` token resolves at apply time to the station's
+    earliest_known (the founding date for VÍ-owned sites). Operator
+    reviews, uncomments, and feeds the file into ``tos audit apply``.
+    """
+    if generated_at is None:
+        generated_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+    lines: List[str] = []
+    station_label = report.station_name or "<unknown>"
+    lines.append("# === tos audit contact-dates — triage action file ===")
+    lines.append(f"# Generated:  {generated_at}")
+    lines.append(f"# Station:    {station_label!r} (id_entity={report.station_id})")
+    if audit_command:
+        lines.append(f"# Audit cmd:  {audit_command}")
+    lines.append(f"# Relationships: {report.audited_relationships} audited")
+    lines.append(f"# Violations:    {len(report.violations)}")
+    lines.append("#")
+    lines.append("# Each flagged relationship has a non-midnight per_time_from — a")
+    lines.append(
+        "# TOS-migration bulk-load timestamp, not a real ownership-start date."
+    )
+    lines.append("#")
+    lines.append(
+        "#   ACTION <station_id> patch-contact-relationship <id_rel> time_from start"
+    )
+    lines.append("#")
+    lines.append("# `start` resolves at apply time to the station's earliest_known")
+    lines.append("# (founding date for VÍ-owned sites). Edit to a specific date if a")
+    lines.append("# contact genuinely started later than founding.")
+    lines.append("#")
+    lines.append("# Workflow:")
+    lines.append("#   1. Review each line. Uncomment the ones to fix.")
+    lines.append("#   2. tos audit apply <file>          # dry-run preview")
+    lines.append("#   3. tos audit apply <file> --apply  # commit writes")
+    lines.append("#")
+    lines.append("# Genuine non-midnight dates: copy the SUPPRESS hint into")
+    lines.append("# data/audit_suppressions/contact_dates.txt instead.")
+    lines.append("")
+
+    if not report.violations:
+        lines.append("# (no violations — nothing to triage)")
+        lines.append("")
+        return "\n".join(lines)
+
+    for v in report.violations:
+        label = f" {v.contact_label!r}" if v.contact_label else ""
+        role = f" role={v.role}" if v.role else ""
+        lines.append(
+            f"# rel {v.id_relationship} — contact {v.id_contact}{label}{role}"
+            f"  (per_time_from={v.per_time_from})"
+        )
+        lines.append(
+            f"#ACTION {report.station_id} patch-contact-relationship "
+            f"{v.id_relationship} time_from start"
+        )
+        lines.append(
+            f"#   SUPPRESS {v.id_relationship}"
+            "  # copy to data/audit_suppressions/contact_dates.txt"
+        )
+        lines.append("")
+
+    return "\n".join(lines)

--- a/src/tostools/tos.py
+++ b/src/tostools/tos.py
@@ -4977,6 +4977,10 @@ def _audit_main(argv):
             "  tos audit visit-coverage HAUC --triage hauc_cov.txt  # emit add-visit ACTIONs\n"
             "  tos audit visit-coverage HAUC --no-suppressions      # bypass SUPPRESS file\n"
             "\n"
+            "  # ---- Contact dates (migration-artifact per_time_from) ----\n"
+            "  tos audit contact-dates RHOF                         # flag non-midnight relationship dates\n"
+            "  tos audit contact-dates RHOF --triage rhof_cts.txt   # emit patch-contact-relationship ACTIONs\n"
+            "\n"
             "  # ---- Apply triage files (writes; needs credentials) -----\n"
             "  tos audit apply trial.txt                            # dry-run preview (default)\n"
             "  tos audit apply trial.txt --apply                    # commit writes\n"
@@ -5735,6 +5739,80 @@ def _audit_main(argv):
     )
     p_coverage.add_argument("--port", type=int, default=443)
 
+    p_contact_dates = sub.add_parser(
+        "contact-dates",
+        help=(
+            "Flag contact↔station relationships with a TOS-migration "
+            "date (non-midnight per_time_from)."
+        ),
+        description=(
+            "When TOS contacts were bulk-loaded into the new system, "
+            "each contact↔station relationship got a time_from set to "
+            "the moment of the load, not the real ownership-start date. "
+            "The signal: a non-midnight time-of-day (genuine dates are "
+            "recorded at T00:00:00; migration bulk-loads carry a real "
+            "clock time, identical within each batch — e.g. 26 "
+            "relationships all at 2025-02-04T15:32:38).\n\n"
+            "Flags every relationship whose per_time_from has a "
+            "non-midnight time component. Use --triage to emit "
+            "patch-contact-relationship ACTIONs that backdate each to "
+            "the station's earliest_known (the `start` token)."
+        ),
+        epilog=(
+            "Examples:\n"
+            "  tos audit contact-dates RHOF\n"
+            "  tos audit contact-dates RHOF --triage rhof_contacts.txt\n"
+            "  tos audit contact-dates RHOF --no-suppressions --json\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p_contact_dates.add_argument(
+        "name", nargs="?", help="Station marker (e.g. RHOF) or display name."
+    )
+    p_contact_dates.add_argument(
+        "--id", dest="id_entity", type=int, help="Station id_entity."
+    )
+    p_contact_dates.add_argument(
+        "--suppressions",
+        type=Path,
+        default=None,
+        help=(
+            "Override the suppression file path. Defaults to "
+            "data/audit_suppressions/contact_dates.txt. File-not-found "
+            "is silent (the file is opt-in)."
+        ),
+    )
+    p_contact_dates.add_argument(
+        "--no-suppressions",
+        action="store_true",
+        help="Bypass the suppression file entirely.",
+    )
+    p_contact_dates.add_argument(
+        "--triage",
+        dest="triage_path",
+        type=Path,
+        default=None,
+        help=(
+            "Emit a draft ACTION file at this path. One commented "
+            "`ACTION <station> patch-contact-relationship <id_rel> "
+            "time_from start` line per violation."
+        ),
+    )
+    p_contact_dates.add_argument(
+        "--json", action="store_true", help="Emit JSON instead of plain text."
+    )
+    p_contact_dates.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Show suppressed entries with file:lineno references.",
+    )
+    p_contact_dates.add_argument(
+        "--server",
+        default="vi-api.vedur.is",
+        help="TOS API host (default: vi-api.vedur.is).",
+    )
+    p_contact_dates.add_argument("--port", type=int, default=443)
+
     p_verify = sub.add_parser(
         "verify-from-rinex",
         help=(
@@ -6124,6 +6202,49 @@ def _audit_main(argv):
             )
         else:
             _print_visit_coverage_report(report, verbose=args.verbose)
+        return 1 if report.has_violations else 0
+
+    if args.kind == "contact-dates":
+        from . import audit_contact_dates as acd_mod
+
+        try:
+            report = acd_mod.audit_station_contact_dates(
+                client,
+                name=args.name,
+                id_entity=args.id_entity,
+                suppressions_path=args.suppressions,
+                use_suppressions=not args.no_suppressions,
+            )
+        except (LookupError, ValueError) as e:
+            print(str(e), file=sys.stderr)
+            return 2
+        if report.suppressions_errors:
+            print(
+                f"warning: {len(report.suppressions_errors)} malformed line(s) "
+                f"in {report.suppressions_path}:",
+                file=sys.stderr,
+            )
+            for err in report.suppressions_errors:
+                print(f"  line {err.line_no}: {err.message}", file=sys.stderr)
+        if args.triage_path:
+            audit_cmd = "tos audit " + " ".join(argv) if argv else "tos audit"
+            content = acd_mod.format_triage_file(report, audit_command=audit_cmd)
+            args.triage_path.write_text(content, encoding="utf-8")
+            print(
+                f"wrote triage file: {args.triage_path} "
+                f"({len(report.violations)} violation(s))",
+                file=sys.stderr,
+            )
+        if args.json:
+            print(
+                _json.dumps(
+                    _contact_dates_report_to_dict(report),
+                    ensure_ascii=False,
+                    indent=2,
+                )
+            )
+        else:
+            _print_contact_dates_report(report, verbose=args.verbose)
         return 1 if report.has_violations else 0
 
     if args.kind == "verify-from-rinex":
@@ -8645,6 +8766,80 @@ def _print_visit_coverage_report(report, *, verbose: bool = False):
                     f"      · {v.event_date} "
                     f"(suppressed at {s.suppressions_path}:{s.line_no})"
                 )
+
+
+def _contact_dates_report_to_dict(report):
+    """Convert a :class:`StationContactDatesReport` to JSON-serialisable dict."""
+
+    def _violation_dict(v):
+        return {
+            "id_relationship": v.id_relationship,
+            "id_contact": v.id_contact,
+            "contact_label": v.contact_label,
+            "role": v.role,
+            "per_time_from": v.per_time_from,
+        }
+
+    return {
+        "kind": "contact-dates",
+        "station_id": report.station_id,
+        "station_name": report.station_name,
+        "audited_relationships": report.audited_relationships,
+        "violations": [_violation_dict(v) for v in report.violations],
+        "suppressed": [
+            {
+                **_violation_dict(s.violation),
+                "suppressions_path": str(s.suppressions_path),
+                "line_no": s.line_no,
+            }
+            for s in report.suppressed
+        ],
+        "suppressions_path": (
+            str(report.suppressions_path) if report.suppressions_path else None
+        ),
+        "suppressions_disabled": report.suppressions_disabled,
+        "suppressions_errors": [
+            {"line_no": e.line_no, "message": e.message, "raw": e.raw}
+            for e in report.suppressions_errors
+        ],
+    }
+
+
+def _print_contact_dates_report(report, *, verbose: bool = False):
+    """Render a contact-dates audit report as plain text on stdout."""
+    status = "CLEAN" if not report.has_violations else "VIOLATIONS"
+    marker = "✓" if not report.has_violations else "✗"
+    name = report.station_name or "?"
+    print(f"{marker} Station {name!r} (id_entity={report.station_id}) — {status}")
+    print(f"  relationships audited: {report.audited_relationships}")
+    if report.suppressed_count:
+        print(
+            f"  suppressed: {report.suppressed_count} entry(ies) via "
+            f"{report.suppressions_path}"
+        )
+    elif report.suppressions_disabled:
+        print("  suppressions: disabled (--no-suppressions)")
+
+    if report.violations:
+        print()
+        print(f"  migration-artifact dates ({len(report.violations)}):")
+        for v in report.violations:
+            label = f" {v.contact_label!r}" if v.contact_label else ""
+            role = f" role={v.role}" if v.role else ""
+            print(f"    rel {v.id_relationship} — contact {v.id_contact}{label}{role}")
+            print(f"      · per_time_from = {v.per_time_from}  → backdate to `start`")
+            if verbose:
+                print(f"        suppress: SUPPRESS {v.id_relationship}")
+
+    if verbose and report.suppressed:
+        print()
+        print(f"  suppressed ({len(report.suppressed)} silenced entry(ies)):")
+        for s in report.suppressed:
+            v = s.violation
+            print(
+                f"    rel {v.id_relationship} (per_time_from={v.per_time_from}) "
+                f"— suppressed at {s.suppressions_path}:{s.line_no}"
+            )
 
 
 def _station_report_to_dict(report):

--- a/tests/test_audit_contact_dates.py
+++ b/tests/test_audit_contact_dates.py
@@ -1,0 +1,310 @@
+"""Tests for :mod:`tostools.audit_contact_dates`.
+
+Pins:
+  * the migration-artifact rule (non-midnight per_time_from)
+  * SUPPRESS filtering (1-tuple key: id_relationship)
+  * triage emitter shape (patch-contact-relationship ... time_from start)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from tostools.api.tos_client import TOSClient
+from tostools.audit_contact_dates import (
+    StationContactDatesReport,
+    _is_migration_artifact,
+    audit_station_contact_dates,
+    format_triage_file,
+    load_contact_dates_suppressions,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _station(station_id=4390, name="Raufarhöfn"):
+    return {
+        "id_entity": station_id,
+        "code_entity_subtype": "geophysical",
+        "attributes": [
+            {
+                "code": "marker",
+                "value": "RHOF",
+                "date_to": None,
+                "date_from": "2002-01-01",
+            },
+            {"code": "name", "value": name, "date_to": None, "date_from": "2002-01-01"},
+        ],
+    }
+
+
+def _rel(
+    id_rel, per_time_from, *, id_contact=1256, name="Veðurstofa Íslands", role="owner"
+):
+    """A joined contact-relationship row (entity_contacts/{id}/ shape)."""
+    return {
+        "id_contact_entity_relationship": id_rel,
+        "id_contact": id_contact,
+        "name": name,
+        "organization": name,
+        "role": role,
+        "per_time_from": per_time_from,
+        "per_time_to": None,
+    }
+
+
+def _resolver():
+    """Patch the marker→entity resolution to return our station fixture."""
+    return patch.object(
+        TOSClient,
+        "basic_search",
+        return_value=[
+            {
+                "code": "marker",
+                "distance": 0,
+                "value_varchar": "rhof",
+                "type_lvl_two": "stöð",
+                "id_entity": 4390,
+            }
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# _is_migration_artifact — the core rule
+# ---------------------------------------------------------------------------
+
+
+def test_is_migration_artifact_non_midnight_true():
+    assert _is_migration_artifact("2025-02-04T15:32:38") is True
+    assert _is_migration_artifact("2024-11-07T13:19:27") is True
+
+
+def test_is_migration_artifact_midnight_false():
+    assert _is_migration_artifact("2006-06-29T00:00:00") is False
+
+
+def test_is_migration_artifact_handles_empty_and_dateonly():
+    assert _is_migration_artifact(None) is False
+    assert _is_migration_artifact("") is False
+    assert _is_migration_artifact("2006-06-29") is False  # no T / time component
+
+
+# ---------------------------------------------------------------------------
+# audit_station_contact_dates — rule + suppression
+# ---------------------------------------------------------------------------
+
+
+def test_audit_flags_non_midnight_relationships():
+    contacts = [
+        _rel(4961, "2024-08-14T09:30:16", role="operator"),
+        _rel(
+            4987,
+            "2024-11-07T13:19:27",
+            id_contact=2483,
+            name="Benedikt G. Ófeigsson",
+            role="operator",
+        ),
+        _rel(5000, "2002-01-01T00:00:00"),  # midnight — genuine, not flagged
+    ]
+    with (
+        _resolver(),
+        patch.object(TOSClient, "get_entity_history", return_value=_station()),
+        patch.object(TOSClient, "get_contacts", return_value=contacts),
+    ):
+        report = audit_station_contact_dates(TOSClient(), name="RHOF")
+
+    assert report.audited_relationships == 3
+    assert [v.id_relationship for v in report.violations] == [4961, 4987]
+    v = report.violations[0]
+    assert v.per_time_from == "2024-08-14T09:30:16"
+    assert v.role == "operator"
+    assert v.contact_label == "Veðurstofa Íslands"
+
+
+def test_audit_clean_when_all_midnight():
+    contacts = [_rel(5000, "2006-06-29T00:00:00")]
+    with (
+        _resolver(),
+        patch.object(TOSClient, "get_entity_history", return_value=_station()),
+        patch.object(TOSClient, "get_contacts", return_value=contacts),
+    ):
+        report = audit_station_contact_dates(TOSClient(), name="RHOF")
+    assert report.audited_relationships == 1
+    assert report.violations == []
+    assert report.has_violations is False
+
+
+def test_audit_skips_relationship_without_id():
+    """A row missing id_contact_entity_relationship can't be patched → skipped."""
+    contacts = [{"per_time_from": "2025-02-04T15:32:38", "id_contact": 1}]  # no id_rel
+    with (
+        _resolver(),
+        patch.object(TOSClient, "get_entity_history", return_value=_station()),
+        patch.object(TOSClient, "get_contacts", return_value=contacts),
+    ):
+        report = audit_station_contact_dates(TOSClient(), name="RHOF")
+    assert report.violations == []
+
+
+def test_audit_suppression_silences_relationship(tmp_path: Path):
+    supp = tmp_path / "contact_dates.txt"
+    supp.write_text("SUPPRESS 4961\n")
+    contacts = [
+        _rel(4961, "2024-08-14T09:30:16"),
+        _rel(4987, "2024-11-07T13:19:27"),
+    ]
+    with (
+        _resolver(),
+        patch.object(TOSClient, "get_entity_history", return_value=_station()),
+        patch.object(TOSClient, "get_contacts", return_value=contacts),
+    ):
+        report = audit_station_contact_dates(
+            TOSClient(), name="RHOF", suppressions_path=supp
+        )
+    assert [v.id_relationship for v in report.violations] == [4987]
+    assert len(report.suppressed) == 1
+    assert report.suppressed[0].violation.id_relationship == 4961
+    assert report.suppressed[0].line_no == 1
+
+
+# ---------------------------------------------------------------------------
+# load_contact_dates_suppressions
+# ---------------------------------------------------------------------------
+
+
+def test_load_suppressions_parses_and_collects_errors(tmp_path: Path):
+    p = tmp_path / "s.txt"
+    p.write_text(
+        "# header\n"
+        "SUPPRESS 4961\n"
+        "SUPPRESS 4987  # genuine 2024 assignment\n"
+        "NOTSUPPRESS 1\n"
+        "SUPPRESS notanint\n"
+        "SUPPRESS\n"
+    )
+    out, errs, path = load_contact_dates_suppressions(p)
+    assert out == {4961: 2, 4987: 3}
+    assert len(errs) == 3
+
+
+def test_load_suppressions_missing_file_silent(tmp_path: Path):
+    out, errs, _ = load_contact_dates_suppressions(tmp_path / "nope.txt")
+    assert out == {}
+    assert errs == []
+
+
+# ---------------------------------------------------------------------------
+# format_triage_file
+# ---------------------------------------------------------------------------
+
+
+def test_format_triage_emits_patch_relationship_actions():
+    report = StationContactDatesReport(
+        station_id=4390,
+        station_name="Raufarhöfn",
+        audited_relationships=3,
+    )
+    from tostools.audit_contact_dates import ContactDateViolation
+
+    report.violations = [
+        ContactDateViolation(
+            id_relationship=4961,
+            id_contact=1256,
+            contact_label="Veðurstofa Íslands",
+            role="operator",
+            per_time_from="2024-08-14T09:30:16",
+        ),
+    ]
+    out = format_triage_file(report, generated_at="2026-05-31T12:00:00+00:00")
+
+    assert "Raufarhöfn" in out
+    assert "id_entity=4390" in out
+    # Commented ACTION targeting the STATION id, backdating via `start`.
+    assert "#ACTION 4390 patch-contact-relationship 4961 time_from start" in out
+    assert "#   SUPPRESS 4961" in out
+    # Context comment carries the suspect timestamp + contact label.
+    assert "2024-08-14T09:30:16" in out
+    assert "Veðurstofa Íslands" in out
+
+
+def test_format_triage_no_violations_placeholder():
+    report = StationContactDatesReport(
+        station_id=4390, station_name="RHOF", audited_relationships=1
+    )
+    out = format_triage_file(report, generated_at="2026-05-31T12:00:00+00:00")
+    assert "no violations" in out
+    assert "#ACTION" not in out
+
+
+# ---------------------------------------------------------------------------
+# CLI verb — _audit_main dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_cli_contact_dates_exit_codes(capsys):
+    from tostools.tos import main as tos_main
+
+    contacts = [_rel(4961, "2024-08-14T09:30:16")]
+    with (
+        _resolver(),
+        patch.object(TOSClient, "get_entity_history", return_value=_station()),
+        patch.object(TOSClient, "get_contacts", return_value=contacts),
+    ):
+        rc = tos_main(["audit", "contact-dates", "RHOF"])
+    assert rc == 1  # has violations
+    out = capsys.readouterr().out
+    assert "VIOLATIONS" in out
+    assert "4961" in out
+
+
+def test_cli_contact_dates_clean_exit_0(capsys):
+    from tostools.tos import main as tos_main
+
+    contacts = [_rel(5000, "2002-01-01T00:00:00")]
+    with (
+        _resolver(),
+        patch.object(TOSClient, "get_entity_history", return_value=_station()),
+        patch.object(TOSClient, "get_contacts", return_value=contacts),
+    ):
+        rc = tos_main(["audit", "contact-dates", "RHOF"])
+    assert rc == 0
+
+
+def test_cli_contact_dates_json(capsys):
+    import json
+
+    from tostools.tos import main as tos_main
+
+    contacts = [_rel(4961, "2024-08-14T09:30:16")]
+    with (
+        _resolver(),
+        patch.object(TOSClient, "get_entity_history", return_value=_station()),
+        patch.object(TOSClient, "get_contacts", return_value=contacts),
+    ):
+        rc = tos_main(["audit", "contact-dates", "RHOF", "--json"])
+    assert rc == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["kind"] == "contact-dates"
+    assert payload["station_id"] == 4390
+    assert payload["violations"][0]["id_relationship"] == 4961
+    assert payload["violations"][0]["per_time_from"] == "2024-08-14T09:30:16"
+
+
+def test_cli_contact_dates_triage_file(tmp_path: Path, capsys):
+    from tostools.tos import main as tos_main
+
+    out_path = tmp_path / "rhof_cts.txt"
+    contacts = [_rel(4961, "2024-08-14T09:30:16")]
+    with (
+        _resolver(),
+        patch.object(TOSClient, "get_entity_history", return_value=_station()),
+        patch.object(TOSClient, "get_contacts", return_value=contacts),
+    ):
+        rc = tos_main(["audit", "contact-dates", "RHOF", "--triage", str(out_path)])
+    assert rc == 1
+    content = out_path.read_text()
+    assert "#ACTION 4390 patch-contact-relationship 4961 time_from start" in content


### PR DESCRIPTION
Completes the contact-write follow-up (Phase 4 of `contact-write-api.md`). Flags contact↔station relationships whose `per_time_from` is a TOS-migration bulk-load timestamp rather than a real ownership-start date — the fleet-wide version of the HEDI fix from PR #43.

## Artifact signature (fleet probe, 77 relationships / 71 stations)
Migration bulk-loads cluster on a few instants, each shared **identically** across the batch:

| timestamp | count |
|---|---|
| `2025-02-04T15:32:38` | 26 |
| `2025-02-05T11:19:42` | 8 |
| `2025-09-12T09:41:14` | 4 |

The discriminator is a **non-midnight time-of-day**: genuine ownership-start dates sit at `T00:00:00` (33 of 38 real-date relationships in the probe); the bulk-loads all carry a real clock time. So the rule —

> flag `per_time_from` whose `HH:MM:SS` ≠ `00:00:00`

— auto-catches every migration batch without a hardcoded date list, and is robust to future loads. (26 relationships can't independently start at exactly 15:32:38 — that's a bulk load.)

## Surface
```
tos audit contact-dates <STN> [--triage path.txt] [--no-suppressions] [--json] [--verbose]
```
- Triage emits `#ACTION <station> patch-contact-relationship <id_rel> time_from start` per violation — `start` resolves at apply time to the station's earliest_known (founding date for VÍ sites).
- SUPPRESS file `data/audit_suppressions/contact_dates.txt` (key `SUPPRESS <id_relationship>`) for genuine non-midnight dates.
- Exit 0 clean / 1 violations / 2 lookup error.
- **Standalone cleanup audit** — deliberately NOT wired into the verify oracle / fleet status. Migration artifacts are a one-time fixup, not ongoing drift (unlike visit-coverage), so it stays clean once swept.

Module `audit_contact_dates.py` mirrors `audit_visit_coverage` (report dataclass + suppression loader + `format_triage_file`).

## Tests (15 new)
Rule (`_is_migration_artifact` non-midnight/midnight/empty), audit flagging + suppression, triage emitter shape, CLI dispatch (exit codes, --json, --triage file).

981 tests pass, ruff + black clean.

## Live-validated
- RHOF flags 2 (`2024-08-14T09:30:16`, `2024-11-07T13:19:27`)
- HEDI now **clean** — its rel-5018 was fixed to `2006-06-29T00:00:00` in PR #43, confirming midnight is correctly NOT flagged (the fix + the audit agree)

## Note re your "add contact" question
This audit doesn't touch contact *creation*. We built relationship CRUD (assign existing contact, patch/remove relationship) but NOT creating a new contact *entity* (`POST /contacts`) — that's still deferred. Say the word and I'll add it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)