### PR TITLE
feat(tos): tos fleet contact-dates — fleet-wide migration-date sweep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -322,6 +322,7 @@ tos contact remove <id_rel>        # delete a relationship (dry-run default)
 tos audit apply <triage_file>      # dry-run; --apply to commit
 tos fleet status                   # bulk verify oracle (exit 0/1/2)
 tos fleet triage                   # generate per-station triage files
+tos fleet contact-dates --triage F # fleet-wide contact migration-date sweep
 ```
 
 Legacy flat-arg form (`tos RHOF`, `tos -s SERIAL`, `tos --fdsnxml/--sc3ml`)

--- a/data/triage/contact_dates_fleet_20260604.txt
+++ b/data/triage/contact_dates_fleet_20260604.txt
@@ -1,0 +1,278 @@
+# === tos fleet contact-dates — combined triage action file ===
+# Generated:  2026-06-04T07:55:16Z
+# Stations:   192 audited
+# Violations: 129 total
+#   HIGH (owner role, uncommented, ready to apply): 100
+#   LOW  (non-owner role, commented for review):    29
+#
+# Each line backdates time_from to `start` (the station's
+# earliest_known / founding date), resolved at apply time.
+#
+# Workflow:
+#   tos audit apply <file>          # dry-run preview
+#   tos audit apply <file> --apply  # commit writes
+
+# ── HIGH confidence: owner relationships (owner owned the station
+#    from founding, so `start` is the correct backdate) ──
+# ARHO rel 4991 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 4233 patch-contact-relationship 4991 time_from start
+# BALD rel 4994 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 4237 patch-contact-relationship 4994 time_from start
+# BAUG rel 4992 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 4438 patch-contact-relationship 4992 time_from start
+# BRTT rel 4993 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 16357 patch-contact-relationship 4993 time_from start
+# BUDH rel 4995 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 4272 patch-contact-relationship 4995 time_from start
+# DYNG rel 4996 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 4247 patch-contact-relationship 4996 time_from start
+# DYNY rel 4997 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 4278 patch-contact-relationship 4997 time_from start
+# ELEY rel 4998 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 20007 patch-contact-relationship 4998 time_from start
+# EYVI rel 4999 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 4284 patch-contact-relationship 4999 time_from start
+# FEDG rel 5001 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 4286 patch-contact-relationship 5001 time_from start
+# FEFC rel 5000 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 18402 patch-contact-relationship 5000 time_from start
+# FIM2 rel 4505 'Veðurstofa Íslands' role=owner  (per_time_from=2010-03-19T00:44:00)
+ACTION 4288 patch-contact-relationship 4505 time_from start
+# FITC rel 5002 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 4290 patch-contact-relationship 5002 time_from start
+# FTEY rel 5003 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 4294 patch-contact-relationship 5003 time_from start
+# GFEL rel 5004 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 4298 patch-contact-relationship 5004 time_from start
+# GIGO rel 5005 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 4249 patch-contact-relationship 5005 time_from start
+# GJOG rel 5006 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 16092 patch-contact-relationship 5006 time_from start
+# GLER rel 5007 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 4300 patch-contact-relationship 5007 time_from start
+# GMEY rel 5009 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 4302 patch-contact-relationship 5009 time_from start
+# GRAN rel 5008 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 4306 patch-contact-relationship 5008 time_from start
+# GRIV rel 5087 'Jarðvísindastofnun Háskóla Íslands' role=owner  (per_time_from=2025-02-05T11:19:42)
+ACTION 19943 patch-contact-relationship 5087 time_from start
+# GRIV rel 5132 'Veðurstofa Íslands' role=owner  (per_time_from=2025-09-08T13:40:51)
+ACTION 19943 patch-contact-relationship 5132 time_from start
+# GRVA rel 5010 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 4310 patch-contact-relationship 5010 time_from start
+# HAFC rel 5011 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 18408 patch-contact-relationship 5011 time_from start
+# HAHV rel 5012 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 4259 patch-contact-relationship 5012 time_from start
+# HERV rel 5016 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 18407 patch-contact-relationship 5016 time_from start
+# HESA rel 5017 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 4322 patch-contact-relationship 5017 time_from start
+# HLFJ rel 5020 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 4324 patch-contact-relationship 5020 time_from start
+# HLID rel 5019 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 4326 patch-contact-relationship 5019 time_from start
+# HOTJ rel 5021 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 4330 patch-contact-relationship 5021 time_from start
+# HRAC rel 5022 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 16096 patch-contact-relationship 5022 time_from start
+# HRIC rel 4532 'Veðurstofa Íslands' role=owner  (per_time_from=2023-06-27T10:07:47)
+ACTION 4442 patch-contact-relationship 4532 time_from start
+# HSKC rel 5013 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 19077 patch-contact-relationship 5013 time_from start
+# HVAS rel 5023 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 18405 patch-contact-relationship 5023 time_from start
+# HVEH rel 5025 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 18557 patch-contact-relationship 5025 time_from start
+# HVER rel 5024 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 4336 patch-contact-relationship 5024 time_from start
+# INSK rel 5026 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 4340 patch-contact-relationship 5026 time_from start
+# INTA rel 4986 'Veðurstofa Íslands' role=owner  (per_time_from=2024-11-07T12:20:27)
+ACTION 4342 patch-contact-relationship 4986 time_from start
+# KALF rel 5029 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 4348 patch-contact-relationship 5029 time_from start
+# KALT rel 4988 'Veðurstofa Íslands' role=owner  (per_time_from=2024-11-15T08:53:57)
+ACTION 4350 patch-contact-relationship 4988 time_from start
+# KASC rel 5027 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 19115 patch-contact-relationship 5027 time_from start
+# KAST rel 5028 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 20332 patch-contact-relationship 5028 time_from start
+# KEIC rel 4537 'Veðurstofa Íslands' role=owner  (per_time_from=2023-09-28T15:00:00)
+ACTION 19844 patch-contact-relationship 4537 time_from start
+# KIDJ rel 5030 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 4352 patch-contact-relationship 5030 time_from start
+# KLVC rel 5031 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 18410 patch-contact-relationship 5031 time_from start
+# KOSK rel 5032 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 4356 patch-contact-relationship 5032 time_from start
+# KRIV rel 5033 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 4378 patch-contact-relationship 5033 time_from start
+# KVEC rel 5034 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 4265 patch-contact-relationship 5034 time_from start
+# KVIS rel 5036 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 4262 patch-contact-relationship 5036 time_from start
+# KVSK rel 5035 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 4263 patch-contact-relationship 5035 time_from start
+# LANH rel 5038 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 4267 patch-contact-relationship 5038 time_from start
+# LFEL rel 5037 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 4359 patch-contact-relationship 5037 time_from start
+# MANA rel 5039 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 16094 patch-contact-relationship 5039 time_from start
+# MJSK rel 5040 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 4361 patch-contact-relationship 5040 time_from start
+# MOFC rel 5041 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 4446 patch-contact-relationship 5041 time_from start
+# MOHA rel 5042 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 4380 patch-contact-relationship 5042 time_from start
+# NAMC rel 5043 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 18401 patch-contact-relationship 5043 time_from start
+# NBIO rel 5045 'Jarðvísindastofnun Háskóla Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 19961 patch-contact-relationship 5045 time_from start
+# NBIO rel 5135 'Veðurstofa Íslands' role=owner  (per_time_from=2025-09-08T15:17:05)
+ACTION 19961 patch-contact-relationship 5135 time_from start
+# NORS rel 5046 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 4364 patch-contact-relationship 5046 time_from start
+# NVEL rel 5044 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 19109 patch-contact-relationship 5044 time_from start
+# NYLA rel 5047 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 4366 patch-contact-relationship 5047 time_from start
+# ODDF rel 5048 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 18400 patch-contact-relationship 5048 time_from start
+# OLKE rel 5086 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-05T11:19:42)
+ACTION 4370 patch-contact-relationship 5086 time_from start
+# ORFC rel 5049 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 20156 patch-contact-relationship 5049 time_from start
+# RIFC rel 5050 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 4448 patch-contact-relationship 5050 time_from start
+# ROTH rel 5051 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 16090 patch-contact-relationship 5051 time_from start
+# SARP rel 5053 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 4396 patch-contact-relationship 5053 time_from start
+# SAUD rel 5055 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 4398 patch-contact-relationship 5055 time_from start
+# SAUR rel 5054 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 4400 patch-contact-relationship 5054 time_from start
+# SAVI rel 5052 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
+ACTION 4440 patch-contact-relationship 5052 time_from start
+# SELF rel 5061 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-05T11:19:42)
+ACTION 4402 patch-contact-relationship 5061 time_from start
+# SENG rel 5119 'Veðurstofa Íslands' role=owner  (per_time_from=2025-08-19T13:21:44)
+ACTION 16818 patch-contact-relationship 5119 time_from start
+# SEY1 rel 5063 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-05T11:19:42)
+ACTION 18279 patch-contact-relationship 5063 time_from start
+# SEY2 rel 5064 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-05T11:19:42)
+ACTION 18280 patch-contact-relationship 5064 time_from start
+# SEY3 rel 5065 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-05T11:19:42)
+ACTION 18281 patch-contact-relationship 5065 time_from start
+# SEY4 rel 5066 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-05T11:19:42)
+ACTION 19081 patch-contact-relationship 5066 time_from start
+# SEY5 rel 5067 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-05T11:19:42)
+ACTION 19082 patch-contact-relationship 5067 time_from start
+# SEY6 rel 5068 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-05T11:19:42)
+ACTION 19106 patch-contact-relationship 5068 time_from start
+# SEY7 rel 5069 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-05T11:19:42)
+ACTION 19083 patch-contact-relationship 5069 time_from start
+# SEY8 rel 5070 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-05T11:19:42)
+ACTION 19084 patch-contact-relationship 5070 time_from start
+# SEY9 rel 5071 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-05T11:19:42)
+ACTION 19085 patch-contact-relationship 5071 time_from start
+# SEYD rel 5062 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-05T11:19:42)
+ACTION 18277 patch-contact-relationship 5062 time_from start
+# SIFJ rel 5072 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-05T11:19:42)
+ACTION 4404 patch-contact-relationship 5072 time_from start
+# SJUK rel 5073 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-05T11:19:42)
+ACTION 4406 patch-contact-relationship 5073 time_from start
+# SKDA rel 5074 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-05T11:19:42)
+ACTION 4410 patch-contact-relationship 5074 time_from start
+# SKSH rel 5122 'Veðurstofa Íslands' role=owner  (per_time_from=2025-08-19T13:40:57)
+ACTION 16821 patch-contact-relationship 5122 time_from start
+# SLEC rel 5075 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-05T11:19:42)
+ACTION 15881 patch-contact-relationship 5075 time_from start
+# STAN rel 5060 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-05T11:19:42)
+ACTION 20168 patch-contact-relationship 5060 time_from start
+# STHV rel 5077 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-05T11:19:42)
+ACTION 19771 patch-contact-relationship 5077 time_from start
+# STKA rel 5076 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-05T11:19:42)
+ACTION 4418 patch-contact-relationship 5076 time_from start
+# SVIE rel 5078 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-05T11:19:42)
+ACTION 16081 patch-contact-relationship 5078 time_from start
+# SVIN rel 5079 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-05T11:19:42)
+ACTION 16082 patch-contact-relationship 5079 time_from start
+# THNA rel 5084 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-05T11:19:42)
+ACTION 20089 patch-contact-relationship 5084 time_from start
+# THNA rel 5085 'Jarðvísindastofnun Háskóla Íslands' role=owner  (per_time_from=2025-02-05T11:19:42)
+ACTION 20089 patch-contact-relationship 5085 time_from start
+# THOB rel 5083 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-05T11:19:42)
+ACTION 16803 patch-contact-relationship 5083 time_from start
+# URHC rel 5080 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-05T11:19:42)
+ACTION 4428 patch-contact-relationship 5080 time_from start
+# VARG rel 4536 'Veðurstofa Íslands' role=owner  (per_time_from=2023-08-17T14:00:00)
+ACTION 19803 patch-contact-relationship 4536 time_from start
+# VOGC rel 5081 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-05T11:19:42)
+ACTION 18406 patch-contact-relationship 5081 time_from start
+# VOGS rel 5082 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-05T11:19:42)
+ACTION 4432 patch-contact-relationship 5082 time_from start
+
+# ── LOW confidence: non-owner roles (data_owner / operator /
+#    observer) may have a genuinely recent start date — REVIEW
+#    each before uncommenting ──
+# AKUR rel 5102 'Landmælingar Íslands' role=operator  (per_time_from=2025-05-08T09:48:48)
+#ACTION 4229 patch-contact-relationship 5102 time_from start
+# ELDC rel 5128 'Veðurstofa Íslands' role=data_owner  (per_time_from=2025-09-01T15:17:56)
+#ACTION 16801 patch-contact-relationship 5128 time_from start
+# ELDC rel 5129 'Veðurstofa Íslands' role=operator  (per_time_from=2025-09-01T15:17:56)
+#ACTION 16801 patch-contact-relationship 5129 time_from start
+# FEFC rel 5139 'Veðurstofa Íslands' role=data_owner  (per_time_from=2025-09-09T10:30:59)
+#ACTION 18402 patch-contact-relationship 5139 time_from start
+# FEFC rel 5140 'Veðurstofa Íslands' role=operator  (per_time_from=2025-09-09T10:30:59)
+#ACTION 18402 patch-contact-relationship 5140 time_from start
+# GRIV rel 5131 'Veðurstofa Íslands' role=data_owner  (per_time_from=2025-09-08T13:40:51)
+#ACTION 19943 patch-contact-relationship 5131 time_from start
+# GRIV rel 5133 'Veðurstofa Íslands' role=operator  (per_time_from=2025-09-08T13:40:51)
+#ACTION 19943 patch-contact-relationship 5133 time_from start
+# HAFC rel 5145 'Veðurstofa Íslands' role=data_owner  (per_time_from=2025-09-12T09:41:14)
+#ACTION 18408 patch-contact-relationship 5145 time_from start
+# HAFC rel 5146 'Veðurstofa Íslands' role=operator  (per_time_from=2025-09-12T09:41:14)
+#ACTION 18408 patch-contact-relationship 5146 time_from start
+# HEID rel 5141 'Landmælingar Íslands' role=data_owner  (per_time_from=2025-09-12T09:41:14)
+#ACTION 4318 patch-contact-relationship 5141 time_from start
+# HEID rel 5142 'Landmælingar Íslands' role=operator  (per_time_from=2025-09-12T09:41:14)
+#ACTION 4318 patch-contact-relationship 5142 time_from start
+# NAMC rel 5137 'Veðurstofa Íslands' role=data_owner  (per_time_from=2025-09-09T09:48:26)
+#ACTION 18401 patch-contact-relationship 5137 time_from start
+# NAMC rel 5138 'Veðurstofa Íslands' role=operator  (per_time_from=2025-09-09T09:48:26)
+#ACTION 18401 patch-contact-relationship 5138 time_from start
+# NBIO rel 5134 'Veðurstofa Íslands' role=data_owner  (per_time_from=2025-09-08T15:17:05)
+#ACTION 19961 patch-contact-relationship 5134 time_from start
+# NBIO rel 5136 'Veðurstofa Íslands' role=operator  (per_time_from=2025-09-08T15:17:05)
+#ACTION 19961 patch-contact-relationship 5136 time_from start
+# NYLA rel 5143 'Veðurstofa Íslands' role=operator  (per_time_from=2025-09-12T09:41:14)
+#ACTION 4366 patch-contact-relationship 5143 time_from start
+# NYLA rel 5144 'Veðurstofa Íslands' role=data_owner  (per_time_from=2025-09-12T09:41:14)
+#ACTION 4366 patch-contact-relationship 5144 time_from start
+# RHOF rel 4961 'Veðurstofa Íslands' role=operator  (per_time_from=2024-08-14T09:30:16)
+#ACTION 4390 patch-contact-relationship 4961 time_from start
+# RHOF rel 4987 'Benedikt G. Ófeigsson' role=operator  (per_time_from=2024-11-07T13:19:27)
+#ACTION 4390 patch-contact-relationship 4987 time_from start
+# SENG rel 5118 'Veðurstofa Íslands' role=data_owner  (per_time_from=2025-08-19T13:21:44)
+#ACTION 16818 patch-contact-relationship 5118 time_from start
+# SENG rel 5120 'Veðurstofa Íslands' role=operator  (per_time_from=2025-08-19T13:21:44)
+#ACTION 16818 patch-contact-relationship 5120 time_from start
+# SEY1 rel 5059 'Veðurstofa Íslands' role=observer  (per_time_from=2025-02-05T11:19:42)
+#ACTION 18279 patch-contact-relationship 5059 time_from start
+# SEYD rel 5058 'Veðurstofa Íslands' role=observer  (per_time_from=2025-02-05T11:19:42)
+#ACTION 18277 patch-contact-relationship 5058 time_from start
+# SKSH rel 5121 'Veðurstofa Íslands' role=data_owner  (per_time_from=2025-08-19T13:40:57)
+#ACTION 16821 patch-contact-relationship 5121 time_from start
+# SKSH rel 5123 'Veðurstofa Íslands' role=operator  (per_time_from=2025-08-19T13:40:57)
+#ACTION 16821 patch-contact-relationship 5123 time_from start
+# STAN rel 5057 'Jarðvísindastofnun Háskóla Íslands' role=observer  (per_time_from=2025-02-05T11:19:42)
+#ACTION 20168 patch-contact-relationship 5057 time_from start
+# TORK rel 5126 'Veðurstofa Íslands' role=operator  (per_time_from=2025-08-28T11:52:49)
+#ACTION 19419 patch-contact-relationship 5126 time_from start
+# TORK rel 5127 'Jarðvísindastofnun Háskóla Íslands' role=operator  (per_time_from=2025-08-28T11:52:49)
+#ACTION 19419 patch-contact-relationship 5127 time_from start
+# VOFJ rel 5124 'Landmælingar Íslands' role=operator  (per_time_from=2025-08-27T14:46:24)
+#ACTION 19229 patch-contact-relationship 5124 time_from start

--- a/docs/architecture/contact-write-api.md
+++ b/docs/architecture/contact-write-api.md
@@ -200,6 +200,18 @@ audit (not in the recurring verify oracle — migration artifacts are a
 one-time fixup, not ongoing drift). Pinned by
 `tests/test_audit_contact_dates.py`.
 
+**Fleet sweep** — `tos fleet contact-dates [--triage PATH]` loops the
+audit over every GNSS station and aggregates. `--triage` emits ONE
+combined file with a confidence split: **owner-role** relationships
+uncommented (backdating to `start`/founding is always correct — the
+owner owned the station from founding regardless of which org);
+non-owner roles (data_owner / operator / observer) commented for review
+(they may have a genuinely recent start date). First fleet run
+(2026-06-04): 129 violations across 192 stations — 100 owner
+(ready-to-apply) + 29 non-owner (review). Provenance:
+`data/triage/contact_dates_fleet_20260604.txt`. In `fleet_ops.py`:
+`run_fleet_contact_dates` + `format_fleet_contact_dates_triage`.
+
 ## Phase 5 — contact-entity writes (SHIPPED; dry-run validated)
 
 Writer `create_contact(*, name, **fields)` → `POST /contacts`;

--- a/src/tostools/fleet_ops.py
+++ b/src/tostools/fleet_ops.py
@@ -34,6 +34,10 @@ from typing import Any, Callable, Dict, List, Optional, Sequence
 
 from tostools.api.tos_client import TOSClient
 from tostools.audit import REAL_STATION_SUBTYPES
+from tostools.audit_contact_dates import (
+    ContactDateViolation,
+    audit_station_contact_dates,
+)
 from tostools.history import (
     ParentEntity,
     default_station_cfg_path,
@@ -565,6 +569,255 @@ def run_fleet_verify(
         results=results,
         with_archive=with_archive,
     )
+
+
+# ---------------------------------------------------------------------------
+# Fleet contact-dates sweep (migration-artifact relationship dates)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FleetContactDatesStation:
+    """One station's contact-dates result in the fleet sweep."""
+
+    marker: str
+    station_id: Optional[int]
+    violations: List[ContactDateViolation] = field(default_factory=list)
+    error: Optional[str] = None
+
+
+@dataclass
+class FleetContactDatesSummary:
+    """Aggregate of a fleet-wide contact-dates sweep."""
+
+    generated_at: str
+    stations: List[FleetContactDatesStation] = field(default_factory=list)
+
+    @property
+    def stations_audited(self) -> int:
+        return len(self.stations)
+
+    @property
+    def clean(self) -> int:
+        return sum(1 for s in self.stations if not s.violations and not s.error)
+
+    @property
+    def with_violations(self) -> int:
+        return sum(1 for s in self.stations if s.violations)
+
+    @property
+    def errors(self) -> int:
+        return sum(1 for s in self.stations if s.error)
+
+    @property
+    def total_violations(self) -> int:
+        return sum(len(s.violations) for s in self.stations)
+
+    @property
+    def all_violations(
+        self,
+    ) -> "List[tuple[FleetContactDatesStation, ContactDateViolation]]":
+        out = []
+        for s in self.stations:
+            for v in s.violations:
+                out.append((s, v))
+        return out
+
+
+def run_fleet_contact_dates(
+    client: TOSClient,
+    *,
+    stations: Optional[Sequence[ParentEntity]] = None,
+    use_suppressions: bool = True,
+    suppressions_path: Optional[Path] = None,
+    station_cfg_path: Optional[str] = None,
+    include: Optional[Sequence[str]] = None,
+    exclude: Optional[Sequence[str]] = None,
+    limit: Optional[int] = None,
+    progress: Optional[Callable[[int, int, FleetContactDatesStation], None]] = None,
+    enumerate_progress: Optional[Callable[[int, int], None]] = None,
+    generated_at: Optional[str] = None,
+) -> FleetContactDatesSummary:
+    """Sweep :func:`audit_station_contact_dates` across the GNSS fleet.
+
+    Read-only: one ``get_entity_history`` + one ``get_contacts`` per
+    station (after marker resolution). Migration artifacts are a
+    one-time cleanup, so this is a standalone sweep — not wired into the
+    recurring verify oracle.
+
+    Per-station failures are captured on the result, never abort the run.
+    """
+    generated_at = generated_at or now_iso_utc()
+    if stations is None:
+        stations = enumerate_fleet_stations(
+            client,
+            station_cfg_path=station_cfg_path,
+            include=include,
+            exclude=exclude,
+            limit=limit,
+            enumerate_progress=enumerate_progress,
+        )
+
+    summary = FleetContactDatesSummary(generated_at=generated_at)
+    for idx, parent in enumerate(stations, start=1):
+        marker = parent.name or f"id={parent.id_entity}"
+        st = FleetContactDatesStation(marker=marker, station_id=parent.id_entity)
+        try:
+            report = audit_station_contact_dates(
+                client,
+                id_entity=parent.id_entity,
+                use_suppressions=use_suppressions,
+                suppressions_path=suppressions_path,
+            )
+            st.violations = list(report.violations)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("contact-dates sweep failed for %s: %s", marker, exc)
+            st.error = str(exc)
+        summary.stations.append(st)
+        if progress is not None:
+            progress(idx, len(stations), st)
+    return summary
+
+
+#: Roles whose `time_from` can always be safely backdated to the
+#: station's `start` (founding): the owner owned the station from
+#: founding regardless of which org. Non-owner roles (data_owner,
+#: operator, observer) may have genuinely later real start dates, so
+#: those stay commented for operator review.
+_HIGH_CONFIDENCE_CONTACT_ROLES = frozenset({"owner"})
+
+
+def format_fleet_contact_dates_triage(
+    summary: FleetContactDatesSummary,
+) -> str:
+    """Render a single combined triage file for the fleet sweep.
+
+    ``role == owner`` violations are emitted **uncommented** (backdating
+    to ``start`` is always correct — the owner owned the station from
+    founding). All other roles are emitted **commented** for operator
+    review (they may have genuinely recent start dates). Each line is a
+    ``patch-contact-relationship <id_rel> time_from start`` ACTION whose
+    ``id_entity`` slot is the station (so ``start`` resolves against the
+    station's earliest_known).
+    """
+    high = [
+        (s, v)
+        for s, v in summary.all_violations
+        if (v.role or "") in _HIGH_CONFIDENCE_CONTACT_ROLES
+    ]
+    low = [
+        (s, v)
+        for s, v in summary.all_violations
+        if (v.role or "") not in _HIGH_CONFIDENCE_CONTACT_ROLES
+    ]
+
+    lines: List[str] = []
+    lines.append("# === tos fleet contact-dates — combined triage action file ===")
+    lines.append(f"# Generated:  {summary.generated_at}")
+    lines.append(f"# Stations:   {summary.stations_audited} audited")
+    lines.append(f"# Violations: {summary.total_violations} total")
+    lines.append(f"#   HIGH (owner role, uncommented, ready to apply): {len(high)}")
+    lines.append(f"#   LOW  (non-owner role, commented for review):    {len(low)}")
+    lines.append("#")
+    lines.append("# Each line backdates time_from to `start` (the station's")
+    lines.append("# earliest_known / founding date), resolved at apply time.")
+    lines.append("#")
+    lines.append("# Workflow:")
+    lines.append("#   tos audit apply <file>          # dry-run preview")
+    lines.append("#   tos audit apply <file> --apply  # commit writes")
+    lines.append("")
+
+    lines.append("# ── HIGH confidence: owner relationships (owner owned the station")
+    lines.append("#    from founding, so `start` is the correct backdate) ──")
+    if not high:
+        lines.append("# (none)")
+    for s, v in sorted(high, key=lambda sv: (sv[0].marker, sv[1].id_relationship)):
+        label = f" {v.contact_label!r}" if v.contact_label else ""
+        lines.append(
+            f"# {s.marker} rel {v.id_relationship}{label} role={v.role}"
+            f"  (per_time_from={v.per_time_from})"
+        )
+        lines.append(
+            f"ACTION {s.station_id} patch-contact-relationship "
+            f"{v.id_relationship} time_from start"
+        )
+    lines.append("")
+
+    lines.append("# ── LOW confidence: non-owner roles (data_owner / operator /")
+    lines.append("#    observer) may have a genuinely recent start date — REVIEW")
+    lines.append("#    each before uncommenting ──")
+    if not low:
+        lines.append("# (none)")
+    for s, v in sorted(low, key=lambda sv: (sv[0].marker, sv[1].id_relationship)):
+        label = f" {v.contact_label!r}" if v.contact_label else ""
+        lines.append(
+            f"# {s.marker} rel {v.id_relationship}{label} role={v.role}"
+            f"  (per_time_from={v.per_time_from})"
+        )
+        lines.append(
+            f"#ACTION {s.station_id} patch-contact-relationship "
+            f"{v.id_relationship} time_from start"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def format_fleet_contact_dates_report(summary: FleetContactDatesSummary) -> str:
+    """Human-readable fleet contact-dates report (counts + batch breakdown)."""
+    from collections import Counter
+
+    lines: List[str] = []
+    lines.append(
+        f"=== FLEET CONTACT-DATES — {summary.generated_at} "
+        f"({summary.stations_audited} station(s)) ==="
+    )
+    lines.append(f"  clean:            {summary.clean}")
+    lines.append(f"  with violations:  {summary.with_violations}")
+    if summary.errors:
+        lines.append(f"  errors:           {summary.errors}")
+    lines.append(f"  total flagged relationships: {summary.total_violations}")
+
+    byday: "Counter[str]" = Counter(
+        v.per_time_from[:10] for _s, v in summary.all_violations
+    )
+    if byday:
+        lines.append("")
+        lines.append("  flagged per_time_from by day:")
+        for day, n in byday.most_common():
+            lines.append(f"    {day}: {n}")
+    return "\n".join(lines) + "\n"
+
+
+def fleet_contact_dates_to_dict(summary: FleetContactDatesSummary) -> Dict[str, Any]:
+    """JSON-serialisable view of a fleet contact-dates sweep."""
+    return {
+        "kind": "fleet-contact-dates",
+        "generated_at": summary.generated_at,
+        "totals": {
+            "stations_audited": summary.stations_audited,
+            "clean": summary.clean,
+            "with_violations": summary.with_violations,
+            "errors": summary.errors,
+            "total_violations": summary.total_violations,
+        },
+        "violations": [
+            {
+                "marker": s.marker,
+                "station_id": s.station_id,
+                "id_relationship": v.id_relationship,
+                "id_contact": v.id_contact,
+                "contact_label": v.contact_label,
+                "role": v.role,
+                "per_time_from": v.per_time_from,
+            }
+            for s, v in summary.all_violations
+        ],
+        "errors": [
+            {"marker": s.marker, "station_id": s.station_id, "error": s.error}
+            for s in summary.stations
+            if s.error
+        ],
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/src/tostools/tos.py
+++ b/src/tostools/tos.py
@@ -4931,6 +4931,89 @@ def _fleet_main(argv):
     )
     _add_common_filters(p_sta)
 
+    p_cd = sub.add_parser(
+        "contact-dates",
+        help=(
+            "Sweep `tos audit contact-dates` across the fleet. Flags "
+            "contact↔station relationships with a TOS-migration date "
+            "(non-midnight per_time_from)."
+        ),
+        description=(
+            "Run the contact-dates audit against every GNSS station and "
+            "aggregate the migration-artifact relationships fleet-wide. "
+            "Read-only — no TOS state mutated.\n\n"
+            "Migration bulk-loads gave each contact↔station relationship "
+            "a time_from set to the load instant (a non-midnight "
+            "clock time) rather than the real ownership-start date. "
+            "This sweep surfaces them all.\n\n"
+            "Use --triage to emit ONE combined action file. Owner-role "
+            "relationships are emitted UNCOMMENTED (backdating to "
+            "`start`/founding is always correct — the owner owned the "
+            "station from founding); non-owner roles (data_owner / "
+            "operator / observer) are COMMENTED for review (they may "
+            "have a genuinely recent start date).\n\n"
+            "One-time cleanup — once swept it stays clean (no new "
+            "migration), so this is not in the recurring verify oracle."
+        ),
+        epilog=(
+            "Examples:\n"
+            "  tos fleet contact-dates\n"
+            "  tos fleet contact-dates --triage data/triage/contact_dates_fleet.txt\n"
+            "  tos fleet contact-dates --json | jq '.totals'\n"
+        ),
+        formatter_class=_argparse.RawDescriptionHelpFormatter,
+    )
+    p_cd.add_argument(
+        "--triage",
+        dest="triage_path",
+        type=Path,
+        default=None,
+        help=(
+            "Emit one combined triage file (owner-role uncommented, "
+            "non-owner commented). Apply with `tos audit apply`."
+        ),
+    )
+    p_cd.add_argument(
+        "--include",
+        nargs="+",
+        default=None,
+        metavar="STN",
+        help="Restrict to these markers (case-insensitive).",
+    )
+    p_cd.add_argument(
+        "--exclude",
+        nargs="+",
+        default=None,
+        metavar="STN",
+        help="Skip these markers.",
+    )
+    p_cd.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Stop after N stations (smoke test).",
+    )
+    p_cd.add_argument(
+        "--stations-cfg",
+        type=Path,
+        default=None,
+        metavar="PATH",
+        help="Override the stations.cfg path.",
+    )
+    p_cd.add_argument(
+        "--suppressions",
+        type=Path,
+        default=None,
+        help="Override the contact_dates.txt suppression path.",
+    )
+    p_cd.add_argument(
+        "--no-suppressions",
+        action="store_true",
+        help="Bypass the suppression file.",
+    )
+    p_cd.add_argument("--json", action="store_true", help="Machine-readable JSON.")
+
     args = p.parse_args(argv)
 
     from .api.tos_client import TOSClient
@@ -4943,6 +5026,64 @@ def _fleet_main(argv):
     from .station_triage import STATUS_MARK
 
     client = TOSClient()
+
+    # contact-dates has its own summary type + render path — handle it
+    # before the shared status/triage machinery below.
+    if args.verb == "contact-dates":
+        from .fleet_ops import (
+            fleet_contact_dates_to_dict,
+            format_fleet_contact_dates_report,
+            format_fleet_contact_dates_triage,
+            run_fleet_contact_dates,
+        )
+
+        def _cd_enum(idx, total):
+            if total and (idx == total or idx % 20 == 0 or idx == 1):
+                print(
+                    f"resolving stations.cfg markers… {idx}/{total}",
+                    file=_sys.stderr,
+                )
+
+        def _cd_progress(idx, total, st):
+            if idx % 25 == 0 or idx == total:
+                print(f"  audited {idx}/{total}…", file=_sys.stderr)
+
+        try:
+            cd_summary = run_fleet_contact_dates(
+                client,
+                use_suppressions=not bool(args.no_suppressions),
+                suppressions_path=args.suppressions,
+                station_cfg_path=str(args.stations_cfg) if args.stations_cfg else None,
+                include=args.include,
+                exclude=args.exclude,
+                limit=args.limit,
+                progress=_cd_progress,
+                enumerate_progress=_cd_enum,
+            )
+        except RuntimeError as exc:
+            print(f"tos fleet: {exc}", file=_sys.stderr)
+            return 2
+
+        if args.triage_path:
+            content = format_fleet_contact_dates_triage(cd_summary)
+            args.triage_path.write_text(content, encoding="utf-8")
+            print(
+                f"wrote combined triage file: {args.triage_path} "
+                f"({cd_summary.total_violations} violation(s))",
+                file=_sys.stderr,
+            )
+        if args.json:
+            print(
+                _json.dumps(
+                    fleet_contact_dates_to_dict(cd_summary),
+                    ensure_ascii=False,
+                    indent=2,
+                )
+            )
+        else:
+            print(format_fleet_contact_dates_report(cd_summary), end="")
+        # Exit 1 if any migration-artifact dates surfaced, else 0.
+        return 1 if cd_summary.total_violations else 0
 
     # Stderr progress reporter — keeps stdout clean for JSON / piping.
     def _progress(idx, total, result):
@@ -9590,6 +9731,9 @@ def _print_top_level_help() -> None:
         "                                       `tos audit apply` (skips\n"
         "                                       clean stations by\n"
         "                                       default).\n"
+        "               fleet contact-dates     Sweep contact-dates audit\n"
+        "                                       fleet-wide; --triage emits a\n"
+        "                                       combined fix file.\n"
         "             Filters: --include / --exclude STN1 STN2 …,\n"
         "                      --limit N, --with-archive, --json.\n"
         "             Use `tos fleet --help` for the full operator guide.\n"

--- a/tests/test_fleet_ops.py
+++ b/tests/test_fleet_ops.py
@@ -580,3 +580,161 @@ def test_progress_callback_fires_once_per_station():
         )
 
     assert seen == [(1, 3, "RHOF"), (2, 3, "HEDI"), (3, 3, "SAVI")]
+
+
+# ---------------------------------------------------------------------------
+# Fleet contact-dates sweep
+# ---------------------------------------------------------------------------
+
+
+def _cd_report(station_id, name, violations):
+    """Build a StationContactDatesReport with the given violations."""
+    from tostools.audit_contact_dates import StationContactDatesReport
+
+    r = StationContactDatesReport(station_id=station_id, station_name=name)
+    r.violations = list(violations)
+    return r
+
+
+def _cd_violation(id_rel, role, per_time_from, *, id_contact=1256, label="VÍ"):
+    from tostools.audit_contact_dates import ContactDateViolation
+
+    return ContactDateViolation(
+        id_relationship=id_rel,
+        id_contact=id_contact,
+        contact_label=label,
+        role=role,
+        per_time_from=per_time_from,
+    )
+
+
+def test_run_fleet_contact_dates_aggregates():
+    from tostools.fleet_ops import run_fleet_contact_dates
+
+    stations = [_station(4390, "RHOF"), _station(4440, "SAVI"), _station(4316, "HEDI")]
+    reports = {
+        4390: _cd_report(
+            4390, "RHOF", [_cd_violation(4961, "operator", "2024-08-14T09:30:16")]
+        ),
+        4440: _cd_report(
+            4440, "SAVI", [_cd_violation(5052, "owner", "2025-02-04T15:32:38")]
+        ),
+        4316: _cd_report(4316, "HEDI", []),  # clean
+    }
+
+    with patch(
+        "tostools.fleet_ops.audit_station_contact_dates",
+        side_effect=lambda client, *, id_entity, **kw: reports[id_entity],
+    ):
+        summary = run_fleet_contact_dates(
+            None, stations=stations, generated_at=FROZEN_TS
+        )
+
+    assert summary.stations_audited == 3
+    assert summary.clean == 1
+    assert summary.with_violations == 2
+    assert summary.total_violations == 2
+
+
+def test_run_fleet_contact_dates_captures_per_station_error():
+    from tostools.fleet_ops import run_fleet_contact_dates
+
+    stations = [_station(4390, "RHOF"), _station(4440, "SAVI")]
+
+    def fake_audit(client, *, id_entity, **kw):
+        if id_entity == 4390:
+            raise RuntimeError("boom")
+        return _cd_report(
+            4440, "SAVI", [_cd_violation(5052, "owner", "2025-02-04T15:32:38")]
+        )
+
+    with patch(
+        "tostools.fleet_ops.audit_station_contact_dates", side_effect=fake_audit
+    ):
+        summary = run_fleet_contact_dates(
+            None, stations=stations, generated_at=FROZEN_TS
+        )
+
+    assert summary.errors == 1
+    assert summary.total_violations == 1  # SAVI still audited
+
+
+def test_fleet_contact_dates_triage_splits_owner_vs_other():
+    """Owner role → uncommented (backdate safe); non-owner → commented."""
+    from tostools.fleet_ops import (
+        FleetContactDatesStation,
+        FleetContactDatesSummary,
+        format_fleet_contact_dates_triage,
+    )
+
+    summary = FleetContactDatesSummary(generated_at=FROZEN_TS)
+    summary.stations = [
+        FleetContactDatesStation(
+            marker="SAVI",
+            station_id=4440,
+            violations=[_cd_violation(5052, "owner", "2025-02-04T15:32:38")],
+        ),
+        FleetContactDatesStation(
+            marker="RHOF",
+            station_id=4390,
+            violations=[_cd_violation(4961, "operator", "2024-08-14T09:30:16")],
+        ),
+    ]
+    out = format_fleet_contact_dates_triage(summary)
+
+    # Owner line is uncommented + correct shape.
+    assert "ACTION 4440 patch-contact-relationship 5052 time_from start" in out
+    assert (
+        "\nACTION 4440 patch-contact-relationship 5052 time_from start" in out
+    )  # not preceded by '#'
+    # Operator line is commented.
+    assert "#ACTION 4390 patch-contact-relationship 4961 time_from start" in out
+    # Header tallies.
+    assert "HIGH (owner role, uncommented, ready to apply): 1" in out
+    assert "LOW  (non-owner role, commented for review):    1" in out
+
+
+def test_fleet_contact_dates_to_dict_shape():
+    from tostools.fleet_ops import (
+        FleetContactDatesStation,
+        FleetContactDatesSummary,
+        fleet_contact_dates_to_dict,
+    )
+
+    summary = FleetContactDatesSummary(generated_at=FROZEN_TS)
+    summary.stations = [
+        FleetContactDatesStation(
+            marker="SAVI",
+            station_id=4440,
+            violations=[_cd_violation(5052, "owner", "2025-02-04T15:32:38")],
+        ),
+    ]
+    d = fleet_contact_dates_to_dict(summary)
+    assert d["kind"] == "fleet-contact-dates"
+    assert d["totals"]["total_violations"] == 1
+    assert d["violations"][0]["id_relationship"] == 5052
+    assert d["violations"][0]["role"] == "owner"
+
+
+def test_cli_fleet_contact_dates_triage(tmp_path, capsys):
+    """End-to-end: tos fleet contact-dates --triage writes the combined file."""
+    from tostools.tos import main as tos_main
+
+    stations = [_station(4440, "SAVI")]
+    report = _cd_report(
+        4440, "SAVI", [_cd_violation(5052, "owner", "2025-02-04T15:32:38")]
+    )
+    out_path = tmp_path / "fleet_cd.txt"
+
+    with (
+        patch("tostools.fleet_ops.enumerate_fleet_stations", return_value=stations),
+        patch(
+            "tostools.fleet_ops.audit_station_contact_dates",
+            side_effect=lambda client, *, id_entity, **kw: report,
+        ),
+    ):
+        rc = tos_main(["fleet", "contact-dates", "--triage", str(out_path)])
+
+    assert rc == 1  # violations present
+    content = out_path.read_text()
+    assert "ACTION 4440 patch-contact-relationship 5052 time_from start" in content


### PR DESCRIPTION
Wraps `tos audit contact-dates` into a fleet-wide sweep, and runs it across the whole network. Read-only (one `get_entity_history` + `get_contacts` per station).

## What the sweep found (committed as provenance)
`data/triage/contact_dates_fleet_20260604.txt` — **129 migration-date relationships across 192 stations**:

| Batch | Count | |
|---|---|---|
| `2025-02-04T15:32:38` | 62 | big VÍ-owner migration |
| `2025-02-05T11:19:42` | 31 | second owner batch |
| Aug/Sept 2025 | ~31 | data_owner/operator role additions |
| 7 scattered older | 7 | individual non-midnight dates |

Split by confidence: **100 owner-role (uncommented, ready) + 29 non-owner (commented for review)**.

## Surface
```
tos fleet contact-dates [--triage PATH] [--include/--exclude/--limit] [--json]
```
- Exit 1 if any migration dates surface, else 0.
- `--triage` emits **one combined action file** with the confidence split.

## The confidence rule
`role == "owner"` → **uncommented**. Backdating an owner relationship to `start` (the station's founding) is always correct — the owner owned the station from founding, whichever org it is. The 100 owner ACTIONs **dry-run clean** (0 failed); each `start` resolves to its station's founding date (e.g. NBIO→2023-11-02, SAVI→2007-08-08).

Non-owner roles (`data_owner` / `operator` / `observer`) → **commented**. Those may have a genuinely recent real start date (e.g. an operator assigned this year), so the operator reviews each before uncommenting.

## Implementation
`fleet_ops.py`: `run_fleet_contact_dates` + `FleetContactDatesSummary` + `format_fleet_contact_dates_{triage,report}` + `fleet_contact_dates_to_dict`. Self-contained loop (contact-dates isn't part of `generate_station_triage`, so it doesn't reuse `_iterate_fleet`).

## Tests (5 new)
Aggregate, per-station error capture, owner/non-owner triage split, JSON shape, CLI `--triage` end-to-end. 999 tests pass, ruff + black clean.

## Next (operator decision)
The committed triage file is ready. `tos audit apply data/triage/contact_dates_fleet_20260604.txt --apply` would commit the **100 owner backdates** in one shot (the 29 non-owner stay commented). That's a big live write — I won't run it without explicit per-action authorization, and the 29 commented ones want a human pass first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)