### PR TITLE
feat(tos): telemetry subtypes + builders + delete_maintenance

### DIFF
--- a/src/tostools/api/tos_writer.py
+++ b/src/tostools/api/tos_writer.py
@@ -2072,6 +2072,32 @@ class TOSWriter:
             "after": payload,
         }
 
+    def delete_maintenance(self, id_maintenance: int) -> Any:
+        """Permanently remove a vitjun (maintenance record) from TOS.
+
+        .. warning::
+
+           Destructive admin endpoint. Use only to clean up known-bad
+           records — e.g. a visit created by accident. To close out a
+           visit that genuinely happened, prefer
+           :meth:`update_maintenance_visit` with ``completed=True``,
+           which preserves the history; deletion erases it.
+
+        Uses ``DELETE /admin_maintenance_row/{id}`` — the singular
+        ``admin_*_row`` form established by :meth:`delete_entity_connection`
+        (``/admin_entity_connection_row/{id}``) and
+        :meth:`delete_attribute_value` (``/admin_attribute_value_row/{id}``).
+        Requires admin-level TOS access (same scope as other admin writes).
+
+        Args:
+            id_maintenance: The ``id_maintenance`` of the vitjun to delete.
+
+        Returns:
+            API response (typically an empty 204), or
+            :class:`DryRunResult` in dry-run mode.
+        """
+        return self._request("DELETE", f"/admin_maintenance_row/{id_maintenance}")
+
 
 # ---------------------------------------------------------------------------
 # Context manager helper for per-call dry_run override

--- a/src/tostools/device.py
+++ b/src/tostools/device.py
@@ -46,6 +46,15 @@ VALID_SUBTYPES: Tuple[str, ...] = (
     "antenna",
     "radome",
     "monument",
+    # Telemetry hardware. modem_gsm carries the canonical device shape
+    # (serial/model/owner/status/date_start — same as gnss_receiver, so
+    # build_required_attributes fits). sim_card carries only ip_address +
+    # phone_number (see build_sim_card_attributes). router is accepted for
+    # completeness; no builder yet (add when a router-as-distinct-entity
+    # use case appears — most fleet sites model the unit as modem_gsm).
+    "modem_gsm",
+    "sim_card",
+    "router",
 )
 
 REQUIRED_ATTR_CODES: Tuple[str, ...] = (
@@ -165,8 +174,10 @@ def validate_model(subtype: str, raw: str) -> str:
             )
         return to_igs_radome(raw) or "NONE"
 
-    if subtype == "monument":
-        # No IGS table for monuments — accept the raw string.
+    if subtype in ("monument", "modem_gsm", "sim_card", "router"):
+        # No IGS table for monuments or telemetry hardware — accept the raw
+        # string (e.g. "Teltonika RUT200", "Conel"). The model is free-text
+        # vendor naming, not a standards-governed code.
         return raw
 
     raise ValueError(
@@ -235,6 +246,56 @@ def build_required_attributes(
             "date_to": None,
         },
     ]
+
+
+def build_sim_card_attributes(
+    ip_address: str,
+    date_start: str,
+    phone_number: Optional[str] = None,
+) -> List[Dict[str, Optional[str]]]:
+    """Build the attribute list for a ``sim_card`` device.
+
+    A ``sim_card`` does NOT use the canonical device shape
+    (serial/model/owner/status) — verified against the live TOS schema
+    (GSIG's sim_card id=5785 on 2026-06-06 carried only ``ip_address`` and
+    ``phone_number``). So this is a separate builder rather than reusing
+    :func:`build_required_attributes`.
+
+    ``ip_address`` is required (it's the operationally important field — the
+    address the scheduler/probe reaches the station through). ``phone_number``
+    is optional and omitted from the list when not given.
+
+    Each attribute carries an explicit ``date_to: None`` (open period), matching
+    :func:`build_required_attributes` and the ``/entities`` endpoint's
+    required-present-field expectation.
+
+    Args:
+        ip_address: The SIM's IP address (e.g. ``"10.4.1.225"``).
+        date_start: ISO-8601 date/datetime the SIM became active. Doubles as
+            ``date_from`` for the attribute periods.
+        phone_number: Optional MSISDN / phone number string.
+
+    Returns:
+        Attribute-dict list for :meth:`TOSWriter.create_device`.
+    """
+    attrs: List[Dict[str, Optional[str]]] = [
+        {
+            "code": "ip_address",
+            "value": ip_address,
+            "date_from": date_start,
+            "date_to": None,
+        },
+    ]
+    if phone_number:
+        attrs.append(
+            {
+                "code": "phone_number",
+                "value": phone_number,
+                "date_from": date_start,
+                "date_to": None,
+            }
+        )
+    return attrs
 
 
 def iter_optional_attributes(

--- a/src/tostools/device.py
+++ b/src/tostools/device.py
@@ -352,6 +352,9 @@ def build_sim_card_attributes(
         "model": model,
         "owner": owner,
         "status": status,
+        # date_start is its own attribute_value row (matches build_required_
+        # attributes + the existing fleet convention / web-UI "Upphafsdagsetning").
+        "date_start": date_start,
         "comment": comment,
     }
     if extra:
@@ -397,6 +400,9 @@ def build_modem_gsm_attributes(
         "model": model,
         "owner": owner,
         "status": status,
+        # date_start is its own attribute_value row (matches build_required_
+        # attributes + the existing fleet convention / web-UI "Upphafsdagsetning").
+        "date_start": date_start,
         "ip_address": ip_address,
         "phone_number": phone_number,
         "provider": provider,

--- a/src/tostools/device.py
+++ b/src/tostools/device.py
@@ -248,54 +248,167 @@ def build_required_attributes(
     ]
 
 
-def build_sim_card_attributes(
-    ip_address: str,
+# Telemetry attribute vocabularies — the set of attribute codes operators may
+# set on each subtype, discovered by a fleet-wide TOS scan on 2026-06-06
+# (B9 warehouse 641 children + 226 deployed units across 194 stations).
+# System-managed fields (``voltage`` — a live measurement; ``created_by_user``
+# — set by TOS) are intentionally excluded: they are never hand-entered.
+SIM_CARD_ATTR_CODES: Tuple[str, ...] = (
+    "ip_address",
+    "phone_number",
+    "serial_number",
+    "provider",
+    "model",
+    "owner",
+    "status",
+    "date_start",
+    "date_end",
+    "comment",
+)
+MODEM_GSM_ATTR_CODES: Tuple[str, ...] = (
+    "serial_number",
+    "model",
+    "owner",
+    "status",
+    "date_start",
+    "ip_address",
+    "phone_number",
+    "provider",
+    "mac_address",
+    "manufacturer",
+    "io_type",
+    "subtype",
+    "comment",
+)
+
+
+def attributes_from_mapping(
+    mapping: Dict[str, Optional[str]],
     date_start: str,
-    phone_number: Optional[str] = None,
 ) -> List[Dict[str, Optional[str]]]:
-    """Build the attribute list for a ``sim_card`` device.
+    """Turn a ``{code: value}`` mapping into the TOS attribute-dict list.
 
-    A ``sim_card`` does NOT use the canonical device shape
-    (serial/model/owner/status) — verified against the live TOS schema
-    (GSIG's sim_card id=5785 on 2026-06-06 carried only ``ip_address`` and
-    ``phone_number``). So this is a separate builder rather than reusing
-    :func:`build_required_attributes`.
+    Falsy values (``None`` / ``""``) are dropped so callers can pass a wide
+    mapping with optional fields left unset. Each emitted attribute carries
+    ``date_from=date_start`` and an explicit ``date_to: None`` (open period),
+    matching :func:`build_required_attributes` and the ``/entities``
+    endpoint's required-present-field expectation.
 
-    ``ip_address`` is required (it's the operationally important field — the
-    address the scheduler/probe reaches the station through). ``phone_number``
-    is optional and omitted from the list when not given.
-
-    Each attribute carries an explicit ``date_to: None`` (open period), matching
-    :func:`build_required_attributes` and the ``/entities`` endpoint's
-    required-present-field expectation.
+    This is the generic builder underneath the typed telemetry builders; it is
+    also what backs the CLI's generic ``--attr code=value`` escape hatch.
 
     Args:
-        ip_address: The SIM's IP address (e.g. ``"10.4.1.225"``).
-        date_start: ISO-8601 date/datetime the SIM became active. Doubles as
-            ``date_from`` for the attribute periods.
-        phone_number: Optional MSISDN / phone number string.
+        mapping: ``{attribute_code: value}``. Insertion order is preserved in
+            the output (Python dicts are ordered), so callers control ordering.
+        date_start: ISO-8601 date/datetime; the ``date_from`` for every row.
 
     Returns:
         Attribute-dict list for :meth:`TOSWriter.create_device`.
     """
-    attrs: List[Dict[str, Optional[str]]] = [
-        {
-            "code": "ip_address",
-            "value": ip_address,
-            "date_from": date_start,
-            "date_to": None,
-        },
+    return [
+        {"code": code, "value": value, "date_from": date_start, "date_to": None}
+        for code, value in mapping.items()
+        if value
     ]
-    if phone_number:
-        attrs.append(
-            {
-                "code": "phone_number",
-                "value": phone_number,
-                "date_from": date_start,
-                "date_to": None,
-            }
-        )
-    return attrs
+
+
+def build_sim_card_attributes(
+    ip_address: str,
+    date_start: str,
+    phone_number: Optional[str] = None,
+    *,
+    serial_number: Optional[str] = None,
+    provider: Optional[str] = None,
+    model: Optional[str] = None,
+    owner: Optional[str] = None,
+    status: Optional[str] = "virkt",
+    comment: Optional[str] = None,
+    extra: Optional[Dict[str, Optional[str]]] = None,
+) -> List[Dict[str, Optional[str]]]:
+    """Build the attribute list for a ``sim_card`` device.
+
+    A ``sim_card`` does NOT use the canonical device shape — verified against
+    the live TOS schema (fleet scan 2026-06-06). ``ip_address`` is the only
+    required field (the address the scheduler/probe reaches the station
+    through); every other attribute in :data:`SIM_CARD_ATTR_CODES` is optional
+    and omitted when falsy.
+
+    ``status`` defaults to ``"virkt"`` (active) — the canonical "device is
+    alive" marker, matching :func:`build_required_attributes`. Pass
+    ``status=None`` to omit it.
+
+    ``extra`` is an escape hatch for any code not covered by the named
+    parameters (backs the CLI ``--attr code=value`` flag); it is merged last so
+    it can also override a named value.
+
+    Returns:
+        Attribute-dict list for :meth:`TOSWriter.create_device`.
+    """
+    mapping: Dict[str, Optional[str]] = {
+        "ip_address": ip_address,
+        "phone_number": phone_number,
+        "serial_number": serial_number,
+        "provider": provider,
+        "model": model,
+        "owner": owner,
+        "status": status,
+        "comment": comment,
+    }
+    if extra:
+        mapping.update(extra)
+    return attributes_from_mapping(mapping, date_start)
+
+
+def build_modem_gsm_attributes(
+    serial: str,
+    model: str,
+    owner: str,
+    date_start: str,
+    *,
+    status: Optional[str] = "virkt",
+    ip_address: Optional[str] = None,
+    phone_number: Optional[str] = None,
+    provider: Optional[str] = None,
+    mac_address: Optional[str] = None,
+    manufacturer: Optional[str] = None,
+    io_type: Optional[str] = None,
+    modem_subtype: Optional[str] = None,
+    comment: Optional[str] = None,
+    extra: Optional[Dict[str, Optional[str]]] = None,
+) -> List[Dict[str, Optional[str]]]:
+    """Build the attribute list for a ``modem_gsm`` (router/modem) device.
+
+    ``modem_gsm`` carries the canonical device core (serial/model/owner/
+    status/date_start) plus telemetry-specific optionals discovered by the
+    fleet scan (:data:`MODEM_GSM_ATTR_CODES`): ip_address, phone_number,
+    provider, mac_address, manufacturer, io_type, subtype, comment.
+
+    ``serial``, ``model``, ``owner`` are required (the device identity);
+    everything else is optional and omitted when falsy. ``status`` defaults to
+    ``"virkt"``. ``modem_subtype`` maps to the TOS ``subtype`` attribute (e.g.
+    ``"3G"``/``"4G"``) — named ``modem_subtype`` here to avoid colliding with
+    the entity ``code_entity_subtype``. ``extra`` is the override/escape hatch.
+
+    Returns:
+        Attribute-dict list for :meth:`TOSWriter.create_device`.
+    """
+    mapping: Dict[str, Optional[str]] = {
+        "serial_number": serial,
+        "model": model,
+        "owner": owner,
+        "status": status,
+        "ip_address": ip_address,
+        "phone_number": phone_number,
+        "provider": provider,
+        "mac_address": mac_address,
+        "manufacturer": manufacturer,
+        "io_type": io_type,
+        "subtype": modem_subtype,
+        "comment": comment,
+    }
+    if extra:
+        mapping.update(extra)
+    return attributes_from_mapping(mapping, date_start)
 
 
 def iter_optional_attributes(

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -16,6 +16,7 @@ from tostools.device import (
     REQUIRED_ATTR_CODES,
     VALID_SUBTYPES,
     build_required_attributes,
+    build_sim_card_attributes,
     iter_optional_attributes,
     normalize_date_start,
     validate_model,
@@ -270,7 +271,15 @@ def test_iter_optional_attributes_partial() -> None:
 
 
 def test_valid_subtypes_are_the_supported_ones() -> None:
-    assert set(VALID_SUBTYPES) == {"gnss_receiver", "antenna", "radome", "monument"}
+    assert set(VALID_SUBTYPES) == {
+        "gnss_receiver",
+        "antenna",
+        "radome",
+        "monument",
+        "modem_gsm",
+        "sim_card",
+        "router",
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -494,3 +503,58 @@ def test_device_main_requires_add_action() -> None:
     with pytest.raises(SystemExit) as exc:
         _device_main([])
     assert exc.value.code != 0
+
+
+# ---------------------------------------------------------------------------
+# Telemetry subtypes (modem_gsm / sim_card / router) + sim_card builder
+# ---------------------------------------------------------------------------
+
+
+def test_valid_subtypes_includes_telemetry() -> None:
+    for sub in ("modem_gsm", "sim_card", "router"):
+        assert sub in VALID_SUBTYPES
+
+
+def test_validate_model_modem_gsm_passthrough() -> None:
+    # Free-text vendor name, no IGS table — returned unchanged.
+    assert validate_model("modem_gsm", "Teltonika RUT200") == "Teltonika RUT200"
+
+
+def test_validate_model_sim_card_passthrough() -> None:
+    assert validate_model("sim_card", "anything") == "anything"
+
+
+def test_validate_model_router_passthrough() -> None:
+    assert validate_model("router", "Conel") == "Conel"
+
+
+def test_validate_model_telemetry_empty_raises() -> None:
+    # Empty model still rejected (the non-empty guard runs before the branch).
+    with pytest.raises(ValueError, match="--model is required"):
+        validate_model("modem_gsm", "")
+
+
+def test_build_sim_card_attributes_ip_only() -> None:
+    attrs = build_sim_card_attributes("10.4.1.225", "2026-06-06")
+    assert attrs == [
+        {
+            "code": "ip_address",
+            "value": "10.4.1.225",
+            "date_from": "2026-06-06",
+            "date_to": None,
+        }
+    ]
+
+
+def test_build_sim_card_attributes_with_phone() -> None:
+    attrs = build_sim_card_attributes("10.4.1.225", "2026-06-06", "8400754")
+    codes = [a["code"] for a in attrs]
+    assert codes == ["ip_address", "phone_number"]
+    phone = next(a for a in attrs if a["code"] == "phone_number")
+    assert phone["value"] == "8400754"
+    assert phone["date_to"] is None
+
+
+def test_build_sim_card_attributes_omits_blank_phone() -> None:
+    # Falsy phone (None or "") is dropped, not written as empty.
+    assert len(build_sim_card_attributes("10.4.1.225", "2026-06-06", "")) == 1

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -15,6 +15,8 @@ from tostools.device import (
     OPTIONAL_ATTR_CODES,
     REQUIRED_ATTR_CODES,
     VALID_SUBTYPES,
+    attributes_from_mapping,
+    build_modem_gsm_attributes,
     build_required_attributes,
     build_sim_card_attributes,
     iter_optional_attributes,
@@ -535,21 +537,25 @@ def test_validate_model_telemetry_empty_raises() -> None:
 
 
 def test_build_sim_card_attributes_ip_only() -> None:
+    # ip_address (required) + status default "virkt"; all other codes omitted.
     attrs = build_sim_card_attributes("10.4.1.225", "2026-06-06")
-    assert attrs == [
-        {
-            "code": "ip_address",
-            "value": "10.4.1.225",
-            "date_from": "2026-06-06",
-            "date_to": None,
-        }
-    ]
+    by_code = {a["code"]: a for a in attrs}
+    assert set(by_code) == {"ip_address", "status"}
+    assert by_code["ip_address"]["value"] == "10.4.1.225"
+    assert by_code["ip_address"]["date_from"] == "2026-06-06"
+    assert by_code["ip_address"]["date_to"] is None
+    assert by_code["status"]["value"] == "virkt"
+
+
+def test_build_sim_card_attributes_status_none_omits() -> None:
+    codes = [a["code"] for a in build_sim_card_attributes("10.4.1.225", "x", status=None)]
+    assert codes == ["ip_address"]
 
 
 def test_build_sim_card_attributes_with_phone() -> None:
     attrs = build_sim_card_attributes("10.4.1.225", "2026-06-06", "8400754")
     codes = [a["code"] for a in attrs]
-    assert codes == ["ip_address", "phone_number"]
+    assert codes == ["ip_address", "phone_number", "status"]
     phone = next(a for a in attrs if a["code"] == "phone_number")
     assert phone["value"] == "8400754"
     assert phone["date_to"] is None
@@ -557,4 +563,85 @@ def test_build_sim_card_attributes_with_phone() -> None:
 
 def test_build_sim_card_attributes_omits_blank_phone() -> None:
     # Falsy phone (None or "") is dropped, not written as empty.
-    assert len(build_sim_card_attributes("10.4.1.225", "2026-06-06", "")) == 1
+    codes = [a["code"] for a in build_sim_card_attributes("10.4.1.225", "x", "")]
+    assert codes == ["ip_address", "status"]
+
+
+def test_build_sim_card_attributes_full_set() -> None:
+    attrs = build_sim_card_attributes(
+        "10.4.1.225",
+        "2026-06-06",
+        "8400754",
+        serial_number="89354010120801048520",
+        provider="Síminn",
+        model="sim kort",
+        owner="Jarðeðlismælihópur",
+        comment="note",
+        extra={"date_end": "2027-01-01"},
+    )
+    codes = {a["code"] for a in attrs}
+    assert codes == {
+        "ip_address",
+        "phone_number",
+        "serial_number",
+        "provider",
+        "model",
+        "owner",
+        "status",
+        "comment",
+        "date_end",
+    }
+
+
+def test_build_sim_card_extra_overrides_named() -> None:
+    # extra is merged last → can override a named value.
+    attrs = build_sim_card_attributes(
+        "10.4.1.225", "x", provider="Síminn", extra={"provider": "Nova"}
+    )
+    prov = next(a for a in attrs if a["code"] == "provider")
+    assert prov["value"] == "Nova"
+
+
+def test_build_modem_gsm_attributes_minimal() -> None:
+    attrs = build_modem_gsm_attributes("5347577", "Conel XR5i v2", "J", "2026-06-06")
+    codes = [a["code"] for a in attrs]
+    assert codes == ["serial_number", "model", "owner", "status"]
+    assert next(a for a in attrs if a["code"] == "status")["value"] == "virkt"
+
+
+def test_build_modem_gsm_attributes_full_set() -> None:
+    attrs = build_modem_gsm_attributes(
+        "5347577",
+        "Conel XR5i v2",
+        "Jarðeðlismælihópur",
+        "2026-06-06",
+        ip_address="157.157.24.132",
+        phone_number="8400754",
+        provider="Nova",
+        mac_address="00:0A:14:85:54:A0",
+        manufacturer="Conel",
+        io_type="Ethernet+RS232",
+        modem_subtype="4G",
+        comment="note",
+    )
+    codes = {a["code"] for a in attrs}
+    assert codes == {
+        "serial_number",
+        "model",
+        "owner",
+        "status",
+        "ip_address",
+        "phone_number",
+        "provider",
+        "mac_address",
+        "manufacturer",
+        "io_type",
+        "subtype",  # modem_subtype maps to TOS `subtype`
+        "comment",
+    }
+
+
+def test_attributes_from_mapping_drops_falsy() -> None:
+    attrs = attributes_from_mapping({"a": "1", "b": None, "c": "", "d": "4"}, "2026")
+    assert [a["code"] for a in attrs] == ["a", "d"]
+    assert all(a["date_from"] == "2026" and a["date_to"] is None for a in attrs)

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -537,25 +537,28 @@ def test_validate_model_telemetry_empty_raises() -> None:
 
 
 def test_build_sim_card_attributes_ip_only() -> None:
-    # ip_address (required) + status default "virkt"; all other codes omitted.
+    # ip_address (required) + status default "virkt" + date_start; rest omitted.
     attrs = build_sim_card_attributes("10.4.1.225", "2026-06-06")
     by_code = {a["code"]: a for a in attrs}
-    assert set(by_code) == {"ip_address", "status"}
+    assert set(by_code) == {"ip_address", "status", "date_start"}
     assert by_code["ip_address"]["value"] == "10.4.1.225"
     assert by_code["ip_address"]["date_from"] == "2026-06-06"
     assert by_code["ip_address"]["date_to"] is None
     assert by_code["status"]["value"] == "virkt"
+    assert by_code["date_start"]["value"] == "2026-06-06"
 
 
 def test_build_sim_card_attributes_status_none_omits() -> None:
-    codes = [a["code"] for a in build_sim_card_attributes("10.4.1.225", "x", status=None)]
-    assert codes == ["ip_address"]
+    codes = [
+        a["code"] for a in build_sim_card_attributes("10.4.1.225", "x", status=None)
+    ]
+    assert codes == ["ip_address", "date_start"]
 
 
 def test_build_sim_card_attributes_with_phone() -> None:
     attrs = build_sim_card_attributes("10.4.1.225", "2026-06-06", "8400754")
     codes = [a["code"] for a in attrs]
-    assert codes == ["ip_address", "phone_number", "status"]
+    assert codes == ["ip_address", "phone_number", "status", "date_start"]
     phone = next(a for a in attrs if a["code"] == "phone_number")
     assert phone["value"] == "8400754"
     assert phone["date_to"] is None
@@ -564,7 +567,7 @@ def test_build_sim_card_attributes_with_phone() -> None:
 def test_build_sim_card_attributes_omits_blank_phone() -> None:
     # Falsy phone (None or "") is dropped, not written as empty.
     codes = [a["code"] for a in build_sim_card_attributes("10.4.1.225", "x", "")]
-    assert codes == ["ip_address", "status"]
+    assert codes == ["ip_address", "status", "date_start"]
 
 
 def test_build_sim_card_attributes_full_set() -> None:
@@ -588,6 +591,7 @@ def test_build_sim_card_attributes_full_set() -> None:
         "model",
         "owner",
         "status",
+        "date_start",
         "comment",
         "date_end",
     }
@@ -605,8 +609,9 @@ def test_build_sim_card_extra_overrides_named() -> None:
 def test_build_modem_gsm_attributes_minimal() -> None:
     attrs = build_modem_gsm_attributes("5347577", "Conel XR5i v2", "J", "2026-06-06")
     codes = [a["code"] for a in attrs]
-    assert codes == ["serial_number", "model", "owner", "status"]
+    assert codes == ["serial_number", "model", "owner", "status", "date_start"]
     assert next(a for a in attrs if a["code"] == "status")["value"] == "virkt"
+    assert next(a for a in attrs if a["code"] == "date_start")["value"] == "2026-06-06"
 
 
 def test_build_modem_gsm_attributes_full_set() -> None:
@@ -630,6 +635,7 @@ def test_build_modem_gsm_attributes_full_set() -> None:
         "model",
         "owner",
         "status",
+        "date_start",
         "ip_address",
         "phone_number",
         "provider",

--- a/tests/test_tos_writer.py
+++ b/tests/test_tos_writer.py
@@ -2123,3 +2123,29 @@ def test_patch_contact_missing_contact_raises():
     with patch.object(w, "_request", return_value=None):
         with pytest.raises(ValueError, match="no contact"):
             w.patch_contact(99999, name="X")
+
+
+# ---------------------------------------------------------------------------
+# delete_maintenance
+# ---------------------------------------------------------------------------
+
+
+def test_delete_maintenance_hits_admin_endpoint():
+    w = _logged_in_writer(dry_run=False)
+    with patch.object(w, "_request", return_value=None) as mock_req:
+        w.delete_maintenance(5147)
+    mock_req.assert_called_once_with("DELETE", "/admin_maintenance_row/5147")
+
+
+def test_delete_maintenance_respects_dry_run():
+    w = _logged_in_writer(dry_run=True)
+    with patch.object(w, "_request") as mock_req:
+        mock_req.return_value = DryRunResult(
+            method="DELETE",
+            endpoint="/admin_maintenance_row/5147",
+            payload=None,
+        )
+        result = w.delete_maintenance(5147)
+    assert isinstance(result, DryRunResult)
+    assert result.method == "DELETE"
+    assert result.endpoint == "/admin_maintenance_row/5147"


### PR DESCRIPTION
Adds the TOS-side primitives that the `receivers cfg` telemetry verbs
(`replace-modem` / `replace-sim` / `visit --delete`) depend on.

## What's in here

**Telemetry device subtypes** (`device.py`)
- `modem_gsm`, `sim_card`, `router` added to `VALID_SUBTYPES`; `validate_model`
  pass-through for them (free-text vendor names, no IGS table — like `monument`).
- `build_modem_gsm_attributes(...)` — canonical core (serial/model/owner/status/
  **date_start**) + telemetry optionals (ip_address, phone_number, provider,
  mac_address, manufacturer, io_type, subtype, comment) + `extra=` escape hatch.
- `build_sim_card_attributes(...)` — `ip_address` required + optionals
  (phone_number, serial_number, provider, model, owner, status, **date_start**,
  comment) + `extra=`. (sim_card is NOT the canonical device shape — verified
  against the live fleet.)
- `attributes_from_mapping(...)` — generic `{code: value}` → attribute-list
  helper (drops falsy), backing both typed builders + the CLI `--attr` flag.
- `SIM_CARD_ATTR_CODES` / `MODEM_GSM_ATTR_CODES` vocab tuples.

**`delete_maintenance(id_maintenance)`** (`api/tos_writer.py`)
- `DELETE /admin_maintenance_row/{id}`, mirroring the singular `admin_*_row`
  convention of `delete_entity_connection` / `delete_attribute_value`.
- **Endpoint verified live** (HEDI vitjun 5516 deleted → HTTP 204).

## Verification
- Attribute vocabulary discovered by a fleet-wide TOS scan (B9 warehouse 641
  children + 226 deployed units across 194 stations).
- `build_*` builders confirmed live against GSIG's RUT241 telemetry.
- 171 device + writer tests pass; ruff clean.

## Notes
- `date_start` was initially omitted from the new builders → fixed in `a29d5f9`
  (new telemetry entities must carry it, matching the fleet convention +
  web-UI "Upphafsdagsetning").
- Admin-merge path as with prior tostools PRs (#27).

🤖 Generated with [Claude Code](https://claude.com/claude-code)