### PR TITLE
fix(tos): fleet contact-dates triage demotes ownership-transfer cases

### DIFF
--- a/data/triage/contact_dates_fleet_20260604.txt
+++ b/data/triage/contact_dates_fleet_20260604.txt
@@ -1,9 +1,10 @@
 # === tos fleet contact-dates — combined triage action file ===
-# Generated:  2026-06-04T07:55:16Z
+# Generated:  2026-06-06T20:46:32Z
 # Stations:   192 audited
 # Violations: 129 total
-#   HIGH (owner role, uncommented, ready to apply): 100
-#   LOW  (non-owner role, commented for review):    29
+#   HIGH     (owner, open, single — uncommented):   94
+#   TRANSFER (owner but closed / multi-owner):      6
+#   LOW      (non-owner role):                      29
 #
 # Each line backdates time_from to `start` (the station's
 # earliest_known / founding date), resolved at apply time.
@@ -12,8 +13,8 @@
 #   tos audit apply <file>          # dry-run preview
 #   tos audit apply <file> --apply  # commit writes
 
-# ── HIGH confidence: owner relationships (owner owned the station
-#    from founding, so `start` is the correct backdate) ──
+# ── HIGH confidence: owner relationships, open, sole owner of the
+#    station (owner owned it from founding → `start` is correct) ──
 # ARHO rel 4991 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
 ACTION 4233 patch-contact-relationship 4991 time_from start
 # BALD rel 4994 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
@@ -54,10 +55,6 @@ ACTION 4300 patch-contact-relationship 5007 time_from start
 ACTION 4302 patch-contact-relationship 5009 time_from start
 # GRAN rel 5008 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
 ACTION 4306 patch-contact-relationship 5008 time_from start
-# GRIV rel 5087 'Jarðvísindastofnun Háskóla Íslands' role=owner  (per_time_from=2025-02-05T11:19:42)
-ACTION 19943 patch-contact-relationship 5087 time_from start
-# GRIV rel 5132 'Veðurstofa Íslands' role=owner  (per_time_from=2025-09-08T13:40:51)
-ACTION 19943 patch-contact-relationship 5132 time_from start
 # GRVA rel 5010 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
 ACTION 4310 patch-contact-relationship 5010 time_from start
 # HAFC rel 5011 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
@@ -128,10 +125,6 @@ ACTION 4446 patch-contact-relationship 5041 time_from start
 ACTION 4380 patch-contact-relationship 5042 time_from start
 # NAMC rel 5043 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
 ACTION 18401 patch-contact-relationship 5043 time_from start
-# NBIO rel 5045 'Jarðvísindastofnun Háskóla Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
-ACTION 19961 patch-contact-relationship 5045 time_from start
-# NBIO rel 5135 'Veðurstofa Íslands' role=owner  (per_time_from=2025-09-08T15:17:05)
-ACTION 19961 patch-contact-relationship 5135 time_from start
 # NORS rel 5046 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
 ACTION 4364 patch-contact-relationship 5046 time_from start
 # NVEL rel 5044 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-04T15:32:38)
@@ -200,10 +193,6 @@ ACTION 4418 patch-contact-relationship 5076 time_from start
 ACTION 16081 patch-contact-relationship 5078 time_from start
 # SVIN rel 5079 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-05T11:19:42)
 ACTION 16082 patch-contact-relationship 5079 time_from start
-# THNA rel 5084 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-05T11:19:42)
-ACTION 20089 patch-contact-relationship 5084 time_from start
-# THNA rel 5085 'Jarðvísindastofnun Háskóla Íslands' role=owner  (per_time_from=2025-02-05T11:19:42)
-ACTION 20089 patch-contact-relationship 5085 time_from start
 # THOB rel 5083 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-05T11:19:42)
 ACTION 16803 patch-contact-relationship 5083 time_from start
 # URHC rel 5080 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-05T11:19:42)
@@ -214,6 +203,24 @@ ACTION 19803 patch-contact-relationship 4536 time_from start
 ACTION 18406 patch-contact-relationship 5081 time_from start
 # VOGS rel 5082 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-05T11:19:42)
 ACTION 4432 patch-contact-relationship 5082 time_from start
+
+# ── TRANSFER / multi-owner: owner relationships that are CLOSED or
+#    share the station with another flagged owner. The current
+#    owner's time_from is often the real TRANSFER date, not
+#    founding — backdating blindly overlaps periods / erases the
+#    transfer. REVIEW each station's owner history first ──
+# GRIV rel 5087 'Jarðvísindastofnun Háskóla Íslands' role=owner  (per_time_from=2025-02-05T11:19:42 → 2025-09-08T14:17:45)
+#ACTION 19943 patch-contact-relationship 5087 time_from start
+# GRIV rel 5132 'Veðurstofa Íslands' role=owner  (per_time_from=2025-09-08T13:40:51)
+#ACTION 19943 patch-contact-relationship 5132 time_from start
+# NBIO rel 5045 'Jarðvísindastofnun Háskóla Íslands' role=owner  (per_time_from=2025-02-04T15:32:38 → 2025-09-08T15:19:43)
+#ACTION 19961 patch-contact-relationship 5045 time_from start
+# NBIO rel 5135 'Veðurstofa Íslands' role=owner  (per_time_from=2025-09-08T15:17:05)
+#ACTION 19961 patch-contact-relationship 5135 time_from start
+# THNA rel 5084 'Veðurstofa Íslands' role=owner  (per_time_from=2025-02-05T11:19:42 → 2025-02-05T11:42:38)
+#ACTION 20089 patch-contact-relationship 5084 time_from start
+# THNA rel 5085 'Jarðvísindastofnun Háskóla Íslands' role=owner  (per_time_from=2025-02-05T11:19:42)
+#ACTION 20089 patch-contact-relationship 5085 time_from start
 
 # ── LOW confidence: non-owner roles (data_owner / operator /
 #    observer) may have a genuinely recent start date — REVIEW
@@ -254,23 +261,23 @@ ACTION 4432 patch-contact-relationship 5082 time_from start
 #ACTION 4366 patch-contact-relationship 5144 time_from start
 # RHOF rel 4961 'Veðurstofa Íslands' role=operator  (per_time_from=2024-08-14T09:30:16)
 #ACTION 4390 patch-contact-relationship 4961 time_from start
-# RHOF rel 4987 'Benedikt G. Ófeigsson' role=operator  (per_time_from=2024-11-07T13:19:27)
+# RHOF rel 4987 'Benedikt G. Ófeigsson' role=operator  (per_time_from=2024-11-07T13:19:27 → 2024-11-07T13:44:48)
 #ACTION 4390 patch-contact-relationship 4987 time_from start
 # SENG rel 5118 'Veðurstofa Íslands' role=data_owner  (per_time_from=2025-08-19T13:21:44)
 #ACTION 16818 patch-contact-relationship 5118 time_from start
 # SENG rel 5120 'Veðurstofa Íslands' role=operator  (per_time_from=2025-08-19T13:21:44)
 #ACTION 16818 patch-contact-relationship 5120 time_from start
-# SEY1 rel 5059 'Veðurstofa Íslands' role=observer  (per_time_from=2025-02-05T11:19:42)
+# SEY1 rel 5059 'Veðurstofa Íslands' role=observer  (per_time_from=2025-02-05T11:19:42 → 2025-02-05T11:24:48)
 #ACTION 18279 patch-contact-relationship 5059 time_from start
-# SEYD rel 5058 'Veðurstofa Íslands' role=observer  (per_time_from=2025-02-05T11:19:42)
+# SEYD rel 5058 'Veðurstofa Íslands' role=observer  (per_time_from=2025-02-05T11:19:42 → 2025-02-05T11:24:13)
 #ACTION 18277 patch-contact-relationship 5058 time_from start
 # SKSH rel 5121 'Veðurstofa Íslands' role=data_owner  (per_time_from=2025-08-19T13:40:57)
 #ACTION 16821 patch-contact-relationship 5121 time_from start
 # SKSH rel 5123 'Veðurstofa Íslands' role=operator  (per_time_from=2025-08-19T13:40:57)
 #ACTION 16821 patch-contact-relationship 5123 time_from start
-# STAN rel 5057 'Jarðvísindastofnun Háskóla Íslands' role=observer  (per_time_from=2025-02-05T11:19:42)
+# STAN rel 5057 'Jarðvísindastofnun Háskóla Íslands' role=observer  (per_time_from=2025-02-05T11:19:42 → 2025-02-05T11:22:52)
 #ACTION 20168 patch-contact-relationship 5057 time_from start
-# TORK rel 5126 'Veðurstofa Íslands' role=operator  (per_time_from=2025-08-28T11:52:49)
+# TORK rel 5126 'Veðurstofa Íslands' role=operator  (per_time_from=2025-08-28T11:52:49 → 2025-08-28T11:54:11)
 #ACTION 19419 patch-contact-relationship 5126 time_from start
 # TORK rel 5127 'Jarðvísindastofnun Háskóla Íslands' role=operator  (per_time_from=2025-08-28T11:52:49)
 #ACTION 19419 patch-contact-relationship 5127 time_from start

--- a/docs/architecture/contact-write-api.md
+++ b/docs/architecture/contact-write-api.md
@@ -207,8 +207,14 @@ uncommented (backdating to `start`/founding is always correct — the
 owner owned the station from founding regardless of which org);
 non-owner roles (data_owner / operator / observer) commented for review
 (they may have a genuinely recent start date). First fleet run
-(2026-06-04): 129 violations across 192 stations — 100 owner
-(ready-to-apply) + 29 non-owner (review). Provenance:
+(2026-06-04): 129 violations across 192 stations — **94 owner (ready-to-apply,
+uncommented) + 6 ownership-transfer (commented) + 29 non-owner
+(commented)**. The triage splits three ways: owner relationships that
+are CLOSED or share a station with another flagged owner are
+ownership-transfer histories (e.g. Jarðvísindastofnun → Veðurstofa on
+GRIV/NBIO/THNA) where the current owner's `time_from` is the real
+transfer date, not founding — backdating those blindly would overlap
+periods, so they're demoted to a commented REVIEW section. Provenance:
 `data/triage/contact_dates_fleet_20260604.txt`. In `fleet_ops.py`:
 `run_fleet_contact_dates` + `format_fleet_contact_dates_triage`.
 

--- a/src/tostools/audit_contact_dates.py
+++ b/src/tostools/audit_contact_dates.py
@@ -70,7 +70,9 @@ class ContactDateViolation:
     ``id_relationship`` is the ``id_contact_entity_relationship`` the
     ACTION targets, ``per_time_from`` is the suspect timestamp,
     ``contact_label`` is the contact's name/organization, ``role`` is
-    its role on the station.
+    its role on the station. ``per_time_to`` (None = open) lets the
+    fleet triage detect closed / transfer relationships, where a blanket
+    backdate-to-founding is unsafe.
     """
 
     id_relationship: int
@@ -78,6 +80,7 @@ class ContactDateViolation:
     contact_label: Optional[str]
     role: Optional[str]
     per_time_from: str
+    per_time_to: Optional[str] = None
 
 
 @dataclass(frozen=True)
@@ -286,6 +289,7 @@ def audit_station_contact_dates(
             contact_label=rel.get("name") or rel.get("organization"),
             role=rel.get("role"),
             per_time_from=str(per_time_from),
+            per_time_to=rel.get("per_time_to"),
         )
 
         supp_line = suppressions.get(id_relationship)

--- a/src/tostools/fleet_ops.py
+++ b/src/tostools/fleet_ops.py
@@ -687,37 +687,89 @@ def run_fleet_contact_dates(
 _HIGH_CONFIDENCE_CONTACT_ROLES = frozenset({"owner"})
 
 
+def _classify_contact_violation(
+    s: "FleetContactDatesStation",
+    v: "ContactDateViolation",
+    owner_counts: Dict[Optional[int], int],
+) -> str:
+    """Three-way confidence bucket for one flagged relationship.
+
+    * ``high``  — owner role, **open** (per_time_to is None), and the
+      ONLY flagged owner on its station. Backdating to ``start``
+      (founding) is unambiguously correct. Emitted uncommented.
+    * ``transfer`` — owner role but **closed** (per_time_to set) OR the
+      station has >1 flagged owner. These are ownership-transfer /
+      multi-owner histories where a blanket backdate-to-founding would
+      overlap periods or erase the transfer (e.g. Jarðvísindastofnun →
+      Veðurstofa). The *current* owner's time_from is often the real
+      transfer date, not founding. Emitted COMMENTED for review.
+    * ``low``   — non-owner role (data_owner / operator / observer);
+      may have a genuinely recent real start date. Emitted COMMENTED.
+    """
+    role = v.role or ""
+    if role not in _HIGH_CONFIDENCE_CONTACT_ROLES:
+        return "low"
+    if v.per_time_to is not None:
+        return "transfer"
+    if owner_counts.get(s.station_id, 0) > 1:
+        return "transfer"
+    return "high"
+
+
 def format_fleet_contact_dates_triage(
     summary: FleetContactDatesSummary,
 ) -> str:
     """Render a single combined triage file for the fleet sweep.
 
-    ``role == owner`` violations are emitted **uncommented** (backdating
-    to ``start`` is always correct — the owner owned the station from
-    founding). All other roles are emitted **commented** for operator
-    review (they may have genuinely recent start dates). Each line is a
-    ``patch-contact-relationship <id_rel> time_from start`` ACTION whose
-    ``id_entity`` slot is the station (so ``start`` resolves against the
-    station's earliest_known).
+    Three confidence buckets (see :func:`_classify_contact_violation`):
+
+    * **HIGH** (owner, open, single-owner-on-station) — emitted
+      **uncommented**: backdating to ``start``/founding is unambiguous.
+    * **TRANSFER** (owner but closed or multi-owner station) — emitted
+      **commented**: ownership-transfer histories where a blanket
+      backdate would overlap/erase periods. Needs operator review.
+    * **LOW** (non-owner roles) — emitted **commented** for review.
+
+    Each line is a ``patch-contact-relationship <id_rel> time_from
+    start`` ACTION whose ``id_entity`` slot is the station.
     """
-    high = [
-        (s, v)
-        for s, v in summary.all_violations
-        if (v.role or "") in _HIGH_CONFIDENCE_CONTACT_ROLES
-    ]
-    low = [
-        (s, v)
-        for s, v in summary.all_violations
-        if (v.role or "") not in _HIGH_CONFIDENCE_CONTACT_ROLES
-    ]
+    # Per-station count of flagged OWNER relationships — drives the
+    # multi-owner / transfer demotion.
+    owner_counts: Dict[Optional[int], int] = {}
+    for s, v in summary.all_violations:
+        if (v.role or "") in _HIGH_CONFIDENCE_CONTACT_ROLES:
+            owner_counts[s.station_id] = owner_counts.get(s.station_id, 0) + 1
+
+    high, transfer, low = [], [], []
+    for s, v in summary.all_violations:
+        bucket = _classify_contact_violation(s, v, owner_counts)
+        {"high": high, "transfer": transfer, "low": low}[bucket].append((s, v))
+
+    def _emit(items, *, commented: bool) -> None:
+        prefix = "#ACTION" if commented else "ACTION"
+        if not items:
+            lines.append("# (none)")
+            return
+        for s, v in sorted(items, key=lambda sv: (sv[0].marker, sv[1].id_relationship)):
+            label = f" {v.contact_label!r}" if v.contact_label else ""
+            to_note = f" → {v.per_time_to}" if v.per_time_to else ""
+            lines.append(
+                f"# {s.marker} rel {v.id_relationship}{label} role={v.role}"
+                f"  (per_time_from={v.per_time_from}{to_note})"
+            )
+            lines.append(
+                f"{prefix} {s.station_id} patch-contact-relationship "
+                f"{v.id_relationship} time_from start"
+            )
 
     lines: List[str] = []
     lines.append("# === tos fleet contact-dates — combined triage action file ===")
     lines.append(f"# Generated:  {summary.generated_at}")
     lines.append(f"# Stations:   {summary.stations_audited} audited")
     lines.append(f"# Violations: {summary.total_violations} total")
-    lines.append(f"#   HIGH (owner role, uncommented, ready to apply): {len(high)}")
-    lines.append(f"#   LOW  (non-owner role, commented for review):    {len(low)}")
+    lines.append(f"#   HIGH     (owner, open, single — uncommented):   {len(high)}")
+    lines.append(f"#   TRANSFER (owner but closed / multi-owner):      {len(transfer)}")
+    lines.append(f"#   LOW      (non-owner role):                      {len(low)}")
     lines.append("#")
     lines.append("# Each line backdates time_from to `start` (the station's")
     lines.append("# earliest_known / founding date), resolved at apply time.")
@@ -727,37 +779,23 @@ def format_fleet_contact_dates_triage(
     lines.append("#   tos audit apply <file> --apply  # commit writes")
     lines.append("")
 
-    lines.append("# ── HIGH confidence: owner relationships (owner owned the station")
-    lines.append("#    from founding, so `start` is the correct backdate) ──")
-    if not high:
-        lines.append("# (none)")
-    for s, v in sorted(high, key=lambda sv: (sv[0].marker, sv[1].id_relationship)):
-        label = f" {v.contact_label!r}" if v.contact_label else ""
-        lines.append(
-            f"# {s.marker} rel {v.id_relationship}{label} role={v.role}"
-            f"  (per_time_from={v.per_time_from})"
-        )
-        lines.append(
-            f"ACTION {s.station_id} patch-contact-relationship "
-            f"{v.id_relationship} time_from start"
-        )
+    lines.append("# ── HIGH confidence: owner relationships, open, sole owner of the")
+    lines.append("#    station (owner owned it from founding → `start` is correct) ──")
+    _emit(high, commented=False)
+    lines.append("")
+
+    lines.append("# ── TRANSFER / multi-owner: owner relationships that are CLOSED or")
+    lines.append("#    share the station with another flagged owner. The current")
+    lines.append("#    owner's time_from is often the real TRANSFER date, not")
+    lines.append("#    founding — backdating blindly overlaps periods / erases the")
+    lines.append("#    transfer. REVIEW each station's owner history first ──")
+    _emit(transfer, commented=True)
     lines.append("")
 
     lines.append("# ── LOW confidence: non-owner roles (data_owner / operator /")
     lines.append("#    observer) may have a genuinely recent start date — REVIEW")
     lines.append("#    each before uncommenting ──")
-    if not low:
-        lines.append("# (none)")
-    for s, v in sorted(low, key=lambda sv: (sv[0].marker, sv[1].id_relationship)):
-        label = f" {v.contact_label!r}" if v.contact_label else ""
-        lines.append(
-            f"# {s.marker} rel {v.id_relationship}{label} role={v.role}"
-            f"  (per_time_from={v.per_time_from})"
-        )
-        lines.append(
-            f"#ACTION {s.station_id} patch-contact-relationship "
-            f"{v.id_relationship} time_from start"
-        )
+    _emit(low, commented=True)
     lines.append("")
     return "\n".join(lines)
 
@@ -809,6 +847,7 @@ def fleet_contact_dates_to_dict(summary: FleetContactDatesSummary) -> Dict[str, 
                 "contact_label": v.contact_label,
                 "role": v.role,
                 "per_time_from": v.per_time_from,
+                "per_time_to": v.per_time_to,
             }
             for s, v in summary.all_violations
         ],

--- a/tests/test_fleet_ops.py
+++ b/tests/test_fleet_ops.py
@@ -608,6 +608,21 @@ def _cd_violation(id_rel, role, per_time_from, *, id_contact=1256, label="VÍ"):
     )
 
 
+def _cd_violation_to(
+    id_rel, role, per_time_from, per_time_to, *, id_contact=1256, label="VÍ"
+):
+    from tostools.audit_contact_dates import ContactDateViolation
+
+    return ContactDateViolation(
+        id_relationship=id_rel,
+        id_contact=id_contact,
+        contact_label=label,
+        role=role,
+        per_time_from=per_time_from,
+        per_time_to=per_time_to,
+    )
+
+
 def test_run_fleet_contact_dates_aggregates():
     from tostools.fleet_ops import run_fleet_contact_dates
 
@@ -690,8 +705,8 @@ def test_fleet_contact_dates_triage_splits_owner_vs_other():
     # Operator line is commented.
     assert "#ACTION 4390 patch-contact-relationship 4961 time_from start" in out
     # Header tallies.
-    assert "HIGH (owner role, uncommented, ready to apply): 1" in out
-    assert "LOW  (non-owner role, commented for review):    1" in out
+    assert "HIGH     (owner, open, single — uncommented):   1" in out
+    assert "LOW      (non-owner role):                      1" in out
 
 
 def test_fleet_contact_dates_to_dict_shape():
@@ -738,3 +753,120 @@ def test_cli_fleet_contact_dates_triage(tmp_path, capsys):
     assert rc == 1  # violations present
     content = out_path.read_text()
     assert "ACTION 4440 patch-contact-relationship 5052 time_from start" in content
+
+
+def test_fleet_contact_dates_triage_demotes_transfer_and_multiowner():
+    """Owner relationships that are CLOSED or share a station with
+    another flagged owner are ownership-transfer cases — they must be
+    COMMENTED (not auto-applied), because the current owner's time_from
+    is often the real transfer date, not founding. Regression for the
+    GRIV/NBIO/THNA bug found reviewing PR #46."""
+    from tostools.fleet_ops import (
+        FleetContactDatesStation,
+        FleetContactDatesSummary,
+        format_fleet_contact_dates_triage,
+    )
+
+    summary = FleetContactDatesSummary(generated_at=FROZEN_TS)
+    summary.stations = [
+        # Single open owner → HIGH (uncommented).
+        FleetContactDatesStation(
+            marker="SAVI",
+            station_id=4440,
+            violations=[_cd_violation(5052, "owner", "2025-02-04T15:32:38")],
+        ),
+        # Transfer: closed old owner + open current owner → both COMMENTED.
+        FleetContactDatesStation(
+            marker="NBIO",
+            station_id=19961,
+            violations=[
+                _cd_violation_to(
+                    5045, "owner", "2025-02-04T15:32:38", "2025-09-08T15:19:43"
+                ),
+                _cd_violation(
+                    5135, "owner", "2025-09-08T15:17:05"
+                ),  # open current owner
+            ],
+        ),
+    ]
+    out = format_fleet_contact_dates_triage(summary)
+
+    # SAVI single open owner stays uncommented.
+    assert "\nACTION 4440 patch-contact-relationship 5052 time_from start" in out
+    # Both NBIO owners demoted to commented (multi-owner / transfer).
+    assert "#ACTION 19961 patch-contact-relationship 5045 time_from start" in out
+    assert "#ACTION 19961 patch-contact-relationship 5135 time_from start" in out
+    # The open current owner (5135) must NOT appear uncommented.
+    assert "\nACTION 19961 patch-contact-relationship 5135" not in out
+    # Header tallies: 1 HIGH, 2 TRANSFER, 0 LOW.
+    assert "HIGH     (owner, open, single — uncommented):   1" in out
+    assert "TRANSFER (owner but closed / multi-owner):      2" in out
+
+
+def test_fleet_contact_dates_triage_closed_single_owner_demoted():
+    """Even a SOLE owner relationship that is closed (per_time_to set)
+    is demoted — a closed owner is part of a history, not the simple
+    'owned from founding to now' case."""
+    from tostools.fleet_ops import (
+        FleetContactDatesStation,
+        FleetContactDatesSummary,
+        format_fleet_contact_dates_triage,
+    )
+
+    summary = FleetContactDatesSummary(generated_at=FROZEN_TS)
+    summary.stations = [
+        FleetContactDatesStation(
+            marker="XXXX",
+            station_id=9999,
+            violations=[
+                _cd_violation_to(
+                    7001, "owner", "2025-02-04T15:32:38", "2025-06-01T00:00:00"
+                )
+            ],
+        ),
+    ]
+    out = format_fleet_contact_dates_triage(summary)
+    assert "#ACTION 9999 patch-contact-relationship 7001 time_from start" in out
+    assert "\nACTION 9999 patch-contact-relationship 7001" not in out
+    assert "TRANSFER (owner but closed / multi-owner):      1" in out
+
+
+def test_contact_date_violation_carries_per_time_to():
+    """audit_station_contact_dates must populate per_time_to so the
+    fleet triage can detect closed/transfer relationships."""
+    from tostools.api.tos_client import TOSClient
+    from tostools.audit_contact_dates import audit_station_contact_dates
+
+    contacts = [
+        {
+            "id_contact_entity_relationship": 5045,
+            "id_contact": 2489,
+            "name": "Jarðvísindastofnun",
+            "role": "owner",
+            "per_time_from": "2025-02-04T15:32:38",
+            "per_time_to": "2025-09-08T15:19:43",
+        }
+    ]
+    with (
+        patch.object(
+            TOSClient,
+            "basic_search",
+            return_value=[
+                {
+                    "code": "marker",
+                    "distance": 0,
+                    "value_varchar": "nbio",
+                    "type_lvl_two": "stöð",
+                    "id_entity": 19961,
+                }
+            ],
+        ),
+        patch.object(
+            TOSClient,
+            "get_entity_history",
+            return_value={"id_entity": 19961, "attributes": []},
+        ),
+        patch.object(TOSClient, "get_contacts", return_value=contacts),
+    ):
+        report = audit_station_contact_dates(TOSClient(), name="NBIO")
+    assert report.violations[0].per_time_to == "2025-09-08T15:19:43"


### PR DESCRIPTION
Code review of #46 caught an **apply-blocking bug** before the 100-owner backdate ran. Fixing it.

## The bug
The fleet triage emitter uncommented **every** owner-role relationship on the rule "the owner owned the station from founding, so backdating `time_from` to `start` is always safe." That's false for **ownership-transfer / multi-owner** stations.

Found on **GRIV (19943), NBIO (19961), THNA (20089)** — each has:
- an **old owner** relationship (closed, `per_time_to` set — e.g. Jarðvísindastofnun Háskóla Íslands), and
- a **current owner** (open — Veðurstofa) whose `time_from` is the real **transfer date**, not founding.

```
NBIO: 5045 Jarð  2025-02-04 → 2025-09-08   (closed)
      5135 VÍ    2025-09-08 → open         (← real transfer date, NOT founding)
```
Backdating the current owner (5135) to founding overlaps the prior period and **erases the transfer**. The #46 dry-run said "100 ok" because the PUTs succeed mechanically — it can't see the semantic overlap. Only a review catches this.

## The fix
- `ContactDateViolation` gains `per_time_to` (None = open), populated from the relationship row.
- `_classify_contact_violation` — three-way split:

| Bucket | Rule | Emitted |
|---|---|---|
| **HIGH** | owner, open, sole flagged owner on station | uncommented |
| **TRANSFER** | owner but closed OR station has >1 flagged owner | **commented** (REVIEW) |
| **LOW** | non-owner role | commented |

New "TRANSFER / multi-owner" section in the triage with a review note + `per_time_to` shown inline.

## Regenerated triage
`data/triage/contact_dates_fleet_20260604.txt`: **94 HIGH** (was 100) + **6 TRANSFER** (the GRIV/NBIO/THNA pairs, now commented) + **29 LOW**. The 94 uncommented owner ACTIONs dry-run clean (0 failed).

## Tests (3 new)
Multi-owner/transfer demotion, closed-sole-owner demotion, `per_time_to` propagation. Updated the existing split test for the new header. 1002 tests pass, ruff + black clean.

## Effect on the held apply
The project-todo's "apply 100 owner backdates" is now **94** — and those 94 are genuinely safe. The 6 transfer relationships join the 29 non-owner ones in the commented review set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)