### PR TITLE
chore(triage): mark fleet contact-dates 94 owner backdates as applied

### DIFF
--- a/data/triage/contact_dates_fleet_20260604.txt
+++ b/data/triage/contact_dates_fleet_20260604.txt
@@ -1,4 +1,10 @@
 # === tos fleet contact-dates — combined triage action file ===
+# ✅ APPLIED 2026-06-06: the 94 uncommented (HIGH) owner backdates were
+#    committed to live TOS — `tos audit apply ... --apply` → 94 ok, 0 failed.
+#    Spot-checked + re-audited clean (SAVI/ARHO/BUDH). The 6 TRANSFER +
+#    29 LOW lines below remain COMMENTED for operator review.
+#    Rollback any line: tos contact patch-relationship <id_rel> \
+#      --time-from "<orig_ts>" --no-dry-run   (originals in comments).
 # Generated:  2026-06-06T20:46:32Z
 # Stations:   192 audited
 # Violations: 129 total


### PR DESCRIPTION
Provenance: records that the 94 owner backdates in `data/triage/contact_dates_fleet_20260604.txt` were committed to live TOS on 2026-06-06.

`tos audit apply data/triage/contact_dates_fleet_20260604.txt --apply` → **94 ok, 0 failed**. Each backdated a contact↔station owner relationship's `time_from` from its TOS-migration timestamp to the station's founding (`start` token).

**Verified post-apply:**
- Raw rows: 5052→2007-08-08, 5082→1999-03-17, 4998→2023-12-10 (all founding dates, midnight)
- Re-audit: SAVI / ARHO / BUDH now CLEAN
- Transfer station NBIO correctly still flags (its 2 owner rels stay commented)

The 6 TRANSFER + 29 LOW lines remain COMMENTED for operator review. The applied-marker in the file header gives the git audit trail (TOS has no `created_at`).

Docs-only / provenance — no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)