### PR TITLE
fix(writer): patch_attribute_value resilient to the public-endpoint 401 quirk

### DIFF
--- a/src/tostools/api/tos_writer.py
+++ b/src/tostools/api/tos_writer.py
@@ -1018,6 +1018,15 @@ class TOSWriter:
         """Modify an existing attribute value by its primary key.
 
         Only fields that are not None are included in the PATCH body.
+
+        Resilient to a known TOS quirk: the public ``/attribute_value/{id}``
+        endpoint intermittently returns ``401 "User provided an invalid token"``
+        even with a valid JWT — and sometimes does so *after* committing the
+        write (observed on the live API, e.g. a fw-version transition that
+        landed despite the 401). On a 401 we therefore re-read the row via
+        ``GET /attribute_value/{id}`` and, if the change is already present,
+        treat the write as committed instead of raising a false failure. A 401
+        where the change did *not* land is re-raised as a genuine error.
         """
         body: Dict[str, Any] = {}
         if value is not None:
@@ -1030,9 +1039,30 @@ class TOSWriter:
             raise ValueError(
                 "patch_attribute_value: at least one field must be provided"
             )
-        return self._request(
-            "PATCH", f"/attribute_value/{id_attribute_value}", data=body
-        )
+        try:
+            return self._request(
+                "PATCH", f"/attribute_value/{id_attribute_value}", data=body
+            )
+        except requests.HTTPError as exc:
+            resp = getattr(exc, "response", None)
+            if resp is None or resp.status_code != 401:
+                raise
+            # Re-read and check whether the PATCH actually landed despite the 401.
+            try:
+                row = self._request("GET", f"/attribute_value/{id_attribute_value}")
+            except Exception:  # noqa: BLE001 — re-read failed; surface original 401
+                raise exc from None
+            if isinstance(row, dict) and all(
+                str(row.get(k)) == str(v) for k, v in body.items()
+            ):
+                self._logger.warning(
+                    "PATCH /attribute_value/%s returned 401 but the change is "
+                    "present on re-read — treating as committed (known TOS "
+                    "public-endpoint quirk).",
+                    id_attribute_value,
+                )
+                return row
+            raise exc from None
 
     def upsert_attribute_value(
         self,
@@ -1882,7 +1912,7 @@ class TOSWriter:
         new_id = created.get("id") if isinstance(created, dict) else None
         if new_id is None:
             raise RuntimeError(
-                f"add_maintenance_visit: POST returned no id; got " f"{created!r}"
+                f"add_maintenance_visit: POST returned no id; got {created!r}"
             )
         new_id = int(new_id)
 

--- a/tests/test_tos_writer.py
+++ b/tests/test_tos_writer.py
@@ -10,6 +10,7 @@ from typing import List, Optional
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 
 from tostools.api.tos_writer import (
     DryRunResult,
@@ -594,6 +595,58 @@ def test_patch_attribute_value_raises_with_no_fields():
     w = _logged_in_writer()
     with pytest.raises(ValueError, match="at least one field"):
         w.patch_attribute_value(42)
+
+
+def _http_401() -> "requests.HTTPError":
+    resp = MagicMock()
+    resp.status_code = 401
+    return requests.HTTPError(response=resp)
+
+
+def test_patch_attribute_value_success_no_reread():
+    """Happy path: a 2xx PATCH returns directly, no re-read."""
+    w = _logged_in_writer(dry_run=False)
+    with patch.object(w, "_request", return_value={"ok": True}) as mock_req:
+        out = w.patch_attribute_value(143503, value="5.7.0")
+    assert out == {"ok": True}
+    assert mock_req.call_count == 1
+    assert mock_req.call_args.args[0] == "PATCH"
+
+
+def test_patch_attribute_value_401_but_committed_is_success():
+    """Known quirk: 401 returned but the change landed → re-read confirms → success."""
+    w = _logged_in_writer(dry_run=False)
+    row = {
+        "id_attribute_value": 143503,
+        "value": "5.5.0",
+        "date_to": "2026-06-08T00:00:00",
+    }
+    with patch.object(w, "_request", side_effect=[_http_401(), row]) as mock_req:
+        out = w.patch_attribute_value(143503, date_to="2026-06-08")
+    assert out == row  # treated as committed, not a failure
+    assert mock_req.call_args_list[0].args[0] == "PATCH"
+    assert mock_req.call_args_list[1].args[0] == "GET"
+
+
+def test_patch_attribute_value_401_not_committed_reraises():
+    """401 where the re-read shows the change did NOT land → genuine failure."""
+    w = _logged_in_writer(dry_run=False)
+    row = {"id_attribute_value": 143503, "value": "5.5.0", "date_to": None}
+    with patch.object(w, "_request", side_effect=[_http_401(), row]):
+        with pytest.raises(requests.HTTPError):
+            w.patch_attribute_value(143503, date_to="2026-06-08")
+
+
+def test_patch_attribute_value_non_401_reraised_without_reread():
+    """A non-401 HTTP error is re-raised immediately (no re-read)."""
+    w = _logged_in_writer(dry_run=False)
+    resp = MagicMock()
+    resp.status_code = 500
+    err = requests.HTTPError(response=resp)
+    with patch.object(w, "_request", side_effect=err) as mock_req:
+        with pytest.raises(requests.HTTPError):
+            w.patch_attribute_value(143503, value="x")
+    assert mock_req.call_count == 1  # PATCH only, no GET re-read
 
 
 def test_patch_entity_connection_raises_with_no_kwargs():


### PR DESCRIPTION
## Problem

TOS's public `/attribute_value/{id}` **PATCH** endpoint intermittently returns `401 "User provided an invalid token"` even with a valid JWT — and **sometimes after committing the write**. Confirmed live this week: a `firmware_version` transition on a deployed receiver set the old period's `date_to` *despite* the PATCH returning 401, so `update-device --change` reported a scary failure on a write that had actually landed. It also bites `correct-date` and any attribute correction.

This is the same family as the public-endpoint 401 that `add_attribute_value` (PR #25) and `delete_attribute_value` already route around via the admin endpoint — but `patch_attribute_value` was still on the public path.

## Fix

`patch_attribute_value` now, on a 401:
1. re-reads the row via `GET /attribute_value/{id}` (the read works fine), and
2. compares the intended fields. If the change is already present → treat as **committed**, return the row. If not → **re-raise** the original 401 (genuine failure).

Non-401 errors are re-raised immediately, with no re-read.

### Why verify-on-read instead of an admin-PATCH fallback

The admin row endpoint uses a **different schema** (`value_varchar`, `id_attribute`) than the public PATCH body (`value`, `date_from`, `date_to`), and whether it accepts PATCH is undocumented. `GET /attribute_value/{id}` returns the public schema and works reliably, so verify-on-read is the lower-risk fix and also correctly distinguishes *committed-despite-401* from *genuinely-failed* (the admin fallback couldn't).

## Tests

4 new unit tests (mocked `_request`): 2xx → no re-read; 401-but-committed → success; 401-not-committed → re-raise; non-401 → immediate re-raise. Full `test_tos_writer.py` (123) passes; ruff clean.

## Deploy note

After merge: tag a release and bump the `tostools` pin in `receivers`' pyproject to pick it up on rek-d01. Once in, the resilient-write workaround added to `receivers cfg update-device` (#92) becomes a redundant safety net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)