### PR TITLE
feat(tos): station onboarding — `tos location add` + `tos station add` + shared-power W1

### DIFF
--- a/data/attribute_codes.yaml
+++ b/data/attribute_codes.yaml
@@ -1523,10 +1523,10 @@ locations:
     icelandic_label: Nafn
     description: Location name
     classification: inherent
-    tos_required_for: [staðsetning]
-    gps_required_for: [staðsetning] # USER FILLS IN — strict superset of tos
+    tos_required_for: [land]
+    gps_required_for: [land] # USER FILLS IN — strict superset of tos
     default_value: ~ # USER OPTIONAL — what TOS records as the default
-    applies_to: [staðsetning]
+    applies_to: [land]
     gps_relevance: "yes"
     walked: false
     why: ""
@@ -1535,10 +1535,10 @@ locations:
     icelandic_label: Breiddargráða
     description: Latitude (decimal degrees)
     classification: inherent
-    tos_required_for: [staðsetning]
-    gps_required_for: [staðsetning] # USER FILLS IN — strict superset of tos
+    tos_required_for: [land]
+    gps_required_for: [land] # USER FILLS IN — strict superset of tos
     default_value: ~ # USER OPTIONAL — what TOS records as the default
-    applies_to: [staðsetning]
+    applies_to: [land]
     gps_relevance: "yes"
     walked: false
     why: ""
@@ -1547,10 +1547,10 @@ locations:
     icelandic_label: Lengdargráða
     description: Longitude (decimal degrees)
     classification: inherent
-    tos_required_for: [staðsetning]
-    gps_required_for: [staðsetning] # USER FILLS IN — strict superset of tos
+    tos_required_for: [land]
+    gps_required_for: [land] # USER FILLS IN — strict superset of tos
     default_value: ~ # USER OPTIONAL — what TOS records as the default
-    applies_to: [staðsetning]
+    applies_to: [land]
     gps_relevance: "yes"
     walked: false
     why: ""
@@ -1559,10 +1559,10 @@ locations:
     icelandic_label: Hæð
     description: Altitude above sea level (m)
     classification: inherent
-    tos_required_for: [staðsetning]
-    gps_required_for: [staðsetning] # USER FILLS IN — strict superset of tos
+    tos_required_for: [land]
+    gps_required_for: [land] # USER FILLS IN — strict superset of tos
     default_value: ~ # USER OPTIONAL — what TOS records as the default
-    applies_to: [staðsetning]
+    applies_to: [land]
     gps_relevance: "yes"
     walked: false
     why: ""
@@ -1574,7 +1574,7 @@ locations:
     tos_required_for: []
     gps_required_for: [] # USER FILLS IN — strict superset of tos
     default_value: ~ # USER OPTIONAL — what TOS records as the default
-    applies_to: [staðsetning]
+    applies_to: [land]
     gps_relevance: "no"
     walked: false
     why: ""
@@ -1586,7 +1586,7 @@ locations:
     tos_required_for: []
     gps_required_for: [] # USER FILLS IN — strict superset of tos
     default_value: ~ # USER OPTIONAL — what TOS records as the default
-    applies_to: [staðsetning]
+    applies_to: [land]
     gps_relevance: "no"
     walked: false
     why: ""
@@ -1598,7 +1598,7 @@ locations:
     tos_required_for: []
     gps_required_for: [] # USER FILLS IN — strict superset of tos
     default_value: ~ # USER OPTIONAL — what TOS records as the default
-    applies_to: [staðsetning]
+    applies_to: [land]
     gps_relevance: "yes"
     walked: false
     why: ""
@@ -1610,7 +1610,7 @@ locations:
     tos_required_for: []
     gps_required_for: [] # USER FILLS IN — strict superset of tos
     default_value: ~ # USER OPTIONAL — what TOS records as the default
-    applies_to: [staðsetning]
+    applies_to: [land]
     gps_relevance: "maybe"
     walked: false
     why: ""

--- a/docs/architecture/shared-power-model.md
+++ b/docs/architecture/shared-power-model.md
@@ -59,7 +59,7 @@ a dedicated source entity, or implicit in which power devices hang off the site.
 
 Ordered cheapest-/least-risky first. Only W1 is near-term; W3 is the heavy one.
 
-### W1 — Surface existing site power (Q2a) — read-only, near-term
+### W1 — Surface existing site power (Q2a) — ✅ IMPLEMENTED 2026-06-08
 
 Extend the reuse view already built in `tos location add` (and the future
 `tos station add`) so that when a site is found/reused, the operator sees the
@@ -77,12 +77,18 @@ Location 'Héðinshöfði' already exists (id_entity=4315) — reusing.
   (none on the site itself yet — see shared-power-model.md)
 ```
 
-Implementation: a helper next to `summarize_location_children` —
-`summarize_site_power(client, land_id)` — that walks the site's `land`
-children + each colocated station's children, filters to the power-device
-subtype set, and returns `{id_entity, subtype, on_station, open}`. Pure read;
-reuses `open_attribute`. Pin in `tests/test_location_add.py` /
-`tests/test_*power*`.
+Implemented as `tostools.power.summarize_site_power(writer, land_id)` — walks
+the `land` children + each colocated station's children, filters to
+`POWER_DEVICE_SUBTYPES`, returns `{id_entity, subtype, model, serial,
+on_station, on_station_name, sensor_tied, time_from, open}` (site-direct power
+sorts first, then by station). Also handles power joined **directly** to the
+site (W3 target state) so it keeps working as power moves site-ward. Wired into
+the `tos location add` reuse view via `_print_site_power`; live-verified on
+Mjóaskarð (`land` 4360 — 9 power devices across the GPS + SIL + Endurvarpi
+stations surfaced with per-station attribution and a "don't duplicate"
+prompt). Pinned by `tests/test_power.py` (8) + `tests/test_location_add.py`
+site-power cases. `SENSOR_TIED_POWER_SUBTYPES` (`anemometer_power_pack`) is
+flagged in each row so the W2 audit can exclude instrument-private power.
 
 ### W2 — Audit invariant: colocated stations must share power (Q2b)
 

--- a/docs/architecture/shared-power-model.md
+++ b/docs/architecture/shared-power-model.md
@@ -1,0 +1,143 @@
+# Scope — shared-power model for colocated stations
+
+Status: **scoping** (design agreed 2026-06-08: power on the `land` site ·
+surface + audit now · kept separate from `tos station add`). Not implemented.
+
+Companion to `station-location-add.md` — that doc adds the `land` site + the
+station-under-site join; this one decides how **power** is represented across
+the stations that share a site.
+
+## 1. Problem
+
+Power is physically a **site-level** resource — colocated stations at one site
+draw from one supply — but TOS models it **per-station**, so each station
+carries its own battery / solar / power-pack devices. Two stations at the same
+site therefore look like two independent power systems when they are one.
+
+Operator-confirmed example: **HEDI**'s GPS (`geophysical` 4316) and SIL
+(`geophysical` 5442) both sit on `land` site 4315 and are *both fed from the
+nearby farm's mains* — one supply, modelled today as… nothing (HEDI has no
+power devices at all on either station or the site). The model can neither
+express "shared" nor even "present."
+
+## 2. Verified TOS facts (2026-06-08, read-only probes)
+
+- **`land` is the only site-level anchor.** Top-level (HEDI 4315 has no parent —
+  `parent_history` 404), hosts colocated stations as children. Carries
+  `name`/`lat`/`lon`/`altitude` only — **no power children today.**
+- **Deployed power attaches to a station.** Sampling active
+  `battery` / `solar_panel` / `power_pack` devices, open parents were
+  `geophysical` (35), `meteorological` (16), `hydrological` (2) — i.e. the
+  station entity, never the `land` site.
+- **`area` is the warehouse, not a site grouping.** The `area`-parented power
+  devices (19 in the sample) hang under `B9 - Kjallari - Jörð` (id 4) and
+  `B9 - Kjallari - Veður` (id 3), both `entity_type=warehouse` — these are
+  **stored/spare** units in B9, unrelated to deployment sites. (Corrects an
+  earlier guess that `area` was a shared-infrastructure anchor.)
+- **Power is a rich device family** (`GET /entity_subtypes/`, entity_type=device):
+  `battery`, `solar_panel`, `power_pack`, `charge_regulator`, `charger`,
+  `solar_charge_controller`, `ups`, `power_generator`, `switch_poe`,
+  `anemometer_power_pack`.
+
+**Conclusion:** there is no existing site-level power model to reuse —
+attaching power to `land` (the Q1a decision) is a new pattern, and aligning the
+fleet means reparenting the ~35+ deployed power devices from station → site.
+
+## 3. Decisions (locked 2026-06-08)
+
+| # | Decision | Choice |
+|---|----------|--------|
+| Q1 | Where shared power lives | **(a) On the `land` site.** Power devices attach to the site; colocated stations inherit one supply. New pattern (no `area`/warehouse reuse). |
+| Q2 | What the tooling does | **(a) Surface** existing site power (read-only awareness) **+ (b) Audit** invariant that colocated stations share power. |
+| Q3 | Scope boundary | **Separate** from `tos station add` — that verb stays station-shell + site-join; shared-power is this independent piece (it drags in a fleet-wide migration). |
+
+Open sub-decision deferred to design (see §6): how to represent the power
+**source** (the "farm" mains vs off-grid solar+battery) — a `land` attribute,
+a dedicated source entity, or implicit in which power devices hang off the site.
+
+## 4. Workstreams
+
+Ordered cheapest-/least-risky first. Only W1 is near-term; W3 is the heavy one.
+
+### W1 — Surface existing site power (Q2a) — read-only, near-term
+
+Extend the reuse view already built in `tos location add` (and the future
+`tos station add`) so that when a site is found/reused, the operator sees the
+power already present at the site, **aggregated across colocated stations**
+(since today it lives on the stations, not the site):
+
+```
+Location 'Héðinshöfði' already exists (id_entity=4315) — reusing.
+  Currently attached:
+    - GPS stöð   id=4316  …
+    - SIL stöð   id=5442  …
+  Site power (aggregated across colocated stations):
+    - battery      id=…  on SIL stöð (5442)   ← shared supply: don't add a duplicate
+    - solar_panel  id=…  on SIL stöð (5442)
+  (none on the site itself yet — see shared-power-model.md)
+```
+
+Implementation: a helper next to `summarize_location_children` —
+`summarize_site_power(client, land_id)` — that walks the site's `land`
+children + each colocated station's children, filters to the power-device
+subtype set, and returns `{id_entity, subtype, on_station, open}`. Pure read;
+reuses `open_attribute`. Pin in `tests/test_location_add.py` /
+`tests/test_*power*`.
+
+### W2 — Audit invariant: colocated stations must share power (Q2b)
+
+`tos audit shared-power <STN>` (and a fleet sweep) flags a site where
+colocated stations have:
+  * **separate/duplicate** power systems (each station its own battery+solar —
+    the duplication the requirement forbids), or
+  * **missing** power (the HEDI "neither models any power" case), or
+  * power that should be site-level still sitting on a station (drift signal
+    feeding the W3 migration).
+
+Off-by-default / `--with-power` opt-in at first (mirrors `--with-coverage`),
+because until the W3 migration runs every site will look "wrong." SUPPRESS
+file `data/audit_suppressions/shared_power.txt`. `--triage` emits the
+reparent ACTIONs (see W3).
+
+### W3 — Site-power model + migration (Q1a) — fleet-wide, heavy
+
+Make `land` the parent of shared power:
+  * **Write path:** attach a power device to the `land` site via the existing
+    `create_entity_connection(parent=land, child=power_device)` — no new writer
+    primitive needed. New `move`-style ACTION reparents an existing
+    station-parented power device to the site (`move_device(power_id,
+    to_id_entity=land_id, …)` — already exists).
+  * **Migration:** reparent the ~35+ deployed power devices station → site.
+    Phased, per-site, through committed triage files (the canonical
+    retrospective-write trail). Per-site: confirm which station(s) the power
+    actually served, move to the `land` parent, leave a vitjun if a physical
+    visit was involved.
+  * **Decision point:** does *every* power device move to the site, or only the
+    genuinely-shared ones (a station-private UPS in a hut might legitimately
+    stay per-station)? Resolve in the W3 design, not here.
+
+## 5. Boundary with `tos station add`
+
+`tos station add` (other doc) is unchanged: it creates the `geophysical`
+station and joins it under the site. It will **call W1's `summarize_site_power`**
+to show the operator the shared supply when attaching to an existing site, but
+it does **not** write power. Power onboarding (attach a new battery/solar to a
+site) is W3, via `tos device add` + a site-parent join — not a `station add`
+responsibility.
+
+## 6. Open questions
+
+1. **Power-source representation.** "Powered from the farm" (mains) vs off-grid
+   (solar+battery) is a real distinction. Options: a `land` attribute
+   (`power_source: mains|solar_battery|generator|…`), a dedicated power-source
+   entity the site references, or purely implicit in the attached power
+   devices. The farm itself may warrant being an entity (external mains
+   supplier). Decide before W3.
+2. **Migration completeness — all vs shared-only** (see W3 decision point).
+3. **Meteorological / hydrological colocation.** The requirement was framed for
+   GPS+SIL, but sites host weather/hydro stations too (and they carry the bulk
+   of power devices). Does site-level power span *all* domains at a site, or
+   just the geophysical ones? Almost certainly all — confirm.
+4. **`anemometer_power_pack` and sensor-specific power.** Some power devices are
+   tied to one instrument (an anemometer's own pack). Those are genuinely
+   per-device, not site-shared — the audit/migration must not flag them.

--- a/docs/architecture/station-location-add.md
+++ b/docs/architecture/station-location-add.md
@@ -1,0 +1,240 @@
+# Scope — `tos station add` + `tos location add`
+
+Status: **in progress** (design agreed 2026-06-07: find-or-create location ·
+station shell only · CLI verb + `--triage` handoff).
+
+- **`tos location add`** + `TOSWriter.find_land_location_by_name` —
+  implemented 2026-06-07. `src/tostools/location.py`,
+  `_location_main`/`_location_add_main` in `tos.py`, pinned by
+  `tests/test_location_add.py` (28 tests). Catalog `staðsetning`→`land` fix
+  applied (§6.3). Two paths with **different verification status**:
+    - ✅ **Reuse path — live-verified.** A site that already exists (commonly
+      because a SIL station is there) is found and reused, child summary
+      shown, never duplicated. Verified live against HEDI (site 4315, returns
+      `reused=True`, lists the colocated GPS + SIL stations).
+    - ⚠️ **Create path — dry-run validated, LIVE-UNVERIFIED.** All create
+      tests are dry-run or `_FakeWriter`; `create_entity("land", …)` has never
+      run against the API. A minted `land` entity is **irreversible** — TOS has
+      no entity-delete endpoint (only `delete_entity_connection` /
+      `delete_attribute_value`), so no throwaway test is possible. Same
+      posture as the contact-entity writes: *verify on first genuine use.* The
+      CLI prints this irreversibility caution on the create path. Residual
+      risk is narrow: `create_entity` is a plain `POST /entities
+      {entity_subtype, attributes}` that does **not** touch the
+      `_subtype_to_entity_type_cache` (so the monument-114 precedent does not
+      apply) — the only open question is whether `/entities` accepts a
+      location-type subtype, which the first live create will settle.
+- ⬜ **`tos station add`** — not yet started.
+
+## 1. Problem
+
+There is no operator command to bring a **new station online from scratch**.
+`tos device add` mints devices (gnss_receiver, antenna, radome, monument) but
+nothing creates the station entity itself or its parent site. Library
+primitives exist (`TOSWriter.create_entity`, `create_entity_connection`,
+`find_station_by_marker`, `find_location_by_name`) but are unexposed.
+
+## 2. TOS data model (verified against live TOS, 2026-06-07)
+
+The hierarchy is **two levels above devices**, not one. The
+`tos-write-api.md` diagram showing the station as root is incomplete.
+
+```
+land  (entity_subtype="land",        entity_type=location, id_entity_type=1)   ← THE LOCATION / SITE
+│      id 103 in /entity_subtypes/.  TOS desc: "Land-based location of one or
+│      multiple colocated stations. REQUIRED PARENT of any land station in
+│      regular operations."
+│      attrs: name, lat, lon, altitude   (+ optional lon_isn93, lat_isn93,
+│             identifier, notes).  Top-level — no parent of its own.
+│
+├── geophysical (entity_subtype="geophysical", entity_type=station, id 111)   ← THE STATION
+│      attrs: marker, name, subtype(="GPS stöð"), lat, lon, altitude,
+│             operational_class, date_start, continuity,
+│             geological_characteristic, is_near_fault_zones,
+│             bedrock_condition, bedrock_type, in_network_epos
+│      └── devices: gnss_receiver, antenna, radome, monument (via joins)
+│
+└── (other colocated stations — e.g. a weather station — share the same land site)
+```
+
+Worked reference — **HEDI**: land site `id 4315` ("Héðinshöfði", subtype
+`land`, lat/lon/alt only) → open join → geophysical station `id 4316`
+("Héðinshöfði", marker `hedi`, the full GPS attribute set). The site also
+carries a second child (5442) = a colocated instrument. This is the canonical
+shape `tos station add` must reproduce: **a `geophysical` entity joined under a
+`land` site.**
+
+## 3. Decisions (locked)
+
+| # | Decision | Choice |
+|---|----------|--------|
+| Q1 | Location handling | **Find-or-create in one verb.** `tos station add` resolves the site by name; mints the `land` entity if none matches, then attaches. `--location-id` forces an existing site; `--create-location` requires a fresh one (error if name already taken). Standalone `tos location add` also provided for site-first workflows. |
+| Q2 | Station-add scope | **Station shell only** — `geophysical` entity + required attrs + join to the site. Devices added afterward via existing `tos device add` + `create-join`. |
+| Q3 | Interface | **CLI verbs + `--triage` handoff** — dry-run default, `--triage PATH --placeholder TOKEN` substitutes the new id into a waiting triage file (reuses `_substitute_id_in_triage`). No new ACTION verbs. |
+
+"Check what's in TOS" (the third ask) = the **pre-flight duplicate guard**,
+modelled on `create_device`'s duplicate-serial guard: refuse + report the
+existing entity, `--force` to override.
+
+## 4. Verbs
+
+### 4.1 `tos location add`
+
+```
+tos location add --name NAME --lat LAT --lon LON --altitude ALT
+                 --date-start DATE
+                 [--lon-isn93 V] [--lat-isn93 V] [--identifier V] [--notes V]
+                 [--force] [--no-dry-run] [--json]
+                 [--triage PATH --placeholder TOKEN]
+                 [--server H] [--port N]
+```
+
+**Attribute `date_from` rule:** every minted attribute value (name, lat, lon,
+altitude, optionals) gets `date_from = --date-start`, `date_to = null` (open).
+When `tos station add` auto-mints a site, it passes the station's
+`--date-start` through, so the site and station share one founding date.
+
+Flow:
+1. Validate `--lat/--lon/--altitude` numeric; `--name` non-empty;
+   `--date-start` parses (`normalize_date_start`).
+2. **Pre-flight:** `find_land_location_by_name(name)` (see §6 open item). On a
+   hit → refuse, print existing `id_entity` + coords, exit 1 unless `--force`.
+   (Stretch: warn when coords fall within N m of an existing site even if the
+   name differs — v2.)
+3. `writer.create_entity("land", attrs)` where attrs = name, lat, lon,
+   altitude (+ provided optionals), each with `date_from=--date-start`.
+4. Report new `id_entity`; `--triage` substitution + sed-hint, same as
+   `tos device add`.
+
+### 4.2 `tos station add`
+
+```
+tos station add --marker MARKER --name NAME --lat LAT --lon LON --altitude ALT
+                --operational-class CLASS --date-start DATE
+                --continuity VAL --geological-characteristic VAL
+                --is-near-fault-zones {yes|no} --bedrock-condition VAL
+                --bedrock-type VAL --in-network-epos {ja|nei}
+                [--subtype 'GPS stöð']            # default; the station-kind attr
+                [--location-id ID | --location-name NAME]   # default name = --name
+                [--create-location]               # require a fresh site (error if name taken)
+                [--force] [--no-dry-run] [--json]
+                [--triage PATH --placeholder TOKEN]
+                [--server H] [--port N]
+```
+
+Required-attribute set is taken from `data/attribute_codes.yaml` → `stations`
+scope, `required_for == ['geophysical']`:
+`marker, name, subtype, lat, lon, altitude, operational_class, date_start,
+continuity, geological_characteristic, is_near_fault_zones, bedrock_condition,
+bedrock_type, in_network_epos`. Each maps to a flag; a missing required value
+with no catalog default → exit 2 listing what's absent. Enum-valued codes
+(operational_class, continuity, in_network_epos, bedrock_*,
+geological_characteristic, is_near_fault_zones) validated against catalog
+`allowed_values` where present.
+
+Flow:
+1. Validate date (`normalize_date_start`), coords numeric, enums.
+2. **Pre-flight — station:** `find_station_by_marker(marker)`. On a hit →
+   refuse, print existing `id_entity` + name, exit 1 unless `--force`. Marker
+   is the uniqueness key.
+3. **Pre-flight — location (find-or-create):**
+   - `--location-id ID` → fetch, assert `code_entity_subtype == "land"`, else
+     exit 2. Use it.
+   - else resolve by `--location-name` (default `--name`):
+     - found → attach (print "using existing site id=X").
+     - not found → **auto-mint** a `land` site from the station's
+       name+coords (the Q1 default). Loudly logged in dry-run so the operator
+       sees the implicit creation before `--no-dry-run`.
+   - `--create-location` flips "found" into an error (refuse to reuse a name).
+4. Create the site if minting (`create_entity("land", …)`).
+5. `create_entity("geophysical", station_attrs)`.
+6. `create_entity_connection(id_parent=site_id, id_child=station_id,
+   time_from=date_start)`.
+7. If station created but join fails → report the orphaned station id (mirrors
+   device-add's failed-join handling), exit 1.
+8. Report, `--json`, `--triage` substitution + sed-hint.
+
+Ordering keeps the most-recoverable failure last: site → station → join.
+
+## 5. Implementation map
+
+| Piece | Location | Note |
+|-------|----------|------|
+| CLI `add` action on `tos station` | `tos.py` `_station_main` (router already has triage/verify/show) | add `add` subparser + dispatch |
+| New `tos location` subcommand | `tos.py` top-level dispatch (alongside `station`/`contact`/`visit`) | brand-new router |
+| Attr builders + validation | new `src/tostools/station.py` | mirror `device.py`: `build_required_station_attributes()`, `build_location_attributes()`, enum validators, `normalize_date_start` reuse |
+| `find_land_location_by_name` | `api/tos_writer.py` | new, or generalize `find_location_by_name` (see §6) |
+| Entity + join writes | existing `create_entity` / `create_entity_connection` | no writer change expected |
+| Triage handoff | existing `_substitute_id_in_triage` + `--triage/--placeholder` | reuse verbatim |
+| Catalog fix | `data/attribute_codes.yaml` `locations` scope | `required_for: ['staðsetning']` → `['land']` (stale key, confirmed §6.3) |
+
+Tests mirror `tests/test_device_*.py`: `tests/test_station_add.py`,
+`tests/test_location_add.py`. Pin: duplicate-marker refusal + `--force`
+override; find / auto-mint / `--create-location`-conflict branches; join
+wiring; dry-run writes nothing; required-attr validation; enum rejection;
+triage substitution; orphaned-station-on-join-failure path.
+
+## 6. Open items to resolve during build
+
+1. ~~**`land` basic_search type filter.**~~ **RESOLVED 2026-06-07.** The `land`
+   site cannot be filtered by `type_lvl_two` (it's `None`); in `basic_search`
+   it surfaces as a top-level hit with `id_lvl_two=None` while stations carry
+   `id_lvl_two`. `find_land_location_by_name` uses `id_lvl_two is None` as the
+   pre-filter, then confirms `code_entity_subtype == "land"` via a history GET.
+   Verified live against HEDI (site 4315).
+2. **`create_entity` for `land`.** Verify `POST /entities {entity_subtype:
+   "land", …}` is the right endpoint for a *location*-type entity (id_entity_type=1)
+   and not a separate `/locations` route. The `create_device` path is only
+   proven for device-type subtypes. Check `_subtype_to_entity_type_cache`
+   resolves `land` → location correctly (the monument id=114 bug noted in
+   tos_writer.py:253-255 is a cautionary precedent).
+3. ~~**Catalog `locations` scope keys on `staðsetning`.**~~ **RESOLVED
+   2026-06-07.** `staðsetning` is not a TOS subtype at all (the location
+   subtypes are `land`/`stock`/`virtual`/`discontinued`/`ocean`/`vehicle`) — it
+   was the Icelandic section name used as a placeholder, matched against nothing.
+   All `[staðsetning]` tokens in the `locations` scope replaced with `[land]`
+   in `data/attribute_codes.yaml`. Zero-risk (the scope was unconsumed; nothing
+   matched the old token). The corrected scope now drives
+   `LOCATION_REQUIRED_ATTR_CODES` in `location.py`.
+4. **Enum allowed-values.** Confirm which station enum codes have
+   `allowed_values` in the catalog vs. free-text, so validation rejects typos
+   without blocking legitimate values.
+5. **Exact-name reuse match → silent-duplicate risk (open).** The reuse guard
+   keys on exact, case-sensitive `value_varchar == name` with no whitespace
+   normalisation. A site stored as `"Héðinshöfði"` is missed by
+   `"Hedinshofdi"` / a trailing space / different casing → a duplicate `land`
+   site is minted (the exact outcome idempotency exists to prevent). v1
+   mitigation: the create path prints a "check spelling first; this is
+   irreversible" caution to stderr. Real fixes (v2): coordinate-proximity
+   match, case/whitespace-insensitive compare, or a fuzzy "did you mean …?"
+   suggestion from `basic_search` near-hits.
+
+## 7. Onboarding boundary — where "online" stops
+
+These verbs write **TOS entities only**. A station is not fully "online" for
+the rest of the toolchain until it also appears in `stations.cfg` — the fleet
+orchestrators (`tos fleet status/triage/verify`) enumerate via
+`enumerate_fleet_stations`, which reads `stations.cfg`
+(`code_subtype == "geophysical"`), not TOS. So a freshly-added TOS station is
+invisible to fleet ops until a parallel `stations.cfg` entry lands.
+
+`stations.cfg` is owned by the **`gps_parser` / `gps-config-data`** packages
+(rendered from templates, deployed to `~/.config/gpsconfig/`), not tostools.
+This scope deliberately does **not** touch it — but onboarding docs/tutorial
+for `tos station add` must point operators at the `gps_parser deploy` step as
+the second half of bringing a station online. Possible future convenience: a
+`--emit-stations-cfg-stub` flag that prints the matching cfg block for the
+operator to paste. Out of scope for v1.
+
+## 8. Out of scope (deliberately)
+
+- Initial device sessions in the same command (Q2 = shell only).
+- `add-station` / `add-location` ACTION verbs for `tos audit apply` (Q3 = CLI
+  only). Revisit if multi-station onboarding batches emerge.
+- Coordinate-proximity duplicate detection (name-match only for v1).
+- Non-`land` location subtypes (sea/ice/borehole, if they exist).
+- **Shared power across colocated stations** — scoped separately in
+  `shared-power-model.md` (decision 2026-06-08: power belongs on the `land`
+  site, not per-station). `tos station add` will *call* that work's
+  `summarize_site_power` read helper to show the operator a site's existing
+  supply when attaching to an existing site, but does not write power itself.

--- a/docs/architecture/station-location-add.md
+++ b/docs/architecture/station-location-add.md
@@ -1,7 +1,8 @@
 # Scope — `tos station add` + `tos location add`
 
-Status: **in progress** (design agreed 2026-06-07: find-or-create location ·
-station shell only · CLI verb + `--triage` handoff).
+Status: **implemented** (design agreed 2026-06-07: find-or-create location ·
+station shell only · CLI verb + `--triage` handoff). Both verbs landed; create
+paths are live-unverified (irreversible — verify on first genuine use).
 
 - **`tos location add`** + `TOSWriter.find_land_location_by_name` —
   implemented 2026-06-07. `src/tostools/location.py`,
@@ -24,7 +25,21 @@ station shell only · CLI verb + `--triage` handoff).
       `_subtype_to_entity_type_cache` (so the monument-114 precedent does not
       apply) — the only open question is whether `/entities` accepts a
       location-type subtype, which the first live create will settle.
-- ⬜ **`tos station add`** — not yet started.
+- **`tos station add`** — implemented 2026-06-08. `src/tostools/station.py`
+  (`station_required_codes` / `build_required_station_attributes` read the
+  catalog `stations` scope dynamically — 7 must-provide, 7 catalog-defaulted),
+  `_station_add_main` / `_resolve_station_site` in `tos.py`, pinned by
+  `tests/test_station_add.py` (19 tests). Station-shell only (Q2a); find-or-
+  create site (Q1a) reusing `find_land_location_by_name`; duplicate-marker
+  guard (`find_station_by_marker`, `--force`); join via
+  `create_entity_connection`; orphaned-station-on-join-failure surfaced as a
+  `create-join` ACTION hint; `--triage` handoff carries the station id; W1
+  `summarize_site_power` surfaced when attaching to an existing site. **Same
+  live-unverified caveat as location create** — the station + site POSTs are
+  dry-run/`_FakeWriter` only; verify on first genuine use (irreversible).
+  Dry-run live-validated: ZZZZ→Mjóaskarð (reuse existing powered site),
+  QQQ9→fresh site (auto-mint), duplicate-marker refusal, non-land
+  `--location-id` rejection.
 
 ## 1. Problem
 

--- a/src/tostools/api/tos_writer.py
+++ b/src/tostools/api/tos_writer.py
@@ -1639,6 +1639,72 @@ class TOSWriter:
                 return int(entity_id)
         return None
 
+    def find_land_location_by_name(self, name: str) -> Optional[int]:
+        """Look up a ``land`` site (location) entity by its ``name``.
+
+        The ``land`` location is the **required parent of any land station**
+        (TOS ``entity_subtype="land"``, ``entity_type=location``). Adding a
+        GPS station at a site that already hosts another instrument — most
+        often a SIL seismic station — means the land site already exists and
+        should be **reused**, not duplicated. This finder is the reuse lookup.
+
+        Unlike :meth:`find_station_by_marker` / :meth:`find_location_by_name`,
+        the ``land`` entity cannot be filtered by ``type_lvl_two``: in
+        ``basic_search`` results it surfaces with ``type_lvl_two=None`` and
+        ``id_lvl_two=None`` (it is a top-level / lvl-one entity, not a
+        station at lvl-two). We use ``id_lvl_two is None`` as the cheap
+        pre-filter, then confirm authoritatively via a history GET that
+        ``code_entity_subtype == "land"`` — so a same-named station never
+        masquerades as its own site.
+
+        Args:
+            name: Full site name as recorded in TOS (e.g. ``"Héðinshöfði"``).
+                Matched exactly (case-sensitive, no whitespace normalisation),
+                consistent with :meth:`find_location_by_name`.
+
+        Returns:
+            The land site's ``id_entity`` (int) or ``None`` if no ``land``
+            entity with that exact name exists.
+        """
+        if not name:
+            return None
+        results = self._request(
+            "POST",
+            "/basic_search/",
+            data={"search_term": name},
+            _force_send=True,
+        )
+        if not isinstance(results, list):
+            return None
+        # Confirm the strongest candidates first (lvl-one hits), but fall
+        # back to confirming any exact-name hit so we never miss a land
+        # entity whose basic_search shape differs from the observed one.
+        candidates: List[int] = []
+        seen: set[int] = set()
+        for prefer_lvl_one in (True, False):
+            for hit in results:
+                if hit.get("code") != "name":
+                    continue
+                if hit.get("distance") != 0:
+                    continue
+                if hit.get("value_varchar") != name:
+                    continue
+                if prefer_lvl_one and hit.get("id_lvl_two") is not None:
+                    continue
+                entity_id = hit.get("id_entity") or hit.get("id_lvl_two")
+                if not entity_id:
+                    continue
+                eid = int(entity_id)
+                if eid in seen:
+                    continue
+                seen.add(eid)
+                candidates.append(eid)
+        for eid in candidates:
+            history = self.get_entity_history(eid)
+            if history and history.get("code_entity_subtype") == "land":
+                return eid
+        return None
+
     # ---------------------------------------------------------------------
     # Entity-connection (join) helpers — Pattern 2 for joins
     # ---------------------------------------------------------------------

--- a/src/tostools/location.py
+++ b/src/tostools/location.py
@@ -1,0 +1,216 @@
+"""Helpers for the ``tos location add`` CLI — the ``land`` site entity.
+
+A "location" in TOS is an entity with ``code_entity_subtype="land"``
+(``entity_type=location``). TOS describes it as the *"land-based location of
+one or multiple colocated stations — required parent of any land station in
+regular operations."* It carries only the physical-site attributes
+(``name``, ``lat``, ``lon``, ``altitude``) and is the parent that GPS / SIL /
+other geophysical stations hang under via an entity_connection.
+
+This module holds the attribute-shaping and coordinate-validation logic so it
+can be unit-tested without argparse or the TOS API. The user-facing entrypoint
+is ``tostools.tos._location_add_main``.
+
+**Reuse over duplication is the common path.** A new GPS station is frequently
+added at a site that *already* hosts another instrument — most often a SIL
+seismic station — so the ``land`` site usually already exists and must be
+reused, not duplicated. ``TOSWriter.find_land_location_by_name`` is the reuse
+lookup; the CLI treats "already exists" as a friendly idempotent result, not
+an error.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from .device import normalize_date_start  # re-export for callers
+from .devices import open_attribute
+
+__all__ = [
+    "LOCATION_SUBTYPE",
+    "LOCATION_REQUIRED_ATTR_CODES",
+    "LOCATION_OPTIONAL_ATTR_CODES",
+    "normalize_date_start",
+    "validate_latitude",
+    "validate_longitude",
+    "validate_altitude",
+    "build_location_attributes",
+    "summarize_location_children",
+]
+
+# The TOS ``code_entity_subtype`` for a land site (id 103 in
+# ``GET /entity_subtypes/``, entity_type=location).
+LOCATION_SUBTYPE = "land"
+
+# Catalog ``locations`` scope, ``required_for == ["land"]`` (the catalog key is
+# being corrected from the stale ``staðsetning`` as part of this work).
+LOCATION_REQUIRED_ATTR_CODES = ("name", "lat", "lon", "altitude")
+
+# Order drives the attribute order in :func:`build_location_attributes`.
+LOCATION_OPTIONAL_ATTR_CODES = ("lon_isn93", "lat_isn93", "identifier", "notes")
+
+
+def _validate_float(label: str, raw: str) -> str:
+    """Parse *raw* as a float and return it unchanged (TOS stores strings).
+
+    Raises ``ValueError`` with a *label*-prefixed message on a non-numeric
+    value, so the CLI can surface which coordinate was bad.
+    """
+    if raw is None or str(raw).strip() == "":
+        raise ValueError(f"{label} must be a non-empty number")
+    try:
+        float(raw)
+    except (TypeError, ValueError):
+        raise ValueError(f"{label} must be numeric, got {raw!r}") from None
+    return str(raw)
+
+
+def validate_latitude(raw: str) -> str:
+    """Validate a latitude in decimal degrees (``-90 ≤ lat ≤ 90``)."""
+    value = _validate_float("lat", raw)
+    if not -90.0 <= float(value) <= 90.0:
+        raise ValueError(f"lat must be between -90 and 90, got {raw!r}")
+    return value
+
+
+def validate_longitude(raw: str) -> str:
+    """Validate a longitude in decimal degrees (``-180 ≤ lon ≤ 180``)."""
+    value = _validate_float("lon", raw)
+    if not -180.0 <= float(value) <= 180.0:
+        raise ValueError(f"lon must be between -180 and 180, got {raw!r}")
+    return value
+
+
+def validate_altitude(raw: str) -> str:
+    """Validate an altitude in metres (any finite number)."""
+    return _validate_float("altitude", raw)
+
+
+def build_location_attributes(
+    *,
+    name: str,
+    lat: str,
+    lon: str,
+    altitude: str,
+    date_start: str,
+    lon_isn93: Optional[str] = None,
+    lat_isn93: Optional[str] = None,
+    identifier: Optional[str] = None,
+    notes: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Shape the attribute list for ``create_entity("land", ...)``.
+
+    Every attribute value (required + provided optionals) carries
+    ``date_from=date_start`` and an explicit ``date_to=None`` (open period) —
+    the same shape the TOS ``/entities`` endpoint expects, matching
+    :func:`tostools.device.build_required_attributes`.
+
+    Coordinates are validated (numeric + range) before shaping. ``name`` must
+    be non-empty. Optionals are emitted only when provided, in
+    :data:`LOCATION_OPTIONAL_ATTR_CODES` order.
+
+    Raises:
+        ValueError: empty ``name`` or invalid coordinate.
+    """
+    if not name or not str(name).strip():
+        raise ValueError("name must be a non-empty string")
+
+    attrs: List[Dict[str, Any]] = [
+        {"code": "name", "value": name, "date_from": date_start, "date_to": None},
+        {
+            "code": "lat",
+            "value": validate_latitude(lat),
+            "date_from": date_start,
+            "date_to": None,
+        },
+        {
+            "code": "lon",
+            "value": validate_longitude(lon),
+            "date_from": date_start,
+            "date_to": None,
+        },
+        {
+            "code": "altitude",
+            "value": validate_altitude(altitude),
+            "date_from": date_start,
+            "date_to": None,
+        },
+    ]
+
+    optionals = {
+        "lon_isn93": lon_isn93,
+        "lat_isn93": lat_isn93,
+        "identifier": identifier,
+        "notes": notes,
+    }
+    for code in LOCATION_OPTIONAL_ATTR_CODES:
+        value = optionals.get(code)
+        if value is not None and str(value) != "":
+            attrs.append(
+                {
+                    "code": code,
+                    "value": value,
+                    "date_from": date_start,
+                    "date_to": None,
+                }
+            )
+    return attrs
+
+
+def summarize_location_children(
+    writer: Any,
+    location_id: int,
+    *,
+    open_only: bool = True,
+) -> List[Dict[str, Any]]:
+    """Summarise the stations/devices attached to a ``land`` site.
+
+    Used to answer "what's already here?" — the common case is a site that
+    already hosts a SIL seismic station (or another GPS station) that an
+    operator is now colocating GPS with. Both ``tos location add`` (show the
+    existing site) and ``tos station add`` (show the site being attached to)
+    render this.
+
+    For each child connection it resolves the child's ``code_entity_subtype``,
+    its ``subtype`` attribute (the human label — ``"GPS stöð"`` /
+    ``"SIL stöð"`` — that distinguishes GPS from SIL even though both are
+    ``geophysical``), its ``name``, and the join's ``time_from`` / ``time_to``.
+
+    Args:
+        writer: any object exposing ``get_entity_history(id)`` (``TOSWriter``
+            or ``TOSClient``).
+        location_id: the ``land`` site's ``id_entity``.
+        open_only: when ``True`` (default), only currently-open joins
+            (``time_to is None``) are returned.
+
+    Returns:
+        A list of dicts (most-recent ``time_from`` first):
+        ``{id_entity, code_entity_subtype, subtype, name, time_from,
+        time_to, open}``. Empty list when the site has no children or its
+        history can't be fetched.
+    """
+    history = writer.get_entity_history(location_id)
+    if not history:
+        return []
+    children: List[Dict[str, Any]] = []
+    for conn in history.get("children_connections") or []:
+        time_to = conn.get("time_to")
+        if open_only and time_to is not None:
+            continue
+        child_id = conn.get("id_entity_child")
+        if child_id is None:
+            continue
+        child_hist = writer.get_entity_history(int(child_id)) or {}
+        children.append(
+            {
+                "id_entity": int(child_id),
+                "code_entity_subtype": child_hist.get("code_entity_subtype"),
+                "subtype": open_attribute(child_hist, "subtype"),
+                "name": open_attribute(child_hist, "name"),
+                "time_from": conn.get("time_from"),
+                "time_to": time_to,
+                "open": time_to is None,
+            }
+        )
+    children.sort(key=lambda c: c.get("time_from") or "", reverse=True)
+    return children

--- a/src/tostools/power.py
+++ b/src/tostools/power.py
@@ -1,0 +1,164 @@
+"""Power-infrastructure helpers — shared-power model (W1: surface site power).
+
+Power at a GPS/seismic site is physically a **site-level** resource: colocated
+stations share one supply (e.g. HEDI's GPS + SIL both run off the nearby farm's
+mains). TOS, however, currently models power **per-station** — battery / solar /
+power-pack devices hang off the individual station entity, never off the
+shared ``land`` site. See ``docs/architecture/shared-power-model.md``.
+
+This module is W1 of that work: a **read-only** aggregator that surfaces the
+power already present at a site by walking the colocated stations, so an
+operator reusing a site sees the shared supply and does not add a duplicate.
+The W2 audit (`tos audit shared-power`) and W3 migration (reparent power
+station→site) will build on the same :data:`POWER_DEVICE_SUBTYPES` set.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from .devices import open_attribute
+
+__all__ = [
+    "POWER_DEVICE_SUBTYPES",
+    "SENSOR_TIED_POWER_SUBTYPES",
+    "summarize_site_power",
+]
+
+# TOS device subtypes that represent power infrastructure (entity_type=device),
+# from ``GET /entity_subtypes/``. The shared-supply members of a site.
+POWER_DEVICE_SUBTYPES = frozenset(
+    {
+        "battery",
+        "solar_panel",
+        "power_pack",
+        "charge_regulator",
+        "charger",
+        "solar_charge_controller",
+        "ups",
+        "power_generator",
+        "switch_poe",
+        "anemometer_power_pack",
+    }
+)
+
+# Power that is tied to a single instrument rather than the site supply — must
+# NOT be treated as site-shared by the W2 audit. Surfaced by W1 (with its
+# station context) but flagged here so downstream consumers can exclude it.
+SENSOR_TIED_POWER_SUBTYPES = frozenset({"anemometer_power_pack"})
+
+
+def _power_row(
+    id_entity: int,
+    history: Dict[str, Any],
+    *,
+    on_station: Optional[int],
+    on_station_name: Optional[str],
+    time_from: Optional[str],
+    open_: bool,
+) -> Dict[str, Any]:
+    subtype = history.get("code_entity_subtype")
+    return {
+        "id_entity": id_entity,
+        "subtype": subtype,
+        "model": open_attribute(history, "model"),
+        "serial": open_attribute(history, "serial_number"),
+        # Where the device currently lives: a colocated station's id, or None
+        # when it hangs directly off the `land` site (the W3 target state).
+        "on_station": on_station,
+        "on_station_name": on_station_name,
+        "sensor_tied": subtype in SENSOR_TIED_POWER_SUBTYPES,
+        "time_from": time_from,
+        "open": open_,
+    }
+
+
+def summarize_site_power(
+    writer: Any,
+    land_id: int,
+    *,
+    open_only: bool = True,
+) -> List[Dict[str, Any]]:
+    """Aggregate the power devices present at a ``land`` site.
+
+    Walks the site's children (the colocated stations) and, for each, its
+    power-device children — because today power lives on the stations, not on
+    the site. Also picks up any power device joined **directly** to the
+    ``land`` site (``on_station=None``), which is the W3 migration target
+    state, so this helper keeps working as power moves site-ward.
+
+    Args:
+        writer: any object exposing ``get_entity_history(id)`` (``TOSWriter``
+            or ``TOSClient``).
+        land_id: the ``land`` site's ``id_entity``.
+        open_only: when ``True`` (default), only currently-open joins are
+            considered (both the station→site join and the power→station join).
+
+    Returns:
+        One row per power device (sorted site-direct first, then by station,
+        then most-recent ``time_from``):
+        ``{id_entity, subtype, model, serial, on_station, on_station_name,
+        sensor_tied, time_from, open}``. Empty list when the site has no
+        power anywhere or its history can't be fetched.
+    """
+    land = writer.get_entity_history(land_id)
+    if not land:
+        return []
+
+    rows: List[Dict[str, Any]] = []
+    for conn in land.get("children_connections") or []:
+        if open_only and conn.get("time_to") is not None:
+            continue
+        child_id = conn.get("id_entity_child")
+        if child_id is None:
+            continue
+        child = writer.get_entity_history(int(child_id)) or {}
+        child_subtype = child.get("code_entity_subtype")
+
+        if child_subtype in POWER_DEVICE_SUBTYPES:
+            # Power joined directly to the site (W3 target state).
+            rows.append(
+                _power_row(
+                    int(child_id),
+                    child,
+                    on_station=None,
+                    on_station_name=None,
+                    time_from=conn.get("time_from"),
+                    open_=conn.get("time_to") is None,
+                )
+            )
+            continue
+
+        # Otherwise treat the child as a colocated station and look for power
+        # among ITS children (the current per-station modelling).
+        station_name = open_attribute(child, "name")
+        for sub_conn in child.get("children_connections") or []:
+            if open_only and sub_conn.get("time_to") is not None:
+                continue
+            power_id = sub_conn.get("id_entity_child")
+            if power_id is None:
+                continue
+            power = writer.get_entity_history(int(power_id)) or {}
+            if power.get("code_entity_subtype") not in POWER_DEVICE_SUBTYPES:
+                continue
+            rows.append(
+                _power_row(
+                    int(power_id),
+                    power,
+                    on_station=int(child_id),
+                    on_station_name=station_name,
+                    time_from=sub_conn.get("time_from"),
+                    open_=sub_conn.get("time_to") is None,
+                )
+            )
+
+    # Site-direct power first (on_station None sorts before any int), then by
+    # station id, then most-recent first.
+    rows.sort(
+        key=lambda r: (
+            r["on_station"] is not None,
+            r["on_station"] or 0,
+            r.get("time_from") or "",
+        ),
+    )
+    return rows

--- a/src/tostools/station.py
+++ b/src/tostools/station.py
@@ -1,0 +1,134 @@
+"""Helpers for the ``tos station add`` CLI — the ``geophysical`` station entity.
+
+A "station" in TOS is an entity with ``code_entity_subtype="geophysical"``
+(``entity_type=station``) — the GPS/SIL/gas/infrasound measurement station. It
+must hang under a ``land`` site (see :mod:`tostools.location`) and carries the
+GPS attribute set (marker, operational_class, bedrock_*, …).
+
+This module shapes + validates the station's required attributes so the logic
+is unit-testable without argparse or the TOS API. The required set and the
+per-code default values are read from ``data/attribute_codes.yaml`` (the
+``stations`` scope, ``required_for`` containing ``geophysical``) so the verb
+stays in sync with the catalog the audits use — no duplicated constant.
+
+The user-facing entrypoint is ``tostools.tos._station_add_main``.
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from .audit_attribute_dates import load_catalog_scoped
+from .device import normalize_date_start  # re-export for callers
+from .location import validate_altitude, validate_latitude, validate_longitude
+
+__all__ = [
+    "STATION_SUBTYPE",
+    "station_required_codes",
+    "build_required_station_attributes",
+    "normalize_date_start",
+    "validate_latitude",
+    "validate_longitude",
+    "validate_altitude",
+]
+
+# TOS ``code_entity_subtype`` for a GPS/geophysical station (id 111 in
+# ``GET /entity_subtypes/``, entity_type=station).
+STATION_SUBTYPE = "geophysical"
+
+# Codes the CLI validates as coordinates before shaping.
+_COORD_VALIDATORS = {
+    "lat": validate_latitude,
+    "lon": validate_longitude,
+    "altitude": validate_altitude,
+}
+
+
+def station_required_codes(
+    catalog_path: Optional[Path] = None,
+) -> "OrderedDict[str, Optional[str]]":
+    """Return ``{code: default_value}`` for every geophysical-required station attr.
+
+    Reads the ``stations`` scope of ``attribute_codes.yaml`` and keeps each
+    code whose ``gps_required_for`` contains ``"geophysical"``. Uses
+    ``gps_required_for`` (not ``tos_required_for``) to match the
+    missing-attributes audit (``audit_missing_attributes`` keys on the same
+    field) — so a station built here satisfies ``tos station verify``.
+    ``default_value`` is the catalog default (``None`` when the operator must
+    supply it). Insertion order follows the catalog.
+    """
+    scoped = load_catalog_scoped(catalog_path)
+    stations = scoped.get("stations", {})
+    out: "OrderedDict[str, Optional[str]]" = OrderedDict()
+    for code, entry in stations.items():
+        required = entry.get("gps_required_for") or []
+        if "geophysical" in required:
+            default = entry.get("default_value")
+            # YAML ``~`` → None; normalise empty string to None too.
+            out[code] = default if (default is not None and default != "") else None
+    return out
+
+
+def build_required_station_attributes(
+    *,
+    provided: Dict[str, Optional[str]],
+    date_start: str,
+    catalog_path: Optional[Path] = None,
+) -> List[Dict[str, Any]]:
+    """Shape the attribute list for ``create_entity("geophysical", ...)``.
+
+    For each geophysical-required code, the value is taken from *provided*
+    (operator input) when present, else the catalog default. The ``date_start``
+    code's value is *date_start* itself. Coordinate codes (lat/lon/altitude)
+    are validated. Every attribute carries ``date_from=date_start`` and an
+    explicit ``date_to=None`` (open period).
+
+    Args:
+        provided: ``{code: value}`` from the CLI. A missing or ``None`` value
+            falls back to the catalog default.
+        date_start: the ``date_from`` for every row, and the value of the
+            ``date_start`` attribute.
+        catalog_path: override for the catalog (tests / alternate networks).
+
+    Raises:
+        ValueError: a required code has neither a provided value nor a catalog
+            default (all such codes reported together), or a coordinate is
+            invalid.
+    """
+    required = station_required_codes(catalog_path)
+    attrs: List[Dict[str, Any]] = []
+    missing: List[str] = []
+
+    for code, default in required.items():
+        if code == "date_start":
+            value: Optional[str] = date_start
+        else:
+            value = provided.get(code)
+            if value is None or value == "":
+                value = default
+
+        if value is None or value == "":
+            missing.append(code)
+            continue
+
+        if code == "marker":
+            # TOS stores markers lowercase (e.g. "hedi") — normalise so a new
+            # station matches the fleet convention and is found by
+            # find_station_by_marker. See its docstring.
+            value = str(value).lower()
+
+        if code in _COORD_VALIDATORS:
+            value = _COORD_VALIDATORS[code](value)  # raises ValueError if bad
+
+        attrs.append(
+            {"code": code, "value": value, "date_from": date_start, "date_to": None}
+        )
+
+    if missing:
+        raise ValueError(
+            "missing required station attribute(s) with no value and no "
+            "catalog default: " + ", ".join(missing)
+        )
+    return attrs

--- a/src/tostools/tos.py
+++ b/src/tostools/tos.py
@@ -3310,6 +3310,7 @@ def _location_add_main(args) -> int:
                     f"duplicate."
                 )
                 _print_location_children(children)
+                _print_site_power(writer, existing_id)
                 print(
                     "\nUse this id as the parent for a new station:\n"
                     f"  tos station add --location-id {existing_id} ..."
@@ -3324,6 +3325,7 @@ def _location_add_main(args) -> int:
                 file=sys.stderr,
             )
             _print_location_children(children)
+            _print_site_power(writer, existing_id)
             id_entity = _create_land_site(writer, attributes, dry_run, args)
     else:
         # No EXACT-name match. The reuse guard is case-sensitive and does not
@@ -3395,6 +3397,35 @@ def _print_location_children(children) -> None:
         print(
             f"    - {label:10} id={c['id_entity']:<7} {name}  "
             f"(since {c.get('time_from')})"
+        )
+
+
+def _print_site_power(writer, land_id) -> None:
+    """Surface the power already present at a site (shared-power model, W1).
+
+    Aggregates power devices across the colocated stations so an operator
+    reusing a site sees the existing supply and does not add a duplicate. See
+    ``docs/architecture/shared-power-model.md``.
+    """
+    from .power import summarize_site_power
+
+    rows = summarize_site_power(writer, land_id)
+    if not rows:
+        print(
+            "  Site power: none modelled yet (neither on the site nor its " "stations)."
+        )
+        return
+    print("  Site power (shared across colocated stations — don't duplicate):")
+    for r in rows:
+        if r.get("on_station") is None:
+            where = "on the site"
+        else:
+            where = f"on {r.get('on_station_name') or 'station'} ({r['on_station']})"
+        model = r.get("model") or ""
+        tied = "  [sensor-tied]" if r.get("sensor_tied") else ""
+        print(
+            f"    - {r['subtype']:22} id={r['id_entity']:<7} {model:14} "
+            f"{where}{tied}"
         )
 
 

--- a/src/tostools/tos.py
+++ b/src/tostools/tos.py
@@ -15,6 +15,7 @@ KNOWN_SUBCOMMANDS = {
     "device",
     "audit",
     "station",
+    "location",
     "contact",
     "fleet",
     "visit",
@@ -3179,6 +3180,266 @@ def _filter_contacts(
                 continue
         out.append(c)
     return out
+
+
+def _location_main(argv):
+    """Handle ``tos location <verb>`` subcommands.
+
+    A "location" in TOS is a ``land`` site entity — the required parent of any
+    land station. Today the only verb is ``add`` (find-or-create a site);
+    inspection verbs may follow. Find-or-create is **idempotent**: a site that
+    already exists (commonly because a SIL seismic station is already there)
+    is reused and its attached stations shown, not duplicated.
+    """
+    p = argparse.ArgumentParser(
+        prog="tos location",
+        description="Manage TOS `land` site (location) entities.",
+    )
+    sub = p.add_subparsers(dest="action", required=True)
+
+    p_add = sub.add_parser(
+        "add",
+        help="Find-or-create a `land` site (idempotent; dry-run by default).",
+    )
+    p_add.add_argument("--name", required=True, help="Site name, e.g. 'Héðinshöfði'.")
+    p_add.add_argument("--lat", required=True, help="Latitude, decimal degrees.")
+    p_add.add_argument("--lon", required=True, help="Longitude, decimal degrees.")
+    p_add.add_argument("--altitude", required=True, help="Altitude, metres.")
+    p_add.add_argument(
+        "--date-start",
+        required=True,
+        help="date_from for every site attribute (YYYY-MM-DD or "
+        "YYYY-MM-DDTHH:MM:SS).",
+    )
+    p_add.add_argument("--lon-isn93", help="Optional ISN93 easting.")
+    p_add.add_argument("--lat-isn93", help="Optional ISN93 northing.")
+    p_add.add_argument("--identifier", help="Optional site identifier.")
+    p_add.add_argument("--notes", help="Optional free-text notes.")
+    p_add.add_argument(
+        "--force",
+        action="store_true",
+        help="Create a NEW site even if one with this name already exists "
+        "(bypasses the idempotent reuse guard — rarely wanted).",
+    )
+    p_add.add_argument(
+        "--no-dry-run",
+        action="store_true",
+        help="Commit the write. Without this flag, the payload is logged only.",
+    )
+    p_add.add_argument(
+        "--server",
+        default="vi-api.vedur.is",
+        help="TOS API host (default: vi-api.vedur.is).",
+    )
+    p_add.add_argument("--port", type=int, default=443)
+    p_add.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a structured JSON summary instead of plain text.",
+    )
+    p_add.add_argument(
+        "--triage",
+        type=Path,
+        default=None,
+        help="Substitute the site's id_entity into a triage file in-place "
+        "(requires --placeholder). Works for both a freshly-created site "
+        "and a reused existing one — so the id flows into a waiting "
+        "`tos station add --location-id` line.",
+    )
+    p_add.add_argument(
+        "--placeholder",
+        help="Token name to substitute in --triage (matched as '<TOKEN>'). "
+        "Required when --triage is given.",
+    )
+
+    args = p.parse_args(argv)
+    if args.action != "add":
+        p.error(f"unknown action: {args.action}")
+        return 2
+    return _location_add_main(args)
+
+
+def _location_add_main(args) -> int:
+    """Find-or-create a ``land`` site. Idempotent reuse is the common path."""
+    from . import location as location_helpers
+    from .api.tos_writer import TOSWriter
+
+    # ---- Input validation ------------------------------------------------
+    try:
+        date_start = location_helpers.normalize_date_start(args.date_start)
+    except ValueError as e:
+        print(f"Invalid --date-start: {e}", file=sys.stderr)
+        return 2
+    try:
+        attributes = location_helpers.build_location_attributes(
+            name=args.name,
+            lat=args.lat,
+            lon=args.lon,
+            altitude=args.altitude,
+            date_start=date_start,
+            lon_isn93=args.lon_isn93,
+            lat_isn93=args.lat_isn93,
+            identifier=args.identifier,
+            notes=args.notes,
+        )
+    except ValueError as e:
+        print(str(e), file=sys.stderr)
+        return 2
+
+    if (args.triage is not None) != (args.placeholder is not None):
+        print("--triage and --placeholder must be used together", file=sys.stderr)
+        return 2
+
+    # ---- Writer setup ----------------------------------------------------
+    scheme = "https" if args.port == 443 else "http"
+    base_url = f"{scheme}://{args.server}:{args.port}/tos/v1"
+    dry_run = not args.no_dry_run
+    writer = TOSWriter(base_url=base_url, dry_run=dry_run)
+
+    # ---- Pre-flight: find-or-create (idempotent reuse) -------------------
+    existing_id = writer.find_land_location_by_name(args.name)
+    reused = existing_id is not None and not args.force
+
+    if existing_id is not None:
+        children = location_helpers.summarize_location_children(writer, existing_id)
+        if reused:
+            if not args.json:
+                print(
+                    f"Location {args.name!r} already exists "
+                    f"(id_entity={existing_id}) — reusing, not creating a "
+                    f"duplicate."
+                )
+                _print_location_children(children)
+                print(
+                    "\nUse this id as the parent for a new station:\n"
+                    f"  tos station add --location-id {existing_id} ..."
+                )
+            id_entity = existing_id
+        else:
+            # --force: create a duplicate anyway. Warn loudly.
+            print(
+                f"WARNING: a site named {args.name!r} already exists "
+                f"(id_entity={existing_id}); --force will create a SECOND, "
+                f"duplicate `land` entity.",
+                file=sys.stderr,
+            )
+            _print_location_children(children)
+            id_entity = _create_land_site(writer, attributes, dry_run, args)
+    else:
+        # No EXACT-name match. The reuse guard is case-sensitive and does not
+        # normalise whitespace, so a site stored under a slightly different
+        # spelling (e.g. an existing SIL stöð) would NOT be found and we'd
+        # mint a duplicate. Make the operator look before committing.
+        if not args.json:
+            print(
+                f"No existing `land` site found with the exact name "
+                f"{args.name!r}.\n"
+                f"  NOTE: the match is exact + case-sensitive. If a SIL or "
+                f"other station may already\n"
+                f"  be at this site under a slightly different spelling, "
+                f"check first — e.g.:\n"
+                f"    tos audit station {args.name!r}\n"
+                f"  A created `land` entity is NOT deletable in TOS (no "
+                f"delete endpoint), so this\n"
+                f"  write is irreversible once committed with --no-dry-run.",
+                file=sys.stderr,
+            )
+        id_entity = _create_land_site(writer, attributes, dry_run, args)
+
+    # ---- Triage handoff (works for reused AND created ids) ---------------
+    _location_triage_handoff(args, id_entity)
+
+    # ---- JSON summary ----------------------------------------------------
+    if args.json:
+        import json as _json
+
+        print(
+            _json.dumps(
+                {
+                    "name": args.name,
+                    "id_entity": id_entity,
+                    "reused_existing": reused,
+                    "dry_run": dry_run,
+                    "date_start": date_start,
+                    "attributes": attributes,
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+        )
+    return 0
+
+
+def _create_land_site(writer, attributes, dry_run, args) -> "int | None":
+    """POST a new ``land`` entity; return its id_entity (None in dry-run)."""
+    from .location import LOCATION_SUBTYPE
+
+    response = writer.create_entity(LOCATION_SUBTYPE, attributes)
+    id_entity = response.get("id_entity") if isinstance(response, dict) else None
+    if not args.json:
+        suffix = " (dry-run)" if dry_run else ""
+        id_str = id_entity if id_entity is not None else "<would be assigned>"
+        print(f"Created land site {args.name!r} id_entity={id_str}{suffix}")
+    return id_entity
+
+
+def _print_location_children(children) -> None:
+    """Render the stations/devices already attached to a site."""
+    if not children:
+        print("  (no stations currently attached)")
+        return
+    print("  Currently attached:")
+    for c in children:
+        label = c.get("subtype") or c.get("code_entity_subtype") or "?"
+        name = c.get("name") or ""
+        print(
+            f"    - {label:10} id={c['id_entity']:<7} {name}  "
+            f"(since {c.get('time_from')})"
+        )
+
+
+def _location_triage_handoff(args, id_entity) -> None:
+    """Substitute the site id into a waiting triage file, or print a hint.
+
+    Mirrors ``tos device add``. A reused (already-existing) site has a real id
+    even in dry-run, so substitution runs for it; a freshly-created site only
+    has an id in live mode (``id_entity is None`` until ``--no-dry-run``).
+    """
+    if args.triage is None:
+        if id_entity is not None and not args.json:
+            print(
+                f"\nTip: to drop this id into a triage file, run:\n"
+                f"  sed -i 's/<TOKEN>/{id_entity}/g' <triage-file>\n"
+                f"(or pass --triage <file> --placeholder TOKEN to do it in one "
+                f"shot)"
+            )
+        return
+    if id_entity is None:
+        if not args.json:
+            print(
+                f"Triage update skipped: no real id_entity yet (dry-run "
+                f"create). Re-run with --no-dry-run to substitute "
+                f"<{args.placeholder}> in {args.triage}.",
+                file=sys.stderr,
+            )
+        return
+    try:
+        result = _substitute_id_in_triage(args.triage, args.placeholder, id_entity)
+    except OSError as e:
+        print(f"Could not read triage file {args.triage}: {e}", file=sys.stderr)
+        return
+    if result["count"] == 0:
+        print(
+            f"Triage update: placeholder {result['token']!r} not found in "
+            f"{args.triage} (no changes written).",
+            file=sys.stderr,
+        )
+    elif not args.json:
+        n = result["count"]
+        print(
+            f"Updated {args.triage}: {result['token']} → {id_entity} "
+            f"({n} replacement{'s' if n != 1 else ''})"
+        )
 
 
 def _contact_main(argv):
@@ -9698,6 +9959,16 @@ def _print_top_level_help() -> None:
         "               station show <STN>      Show station identity, open\n"
         "                                       attributes, joined devices.\n"
         "\n"
+        "  location   Manage `land` site entities (the required parent of any\n"
+        "             land station; one site can host colocated GPS + SIL).\n"
+        "               location add --name N --lat .. --lon .. --altitude ..\n"
+        "                            --date-start DATE\n"
+        "                                       Find-or-create a site. Idempotent:\n"
+        "                                       reuses an existing site (shows\n"
+        "                                       what's attached) instead of\n"
+        "                                       duplicating. Dry-run default;\n"
+        "                                       --no-dry-run commits.\n"
+        "\n"
         "  contact    Inspect TOS contact records (id_contact namespace).\n"
         "               contact show --id N     One contact record.\n"
         "               contact list --station S  Contacts for a station.\n"
@@ -9787,6 +10058,8 @@ def main(argv=None):
             return _audit_main(rest)
         if subcmd == "station":
             return _station_main(rest)
+        if subcmd == "location":
+            return _location_main(rest)
         if subcmd == "contact":
             return _contact_main(rest)
         if subcmd == "fleet":

--- a/src/tostools/tos.py
+++ b/src/tostools/tos.py
@@ -2212,6 +2212,8 @@ def _station_main(argv):
     )
     p_show.add_argument("--port", type=int, default=443)
 
+    _add_station_add_parser(sub)
+
     args = p.parse_args(argv)
 
     if args.verb == "triage":
@@ -2220,8 +2222,146 @@ def _station_main(argv):
         return _station_verify_main(args)
     if args.verb == "show":
         return _station_show_main(args)
+    if args.verb == "add":
+        return _station_add_main(args)
 
     return 2
+
+
+def _add_station_add_parser(sub) -> None:
+    """Register ``tos station add`` — create a geophysical station + site-join.
+
+    Creates the ``geophysical`` station shell (required attributes from the
+    catalog, operator-overridable defaults), find-or-creates its ``land`` site
+    (see :mod:`tostools.location`), and joins the two. Devices are added
+    afterwards via ``tos device add`` + ``create-join`` (station-shell only —
+    see docs/architecture/station-location-add.md).
+    """
+    p_add = sub.add_parser(
+        "add",
+        help=(
+            "Create a geophysical station (shell) + find-or-create its land "
+            "site + join them. Dry-run by default."
+        ),
+        description=(
+            "Create a new GPS station entity and attach it to its land site.\n\n"
+            "Must-provide attributes (no catalog default): --marker, --name, "
+            "--lat, --lon, --altitude, --date-start, --continuity.\n"
+            "Catalog-defaulted (override if needed): --subtype, "
+            "--operational-class, --geological-characteristic, "
+            "--is-near-fault-zones, --bedrock-condition, --bedrock-type, "
+            "--in-network-epos.\n\n"
+            "Location: by default the site is found-or-created by name "
+            "(--name); the station's own coordinates seed a new site. Use "
+            "--location-id to attach to a specific existing site, or "
+            "--create-location to require a fresh one."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    # --- must-provide (no catalog default) ---
+    p_add.add_argument(
+        "--marker", required=True, help="4-char RINEX marker, e.g. HEDI."
+    )
+    p_add.add_argument(
+        "--name", required=True, help="Station name, e.g. 'Héðinshöfði'."
+    )
+    p_add.add_argument("--lat", required=True, help="Latitude, decimal degrees.")
+    p_add.add_argument("--lon", required=True, help="Longitude, decimal degrees.")
+    p_add.add_argument("--altitude", required=True, help="Altitude, metres.")
+    p_add.add_argument(
+        "--date-start",
+        required=True,
+        help="Station start date (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS); the "
+        "date_from for every attribute and the site join.",
+    )
+    p_add.add_argument(
+        "--continuity",
+        required=True,
+        help="Measurement continuity, e.g. 'continuous' or 'campaign'.",
+    )
+    # --- catalog-defaulted (override only) ---
+    p_add.add_argument(
+        "--subtype",
+        default=None,
+        help="Station kind attribute (catalog default: 'GPS stöð').",
+    )
+    p_add.add_argument(
+        "--operational-class", default=None, help="Operational class (default: 'B')."
+    )
+    p_add.add_argument(
+        "--geological-characteristic",
+        default=None,
+        help="Geological characteristic (default: 'bedrock').",
+    )
+    p_add.add_argument(
+        "--is-near-fault-zones",
+        default=None,
+        help="Near fault zones (default: 'yes').",
+    )
+    p_add.add_argument(
+        "--bedrock-condition",
+        default=None,
+        help="Bedrock condition (default: 'weathered').",
+    )
+    p_add.add_argument(
+        "--bedrock-type", default=None, help="Bedrock type (default: 'igneous')."
+    )
+    p_add.add_argument(
+        "--in-network-epos", default=None, help="In EPOS network (default: 'nei')."
+    )
+    # --- location resolution (find-or-create) ---
+    loc_group = p_add.add_mutually_exclusive_group()
+    loc_group.add_argument(
+        "--location-id",
+        type=int,
+        default=None,
+        help="Attach to this existing `land` site id_entity (must be a land "
+        "entity). Skips find-or-create.",
+    )
+    loc_group.add_argument(
+        "--location-name",
+        default=None,
+        help="Site name to find-or-create (default: --name).",
+    )
+    p_add.add_argument(
+        "--create-location",
+        action="store_true",
+        help="Require a FRESH site: error if a site with the resolved name "
+        "already exists (instead of reusing it).",
+    )
+    # --- common ---
+    p_add.add_argument(
+        "--force",
+        action="store_true",
+        help="Create the station even if its marker already exists in TOS "
+        "(bypasses the duplicate-marker guard).",
+    )
+    p_add.add_argument(
+        "--no-dry-run",
+        action="store_true",
+        help="Commit the writes. Without this flag, payloads are logged only.",
+    )
+    p_add.add_argument(
+        "--json", action="store_true", help="Emit a structured JSON summary."
+    )
+    p_add.add_argument(
+        "--triage",
+        type=Path,
+        default=None,
+        help="Substitute the new station id_entity into a triage file "
+        "in-place (requires --placeholder).",
+    )
+    p_add.add_argument(
+        "--placeholder",
+        help="Token name to substitute in --triage (matched as '<TOKEN>'). "
+        "Required when --triage is given.",
+    )
+    p_add.add_argument(
+        "--server",
+        default="vi-api.vedur.is",
+        help="TOS API host (default: vi-api.vedur.is).",
+    )
+    p_add.add_argument("--port", type=int, default=443)
 
 
 def _station_triage_main(args) -> int:
@@ -3180,6 +3320,228 @@ def _filter_contacts(
                 continue
         out.append(c)
     return out
+
+
+def _station_add_main(args) -> int:
+    """Create a geophysical station shell + find-or-create its land site + join.
+
+    Station-shell only (devices added afterwards via ``tos device add`` +
+    ``create-join``). See docs/architecture/station-location-add.md.
+    """
+    from . import location as location_helpers
+    from . import station as station_helpers
+    from .api.tos_writer import TOSWriter
+
+    # ---- Validate + shape station attributes -----------------------------
+    try:
+        date_start = station_helpers.normalize_date_start(args.date_start)
+    except ValueError as e:
+        print(f"Invalid --date-start: {e}", file=sys.stderr)
+        return 2
+
+    provided = {
+        "marker": args.marker,
+        "name": args.name,
+        "lat": args.lat,
+        "lon": args.lon,
+        "altitude": args.altitude,
+        "continuity": args.continuity,
+        "subtype": args.subtype,
+        "operational_class": args.operational_class,
+        "geological_characteristic": args.geological_characteristic,
+        "is_near_fault_zones": args.is_near_fault_zones,
+        "bedrock_condition": args.bedrock_condition,
+        "bedrock_type": args.bedrock_type,
+        "in_network_epos": args.in_network_epos,
+    }
+    try:
+        station_attrs = station_helpers.build_required_station_attributes(
+            provided=provided, date_start=date_start
+        )
+    except ValueError as e:
+        print(str(e), file=sys.stderr)
+        return 2
+
+    if (args.triage is not None) != (args.placeholder is not None):
+        print("--triage and --placeholder must be used together", file=sys.stderr)
+        return 2
+
+    # ---- Writer setup ----------------------------------------------------
+    scheme = "https" if args.port == 443 else "http"
+    base_url = f"{scheme}://{args.server}:{args.port}/tos/v1"
+    dry_run = not args.no_dry_run
+    writer = TOSWriter(base_url=base_url, dry_run=dry_run)
+
+    # ---- Pre-flight: duplicate-marker guard ------------------------------
+    existing_marker_id = writer.find_station_by_marker(args.marker)
+    if existing_marker_id is not None and not args.force:
+        print(
+            f"A station with marker {args.marker!r} already exists "
+            f"(id_entity={existing_marker_id}). Pass --force to add anyway, "
+            f"or pick a different marker.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # ---- Resolve the land site (find-or-create) --------------------------
+    site_id, site_reused, rc = _resolve_station_site(
+        writer, args, date_start, location_helpers
+    )
+    if rc is not None:
+        return rc
+
+    # ---- Create the station entity ---------------------------------------
+    try:
+        response = writer.create_entity(station_helpers.STATION_SUBTYPE, station_attrs)
+    except Exception as e:  # noqa: BLE001 — a just-minted site may be orphaned
+        msg = f"Station create failed: {e}."
+        if not site_reused and site_id is not None:
+            # A fresh `land` site was minted moments ago and TOS has no
+            # entity-delete — flag the orphan so the operator reuses it.
+            msg += (
+                f" NOTE: a new `land` site (id_entity={site_id}) was just "
+                f"created and CANNOT be deleted — reuse it on retry with "
+                f"--location-id {site_id}."
+            )
+        print(msg, file=sys.stderr)
+        return 1
+    station_id = response.get("id_entity") if isinstance(response, dict) else None
+    if not args.json:
+        suffix = " (dry-run)" if dry_run else ""
+        id_str = station_id if station_id is not None else "<would be assigned>"
+        print(
+            f"Created station marker={args.marker!r} subtype=geophysical "
+            f"id_entity={id_str}{suffix}"
+        )
+
+    # ---- Join station under the site -------------------------------------
+    join_response: Any
+    if dry_run or station_id is None or site_id is None:
+        if not args.json:
+            print(
+                f"  Would join station (child={station_id or '<new>'}) under "
+                f"site (parent={site_id or '<new>'}) at time_from={date_start}."
+            )
+        join_response = {"dry_run": True, "parent": site_id, "child": station_id}
+    else:
+        try:
+            join_response = writer.create_entity_connection(
+                id_parent=site_id, id_child=station_id, time_from=date_start
+            )
+        except Exception as e:  # noqa: BLE001 — surface the orphaned station id
+            print(
+                f"Station created (id_entity={station_id}) but the join to "
+                f"site {site_id} failed: {e}. Re-run the join manually "
+                f"(ACTION {station_id} create-join {site_id} {args.date_start}).",
+                file=sys.stderr,
+            )
+            return 1
+
+    # ---- Triage handoff (station id) + JSON ------------------------------
+    _location_triage_handoff(args, station_id)
+
+    if args.json:
+        import json as _json
+
+        print(
+            _json.dumps(
+                {
+                    "marker": args.marker,
+                    "name": args.name,
+                    "station_id": station_id,
+                    "site_id": site_id,
+                    "site_reused": site_reused,
+                    "dry_run": dry_run,
+                    "date_start": date_start,
+                    "attributes": station_attrs,
+                    "join": join_response,
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+        )
+    return 0
+
+
+def _resolve_station_site(writer, args, date_start, location_helpers):
+    """Resolve the land site for a station add — find-or-create.
+
+    Returns ``(site_id, site_reused, rc)``. When ``rc`` is not ``None`` the
+    caller should return it immediately (an error). ``site_id`` is ``None``
+    only when a fresh site is minted in dry-run (no real id yet).
+    """
+    # Explicit existing site by id.
+    if args.location_id is not None:
+        history = writer.get_entity_history(args.location_id)
+        subtype = history.get("code_entity_subtype") if history else None
+        if subtype != location_helpers.LOCATION_SUBTYPE:
+            print(
+                f"--location-id {args.location_id} is not a `land` site "
+                f"(code_entity_subtype={subtype!r}). Pass the id of a land "
+                f"location.",
+                file=sys.stderr,
+            )
+            return None, False, 2
+        if not args.json:
+            print(f"Attaching to existing site id_entity={args.location_id}.")
+            _print_location_children(
+                location_helpers.summarize_location_children(writer, args.location_id)
+            )
+            _print_site_power(writer, args.location_id)
+        return args.location_id, True, None
+
+    # Resolve by name (default: the station's own name).
+    site_name = args.location_name or args.name
+    found = writer.find_land_location_by_name(site_name)
+
+    if found is not None:
+        if args.create_location:
+            print(
+                f"--create-location was given but a `land` site named "
+                f"{site_name!r} already exists (id_entity={found}). Drop "
+                f"--create-location to reuse it, or pick another name.",
+                file=sys.stderr,
+            )
+            return None, False, 2
+        if not args.json:
+            print(
+                f"Site {site_name!r} already exists (id_entity={found}) — "
+                f"attaching the new station to it."
+            )
+            _print_location_children(
+                location_helpers.summarize_location_children(writer, found)
+            )
+            _print_site_power(writer, found)
+        return found, True, None
+
+    # No site → auto-mint from the station's name + coordinates.
+    try:
+        site_attrs = location_helpers.build_location_attributes(
+            name=site_name,
+            lat=args.lat,
+            lon=args.lon,
+            altitude=args.altitude,
+            date_start=date_start,
+        )
+    except ValueError as e:
+        print(str(e), file=sys.stderr)
+        return None, False, 2
+
+    dry_run = not args.no_dry_run
+    if not args.json:
+        print(
+            f"No existing `land` site named {site_name!r} — creating one from "
+            f"the station's coordinates. NOTE: a `land` entity is NOT "
+            f"deletable in TOS; this write is irreversible once committed.",
+            file=sys.stderr,
+        )
+    response = writer.create_entity(location_helpers.LOCATION_SUBTYPE, site_attrs)
+    site_id = response.get("id_entity") if isinstance(response, dict) else None
+    if not args.json:
+        suffix = " (dry-run)" if dry_run else ""
+        id_str = site_id if site_id is not None else "<would be assigned>"
+        print(f"Created land site {site_name!r} id_entity={id_str}{suffix}")
+    return site_id, False, None
 
 
 def _location_main(argv):
@@ -9983,6 +10345,10 @@ def _print_top_level_help() -> None:
         "             `tos device show --id N`.\n"
         "\n"
         "  station    Top-level station orchestration. Subverbs:\n"
+        "               station add --marker M --name N ...\n"
+        "                                       Create a geophysical station\n"
+        "                                       shell + find-or-create its land\n"
+        "                                       site + join. Dry-run default.\n"
         "               station triage <STN>    Generate combined triage file\n"
         "                                       (commented ACTION lines).\n"
         "               station verify <STN>    Re-run audits; exit 0 clean,\n"

--- a/tests/test_location_add.py
+++ b/tests/test_location_add.py
@@ -1,0 +1,514 @@
+"""Tests for ``tos location add`` — the ``land`` site find-or-create verb.
+
+Three layers:
+
+1. :mod:`tostools.location` helpers — coordinate validation, attribute
+   shaping, child summary.
+2. :meth:`TOSWriter.find_land_location_by_name` — the idempotent reuse lookup.
+3. The CLI (``tostools.tos._location_main`` / ``_location_add_main``) — wired
+   against a fake writer, exercising the reuse / create / --force / validation
+   / triage-handoff paths.
+
+The driving domain fact (operator-confirmed): a new GPS station is usually
+colocated at a site that already exists because a SIL seismic station is
+there — so "location already exists" is the COMMON, idempotent path, not an
+error.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+from unittest.mock import patch
+
+import pytest
+
+from tostools.api.tos_writer import TOSWriter
+from tostools.location import (
+    LOCATION_OPTIONAL_ATTR_CODES,
+    build_location_attributes,
+    summarize_location_children,
+    validate_altitude,
+    validate_latitude,
+    validate_longitude,
+)
+
+# ---------------------------------------------------------------------------
+# Layer 1 — location.py helpers
+# ---------------------------------------------------------------------------
+
+
+def test_validate_latitude_accepts_in_range() -> None:
+    assert validate_latitude("66.0807") == "66.0807"
+    assert validate_latitude("-90") == "-90"
+    assert validate_latitude("90") == "90"
+
+
+def test_validate_latitude_rejects_out_of_range() -> None:
+    with pytest.raises(ValueError, match="between -90 and 90"):
+        validate_latitude("90.1")
+
+
+def test_validate_longitude_rejects_out_of_range() -> None:
+    with pytest.raises(ValueError, match="between -180 and 180"):
+        validate_longitude("181")
+
+
+def test_validate_coordinate_rejects_non_numeric() -> None:
+    with pytest.raises(ValueError, match="lat must be numeric"):
+        validate_latitude("north")
+    with pytest.raises(ValueError, match="altitude must be numeric"):
+        validate_altitude("high")
+
+
+def test_validate_altitude_accepts_negative() -> None:
+    # Below sea level is legitimate.
+    assert validate_altitude("-12.5") == "-12.5"
+
+
+def test_build_location_attributes_required_shape() -> None:
+    attrs = build_location_attributes(
+        name="Héðinshöfði",
+        lat="66.0807",
+        lon="-17.3095",
+        altitude="143",
+        date_start="2026-06-07T00:00:00",
+    )
+    codes = [a["code"] for a in attrs]
+    assert codes == ["name", "lat", "lon", "altitude"]
+    for a in attrs:
+        assert a["date_from"] == "2026-06-07T00:00:00"
+        assert a["date_to"] is None
+
+
+def test_build_location_attributes_includes_optionals_in_order() -> None:
+    attrs = build_location_attributes(
+        name="X",
+        lat="65",
+        lon="-19",
+        altitude="10",
+        date_start="2026-01-01T00:00:00",
+        notes="hi",
+        identifier="TST",
+    )
+    codes = [a["code"] for a in attrs]
+    # Optionals appended in LOCATION_OPTIONAL_ATTR_CODES order, not kwarg order.
+    assert codes == ["name", "lat", "lon", "altitude", "identifier", "notes"]
+    assert all(
+        c in (("name", "lat", "lon", "altitude") + LOCATION_OPTIONAL_ATTR_CODES)
+        for c in codes
+    )
+
+
+def test_build_location_attributes_omits_blank_optionals() -> None:
+    attrs = build_location_attributes(
+        name="X",
+        lat="65",
+        lon="-19",
+        altitude="10",
+        date_start="2026-01-01T00:00:00",
+        identifier="",
+        notes=None,
+    )
+    assert [a["code"] for a in attrs] == ["name", "lat", "lon", "altitude"]
+
+
+def test_build_location_attributes_empty_name_raises() -> None:
+    with pytest.raises(ValueError, match="name must be a non-empty"):
+        build_location_attributes(
+            name="  ",
+            lat="65",
+            lon="-19",
+            altitude="10",
+            date_start="2026-01-01T00:00:00",
+        )
+
+
+def test_build_location_attributes_invalid_coord_raises() -> None:
+    with pytest.raises(ValueError, match="between -90 and 90"):
+        build_location_attributes(
+            name="X",
+            lat="999",
+            lon="-19",
+            altitude="10",
+            date_start="2026-01-01T00:00:00",
+        )
+
+
+class _FakeHistoryWriter:
+    """Minimal writer exposing ``get_entity_history`` for summary tests."""
+
+    def __init__(self, histories: Dict[int, Dict[str, Any]]) -> None:
+        self._histories = histories
+
+    def get_entity_history(self, entity_id: int) -> Optional[Dict[str, Any]]:
+        return self._histories.get(int(entity_id))
+
+
+def _attr(code: str, value: str) -> Dict[str, Any]:
+    return {"code": code, "value": value, "date_from": "2000", "date_to": None}
+
+
+def test_summarize_location_children_resolves_subtype_and_name() -> None:
+    histories = {
+        4315: {
+            "children_connections": [
+                {"id_entity_child": 4316, "time_from": "2006", "time_to": None},
+                {"id_entity_child": 5442, "time_from": "2000", "time_to": None},
+            ]
+        },
+        4316: {
+            "code_entity_subtype": "geophysical",
+            "attributes": [_attr("subtype", "GPS stöð"), _attr("name", "Héð")],
+        },
+        5442: {
+            "code_entity_subtype": "geophysical",
+            "attributes": [_attr("subtype", "SIL stöð"), _attr("name", "Héð")],
+        },
+    }
+    children = summarize_location_children(_FakeHistoryWriter(histories), 4315)
+    # Sorted most-recent time_from first → GPS (2006) before SIL (2000).
+    assert [c["subtype"] for c in children] == ["GPS stöð", "SIL stöð"]
+    assert children[0]["id_entity"] == 4316
+    assert children[1]["code_entity_subtype"] == "geophysical"
+    assert all(c["open"] for c in children)
+
+
+def test_summarize_location_children_open_only_filters_closed() -> None:
+    histories = {
+        1: {
+            "children_connections": [
+                {"id_entity_child": 2, "time_from": "2000", "time_to": "2005"},
+                {"id_entity_child": 3, "time_from": "2006", "time_to": None},
+            ]
+        },
+        2: {"code_entity_subtype": "geophysical", "attributes": []},
+        3: {"code_entity_subtype": "geophysical", "attributes": []},
+    }
+    open_only = summarize_location_children(_FakeHistoryWriter(histories), 1)
+    assert [c["id_entity"] for c in open_only] == [3]
+    both = summarize_location_children(
+        _FakeHistoryWriter(histories), 1, open_only=False
+    )
+    assert {c["id_entity"] for c in both} == {2, 3}
+
+
+def test_summarize_location_children_empty_history() -> None:
+    assert summarize_location_children(_FakeHistoryWriter({}), 999) == []
+
+
+# ---------------------------------------------------------------------------
+# Layer 2 — TOSWriter.find_land_location_by_name
+# ---------------------------------------------------------------------------
+
+
+def _writer() -> TOSWriter:
+    return TOSWriter(dry_run=True, username="u", password="p")
+
+
+def _name_hit(entity_id: int, name: str, id_lvl_two: Optional[int]) -> dict:
+    return {
+        "code": "name",
+        "value_varchar": name,
+        "distance": 0,
+        "id_entity": entity_id,
+        "id_lvl_two": id_lvl_two,
+    }
+
+
+def test_find_land_location_returns_lvl_one_confirmed_land() -> None:
+    w = _writer()
+    search = [
+        _name_hit(4316, "Héðinshöfði", id_lvl_two=4316),  # station
+        _name_hit(4315, "Héðinshöfði", id_lvl_two=None),  # the land site
+    ]
+    land_history = {"code_entity_subtype": "land"}
+    with patch.object(w, "_request") as req:
+        # 1: basic_search, 2: confirm history for the lvl-one candidate (4315)
+        req.side_effect = [search, land_history]
+        assert w.find_land_location_by_name("Héðinshöfði") == 4315
+    # The first confirm GET should target the lvl-one hit, not the station.
+    assert req.call_args_list[1].args[1] == "/history/entity/4315/"
+
+
+def test_find_land_location_returns_none_when_only_station_matches() -> None:
+    w = _writer()
+    search = [_name_hit(4316, "Héðinshöfði", id_lvl_two=4316)]
+    station_history = {"code_entity_subtype": "geophysical"}
+    with patch.object(w, "_request") as req:
+        req.side_effect = [search, station_history]
+        assert w.find_land_location_by_name("Héðinshöfði") is None
+
+
+def test_find_land_location_none_on_empty_name() -> None:
+    w = _writer()
+    with patch.object(w, "_request") as req:
+        assert w.find_land_location_by_name("") is None
+        req.assert_not_called()
+
+
+def test_find_land_location_none_on_no_hits() -> None:
+    w = _writer()
+    with patch.object(w, "_request", return_value=[]):
+        assert w.find_land_location_by_name("Nowhere") is None
+
+
+def test_find_land_location_skips_distance_and_value_mismatch() -> None:
+    w = _writer()
+    search = [
+        {
+            "code": "name",
+            "value_varchar": "Other",
+            "distance": 0,
+            "id_lvl_two": None,
+            "id_entity": 1,
+        },
+        {
+            "code": "name",
+            "value_varchar": "Place",
+            "distance": 3,
+            "id_lvl_two": None,
+            "id_entity": 2,
+        },
+    ]
+    with patch.object(w, "_request", return_value=search) as req:
+        assert w.find_land_location_by_name("Place") is None
+        # Only the basic_search call — no candidate cleared the filters.
+        assert req.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Layer 3 — CLI (_location_main / _location_add_main)
+# ---------------------------------------------------------------------------
+
+
+class _FakeWriter:
+    """Records create_entity calls; scripts find/summary results."""
+
+    last_instance: "Optional[_FakeWriter]" = None
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.dry_run = kwargs.get("dry_run", True)
+        self.existing_id: Optional[int] = None
+        self.children: List[Dict[str, Any]] = []
+        self.create_calls: List[tuple] = []
+        self.create_response: Any = {"id_entity": None}
+        _FakeWriter.last_instance = self
+
+    def find_land_location_by_name(self, name: str) -> Optional[int]:
+        return self.existing_id
+
+    def get_entity_history(self, entity_id: int) -> Dict[str, Any]:
+        return {"children_connections": []}
+
+    def create_entity(self, subtype: str, attributes: List[Dict[str, Any]]) -> Any:
+        self.create_calls.append((subtype, attributes))
+        return self.create_response
+
+
+def _run_cli(argv: List[str], configure=None) -> int:
+    """Run ``tos location <argv>`` with TOSWriter replaced by _FakeWriter.
+
+    *configure* is an optional callback invoked with the fake instance right
+    after construction, so a test can set existing_id / children / response.
+    Patched via a subclass so per-instance config lands before the CLI uses it.
+    """
+    from tostools import location as location_mod
+    from tostools.tos import _location_main
+
+    # Reset so a test can assert "writer never constructed" (validation that
+    # fails before TOSWriter() leaves this None).
+    _FakeWriter.last_instance = None
+    created: Dict[str, Any] = {}
+
+    class _Configured(_FakeWriter):
+        def __init__(self, *a: Any, **k: Any) -> None:
+            super().__init__(*a, **k)
+            created["w"] = self
+            if configure:
+                configure(self)
+
+    with (
+        patch("tostools.api.tos_writer.TOSWriter", _Configured),
+        patch.object(
+            location_mod,
+            "summarize_location_children",
+            lambda w, lid, **kw: getattr(w, "children", []),
+        ),
+    ):
+        return _location_main(argv)
+
+
+def _base_args() -> List[str]:
+    return [
+        "add",
+        "--name",
+        "Teststaður",
+        "--lat",
+        "65.1",
+        "--lon",
+        "-19.2",
+        "--altitude",
+        "120",
+        "--date-start",
+        "2026-06-07",
+    ]
+
+
+def test_cli_reuse_existing_skips_create(capsys) -> None:
+    def cfg(w: _FakeWriter) -> None:
+        w.existing_id = 4315
+        w.children = [
+            {
+                "id_entity": 5442,
+                "subtype": "SIL stöð",
+                "code_entity_subtype": "geophysical",
+                "name": "Héð",
+                "time_from": "2000",
+                "open": True,
+            },
+        ]
+
+    rc = _run_cli(_base_args(), configure=cfg)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "already exists" in out
+    assert "SIL stöð" in out
+    assert "tos station add --location-id 4315" in out
+    # No create on the reuse path.
+    assert _FakeWriter.last_instance is not None
+    assert _FakeWriter.last_instance.create_calls == []
+
+
+def test_cli_create_path_warns_exact_match_and_irreversible(capsys) -> None:
+    # existing_id stays None → create path emits the spelling / no-delete
+    # caution to stderr so the operator looks before --no-dry-run.
+    rc = _run_cli(_base_args())
+    err = capsys.readouterr().err
+    assert rc == 0
+    assert "exact" in err.lower()
+    assert "irreversible" in err.lower()
+
+
+def test_cli_create_new_dry_run(capsys) -> None:
+    rc = _run_cli(_base_args())  # existing_id stays None → create
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "would be assigned" in out
+    assert "(dry-run)" in out
+    w = _FakeWriter.last_instance
+    assert w is not None and len(w.create_calls) == 1
+    subtype, attrs = w.create_calls[0]
+    assert subtype == "land"
+    assert [a["code"] for a in attrs][:4] == ["name", "lat", "lon", "altitude"]
+
+
+def test_cli_create_live_reports_id_and_triage(tmp_path, capsys) -> None:
+    triage = tmp_path / "onboard.txt"
+    triage.write_text("parent = <SITE_ID>\n", encoding="utf-8")
+
+    def cfg(w: _FakeWriter) -> None:
+        w.create_response = {"id_entity": 7777}
+
+    argv = _base_args() + [
+        "--no-dry-run",
+        "--triage",
+        str(triage),
+        "--placeholder",
+        "SITE_ID",
+    ]
+    rc = _run_cli(argv, configure=cfg)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "id_entity=7777" in out
+    assert triage.read_text(encoding="utf-8") == "parent = 7777\n"
+
+
+def test_cli_reused_id_substituted_into_triage_even_in_dry_run(tmp_path) -> None:
+    triage = tmp_path / "onboard.txt"
+    triage.write_text("parent = <SITE_ID>\n", encoding="utf-8")
+
+    def cfg(w: _FakeWriter) -> None:
+        w.existing_id = 4315
+
+    argv = _base_args() + ["--triage", str(triage), "--placeholder", "SITE_ID"]
+    rc = _run_cli(argv, configure=cfg)
+    assert rc == 0
+    # Reused site has a real id even in dry-run → substitution proceeds.
+    assert triage.read_text(encoding="utf-8") == "parent = 4315\n"
+
+
+def test_cli_force_creates_duplicate_with_warning(capsys) -> None:
+    def cfg(w: _FakeWriter) -> None:
+        w.existing_id = 4315
+
+    rc = _run_cli(_base_args() + ["--force"], configure=cfg)
+    err = capsys.readouterr().err
+    assert rc == 0
+    assert "duplicate" in err.lower()
+    w = _FakeWriter.last_instance
+    assert w is not None and len(w.create_calls) == 1
+
+
+def test_cli_invalid_coord_exits_2_without_writer(capsys) -> None:
+    argv = [
+        "add",
+        "--name",
+        "X",
+        "--lat",
+        "999",
+        "--lon",
+        "-19",
+        "--altitude",
+        "10",
+        "--date-start",
+        "2026-06-07",
+    ]
+    rc = _run_cli(argv)
+    assert rc == 2
+    assert "between -90 and 90" in capsys.readouterr().err
+    # Validation fails before the writer is even constructed.
+    assert _FakeWriter.last_instance is None
+
+
+def test_cli_invalid_date_exits_2(capsys) -> None:
+    argv = [
+        "add",
+        "--name",
+        "X",
+        "--lat",
+        "65",
+        "--lon",
+        "-19",
+        "--altitude",
+        "10",
+        "--date-start",
+        "not-a-date",
+    ]
+    rc = _run_cli(argv)
+    assert rc == 2
+    assert "Invalid --date-start" in capsys.readouterr().err
+
+
+def test_cli_triage_without_placeholder_exits_2(capsys) -> None:
+    argv = _base_args() + ["--triage", "/tmp/x.txt"]
+    rc = _run_cli(argv)
+    assert rc == 2
+    assert "must be used together" in capsys.readouterr().err
+
+
+def test_cli_json_output_shape(capsys) -> None:
+    import json
+
+    rc = _run_cli(_base_args() + ["--json"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    payload = json.loads(out)
+    assert payload["name"] == "Teststaður"
+    assert payload["reused_existing"] is False
+    assert payload["dry_run"] is True
+    assert [a["code"] for a in payload["attributes"]][:4] == [
+        "name",
+        "lat",
+        "lon",
+        "altitude",
+    ]

--- a/tests/test_location_add.py
+++ b/tests/test_location_add.py
@@ -290,6 +290,7 @@ class _FakeWriter:
         self.dry_run = kwargs.get("dry_run", True)
         self.existing_id: Optional[int] = None
         self.children: List[Dict[str, Any]] = []
+        self.power_rows: List[Dict[str, Any]] = []
         self.create_calls: List[tuple] = []
         self.create_response: Any = {"id_entity": None}
         _FakeWriter.last_instance = self
@@ -327,12 +328,19 @@ def _run_cli(argv: List[str], configure=None) -> int:
             if configure:
                 configure(self)
 
+    import tostools.power as power_mod
+
     with (
         patch("tostools.api.tos_writer.TOSWriter", _Configured),
         patch.object(
             location_mod,
             "summarize_location_children",
             lambda w, lid, **kw: getattr(w, "children", []),
+        ),
+        patch.object(
+            power_mod,
+            "summarize_site_power",
+            lambda w, lid, **kw: getattr(w, "power_rows", []),
         ),
     ):
         return _location_main(argv)
@@ -377,6 +385,40 @@ def test_cli_reuse_existing_skips_create(capsys) -> None:
     # No create on the reuse path.
     assert _FakeWriter.last_instance is not None
     assert _FakeWriter.last_instance.create_calls == []
+
+
+def test_cli_reuse_surfaces_site_power(capsys) -> None:
+    def cfg(w: _FakeWriter) -> None:
+        w.existing_id = 4360
+        w.power_rows = [
+            {
+                "id_entity": 16486,
+                "subtype": "battery",
+                "model": "Vision",
+                "on_station": 5487,
+                "on_station_name": "Mjóaskarð",
+                "sensor_tied": False,
+            },
+        ]
+
+    rc = _run_cli(_base_args(), configure=cfg)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Site power" in out
+    assert "battery" in out
+    assert "Mjóaskarð" in out
+    assert "don't duplicate" in out
+
+
+def test_cli_reuse_reports_no_site_power(capsys) -> None:
+    def cfg(w: _FakeWriter) -> None:
+        w.existing_id = 4315
+        w.power_rows = []  # HEDI: no power modelled
+
+    rc = _run_cli(_base_args(), configure=cfg)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "none modelled yet" in out
 
 
 def test_cli_create_path_warns_exact_match_and_irreversible(capsys) -> None:

--- a/tests/test_power.py
+++ b/tests/test_power.py
@@ -1,0 +1,162 @@
+"""Tests for ``tostools.power`` — shared-power surfacing (W1).
+
+``summarize_site_power`` walks a ``land`` site's colocated stations (and any
+power joined directly to the site) and returns one row per power device, so an
+operator reusing a site sees the existing supply instead of duplicating it.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from tostools.power import (
+    POWER_DEVICE_SUBTYPES,
+    SENSOR_TIED_POWER_SUBTYPES,
+    summarize_site_power,
+)
+
+
+class _FakeHistoryWriter:
+    """Serves ``get_entity_history`` from a fixed ``{id: history}`` map."""
+
+    def __init__(self, histories: Dict[int, Dict[str, Any]]) -> None:
+        self._histories = histories
+
+    def get_entity_history(self, entity_id: int) -> Optional[Dict[str, Any]]:
+        return self._histories.get(int(entity_id))
+
+
+def _attr(code: str, value: str) -> Dict[str, Any]:
+    return {"code": code, "value": value, "date_from": "2000", "date_to": None}
+
+
+def _station(name: str, *children) -> Dict[str, Any]:
+    return {
+        "code_entity_subtype": "geophysical",
+        "attributes": [_attr("name", name)],
+        "children_connections": list(children),
+    }
+
+
+def _device(subtype: str, model: str = "M", serial: str = "S") -> Dict[str, Any]:
+    return {
+        "code_entity_subtype": subtype,
+        "attributes": [_attr("model", model), _attr("serial_number", serial)],
+        "children_connections": [],
+    }
+
+
+def _conn(child_id: int, time_from: str = "2010", time_to=None) -> Dict[str, Any]:
+    return {"id_entity_child": child_id, "time_from": time_from, "time_to": time_to}
+
+
+def test_subtype_sets_are_sane() -> None:
+    assert "battery" in POWER_DEVICE_SUBTYPES
+    assert "solar_panel" in POWER_DEVICE_SUBTYPES
+    # sensor-tied power is a subset of the power family
+    assert SENSOR_TIED_POWER_SUBTYPES <= POWER_DEVICE_SUBTYPES
+
+
+def test_aggregates_power_across_colocated_stations() -> None:
+    histories = {
+        4360: {  # the land site
+            "code_entity_subtype": "land",
+            "children_connections": [_conn(5487, "2010-06"), _conn(18071, "2010-08")],
+        },
+        5487: _station("Mjóaskarð", _conn(16486), _conn(4905)),
+        18071: _station("Mjóaskarð - Endurvarpi", _conn(21468)),
+        16486: _device("battery", "Vision"),
+        4905: _device("gnss_receiver", "PolaRx5"),  # NOT power — ignored
+        21468: _device("battery", "Sunark"),
+    }
+    rows = summarize_site_power(_FakeHistoryWriter(histories), 4360)
+    assert {r["id_entity"] for r in rows} == {16486, 21468}
+    by_id = {r["id_entity"]: r for r in rows}
+    assert by_id[16486]["on_station"] == 5487
+    assert by_id[16486]["on_station_name"] == "Mjóaskarð"
+    assert by_id[16486]["model"] == "Vision"
+    assert by_id[21468]["on_station"] == 18071
+
+
+def test_site_direct_power_has_no_station_and_sorts_first() -> None:
+    histories = {
+        1: {
+            "code_entity_subtype": "land",
+            "children_connections": [_conn(2, "2010"), _conn(9, "2009")],
+        },
+        # 9 is power joined DIRECTLY to the site (W3 target state)
+        9: _device("solar_panel", "Offgridtec"),
+        2: _station("Stn", _conn(3)),
+        3: _device("battery"),
+    }
+    rows = summarize_site_power(_FakeHistoryWriter(histories), 1)
+    assert rows[0]["id_entity"] == 9  # site-direct sorts before station power
+    assert rows[0]["on_station"] is None
+    assert rows[1]["id_entity"] == 3
+    assert rows[1]["on_station"] == 2
+
+
+def test_open_only_filters_closed_station_join() -> None:
+    histories = {
+        1: {
+            "code_entity_subtype": "land",
+            "children_connections": [
+                _conn(2, "2000", time_to="2005"),  # station no longer at site
+                _conn(3, "2006"),
+            ],
+        },
+        2: _station("Old", _conn(20)),
+        3: _station("Now", _conn(30)),
+        20: _device("battery"),
+        30: _device("battery"),
+    }
+    fw = _FakeHistoryWriter(histories)
+    assert {r["id_entity"] for r in summarize_site_power(fw, 1)} == {30}
+    assert {r["id_entity"] for r in summarize_site_power(fw, 1, open_only=False)} == {
+        20,
+        30,
+    }
+
+
+def test_open_only_filters_closed_power_join() -> None:
+    histories = {
+        1: {
+            "code_entity_subtype": "land",
+            "children_connections": [_conn(2)],
+        },
+        2: _station(
+            "Stn",
+            _conn(20, "2000", time_to="2005"),  # battery swapped out
+            _conn(21, "2005"),
+        ),
+        20: _device("battery", "Old"),
+        21: _device("battery", "New"),
+    }
+    rows = summarize_site_power(_FakeHistoryWriter(histories), 1)
+    assert [r["id_entity"] for r in rows] == [21]
+
+
+def test_sensor_tied_power_is_flagged() -> None:
+    histories = {
+        1: {"code_entity_subtype": "land", "children_connections": [_conn(2)]},
+        2: _station("Wx", _conn(20), _conn(21)),
+        20: _device("anemometer_power_pack"),
+        21: _device("battery"),
+    }
+    rows = summarize_site_power(_FakeHistoryWriter(histories), 1)
+    flags = {r["id_entity"]: r["sensor_tied"] for r in rows}
+    assert flags[20] is True
+    assert flags[21] is False
+
+
+def test_empty_when_no_power() -> None:
+    histories = {
+        1: {"code_entity_subtype": "land", "children_connections": [_conn(2)]},
+        2: _station("Stn", _conn(3)),
+        3: _device("gnss_receiver"),
+    }
+    assert summarize_site_power(_FakeHistoryWriter(histories), 1) == []
+
+
+def test_empty_when_history_missing() -> None:
+    assert summarize_site_power(_FakeHistoryWriter({}), 999) == []

--- a/tests/test_station_add.py
+++ b/tests/test_station_add.py
@@ -1,0 +1,421 @@
+"""Tests for ``tos station add`` — geophysical station shell + site-join.
+
+Two layers:
+
+1. :mod:`tostools.station` helpers — catalog-driven required set + attribute
+   shaping (must-provide vs catalog-defaulted, coordinate validation).
+2. The CLI (``tostools.tos._station_add_main``) against a fake writer —
+   duplicate-marker guard, find-or-create site (existing / auto-mint /
+   --location-id / --create-location conflict), the station create + join,
+   dry-run safety, and the orphaned-station-on-join-failure path.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+from unittest.mock import patch
+
+import pytest
+
+from tostools.station import (
+    STATION_SUBTYPE,
+    build_required_station_attributes,
+    station_required_codes,
+)
+
+# ---------------------------------------------------------------------------
+# Layer 1 — station.py helpers
+# ---------------------------------------------------------------------------
+
+
+def test_station_subtype_is_geophysical() -> None:
+    assert STATION_SUBTYPE == "geophysical"
+
+
+def test_required_codes_split_must_provide_vs_defaulted() -> None:
+    codes = station_required_codes()
+    must_provide = {c for c, d in codes.items() if d is None}
+    defaulted = {c for c, d in codes.items() if d is not None}
+    # Must-provide (no catalog default).
+    assert must_provide == {
+        "marker",
+        "name",
+        "lat",
+        "lon",
+        "altitude",
+        "date_start",
+        "continuity",
+    }
+    # Catalog-defaulted (operator can override).
+    assert {"subtype", "operational_class", "in_network_epos"} <= defaulted
+    assert codes["subtype"] == "GPS stöð"
+
+
+def _full_provided() -> Dict[str, Optional[str]]:
+    return {
+        "marker": "TEST",
+        "name": "Teststaður",
+        "lat": "65.1",
+        "lon": "-19.2",
+        "altitude": "120",
+        "continuity": "continuous",
+    }
+
+
+def test_build_uses_catalog_defaults_for_unprovided() -> None:
+    attrs = build_required_station_attributes(
+        provided=_full_provided(), date_start="2026-06-08T00:00:00"
+    )
+    by_code = {a["code"]: a["value"] for a in attrs}
+    assert by_code["subtype"] == "GPS stöð"
+    assert by_code["operational_class"] == "B"
+    assert by_code["in_network_epos"] == "nei"
+    assert by_code["marker"] == "test"  # lowercased to the fleet convention
+    # date_start attribute carries the date value.
+    assert by_code["date_start"] == "2026-06-08T00:00:00"
+    # Every row open, anchored at date_start.
+    for a in attrs:
+        assert a["date_from"] == "2026-06-08T00:00:00"
+        assert a["date_to"] is None
+
+
+def test_build_override_beats_default() -> None:
+    prov = _full_provided()
+    prov["operational_class"] = "A"
+    prov["subtype"] = "SIL stöð"
+    attrs = build_required_station_attributes(
+        provided=prov, date_start="2026-06-08T00:00:00"
+    )
+    by_code = {a["code"]: a["value"] for a in attrs}
+    assert by_code["operational_class"] == "A"
+    assert by_code["subtype"] == "SIL stöð"
+
+
+def test_build_missing_no_default_reports_all() -> None:
+    prov = _full_provided()
+    del prov["continuity"]  # no catalog default
+    del prov["altitude"]  # no catalog default
+    with pytest.raises(ValueError, match="continuity") as exc:
+        build_required_station_attributes(
+            provided=prov, date_start="2026-06-08T00:00:00"
+        )
+    assert "altitude" in str(exc.value)
+
+
+def test_build_validates_coordinates() -> None:
+    prov = _full_provided()
+    prov["lat"] = "999"
+    with pytest.raises(ValueError, match="between -90 and 90"):
+        build_required_station_attributes(
+            provided=prov, date_start="2026-06-08T00:00:00"
+        )
+
+
+def test_build_lowercases_marker() -> None:
+    # TOS stores markers lowercase (e.g. "hedi"); a new station must match the
+    # fleet convention so find_station_by_marker resolves it.
+    prov = _full_provided()
+    prov["marker"] = "HEDI"
+    attrs = build_required_station_attributes(
+        provided=prov, date_start="2026-06-08T00:00:00"
+    )
+    by_code = {a["code"]: a["value"] for a in attrs}
+    assert by_code["marker"] == "hedi"
+
+
+def test_built_station_passes_missing_attributes_audit() -> None:
+    """The headline claim: a fully-built station shell has zero station-scope
+    missing-attribute violations (justifies keying on gps_required_for)."""
+    from unittest.mock import MagicMock
+
+    import tostools.audit_missing_attributes as ama
+
+    attrs = build_required_station_attributes(
+        provided=_full_provided(), date_start="2026-06-08T00:00:00"
+    )
+    fake_history = {
+        "id_entity": 1,
+        "code_entity_subtype": "geophysical",
+        "attributes": attrs,
+        "children_connections": [],  # no devices yet → no device-scope findings
+    }
+    client = MagicMock()
+    client.get_entity_history.return_value = {}
+    with patch.object(ama, "_resolve_station_entity", return_value=fake_history):
+        report = ama.audit_station_missing_attributes(
+            client, name="Teststaður", use_suppressions=False
+        )
+    assert report.violations == [], [v.code for v in report.violations]
+
+
+# ---------------------------------------------------------------------------
+# Layer 2 — CLI (_station_add_main)
+# ---------------------------------------------------------------------------
+
+
+class _FakeWriter:
+    """Scriptable fake: marker/site lookups + records create / join calls."""
+
+    last_instance: "Optional[_FakeWriter]" = None
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.dry_run = kwargs.get("dry_run", True)
+        self.marker_id: Optional[int] = None  # find_station_by_marker result
+        self.land_id: Optional[int] = None  # find_land_location_by_name result
+        self.location_history: Dict[int, Dict[str, Any]] = {}
+        self.create_calls: List[tuple] = []
+        self.join_calls: List[Dict[str, Any]] = []
+        # create_entity returns these in order (land first if minted, then
+        # station) — default both unknown (dry-run shape).
+        self.create_responses: List[Any] = []
+        self.join_raises = False
+        self.create_raises_on: Optional[str] = None  # subtype that raises
+        _FakeWriter.last_instance = self
+
+    def find_station_by_marker(self, marker: str) -> Optional[int]:
+        return self.marker_id
+
+    def find_land_location_by_name(self, name: str) -> Optional[int]:
+        return self.land_id
+
+    def get_entity_history(self, entity_id: int) -> Dict[str, Any]:
+        return self.location_history.get(int(entity_id), {"children_connections": []})
+
+    def create_entity(self, subtype: str, attributes: List[Dict[str, Any]]) -> Any:
+        if subtype == self.create_raises_on:
+            raise RuntimeError(f"{subtype} create boom")
+        self.create_calls.append((subtype, attributes))
+        if self.create_responses:
+            return self.create_responses.pop(0)
+        return {"id_entity": None}
+
+    def create_entity_connection(self, *, id_parent, id_child, time_from) -> Any:
+        if self.join_raises:
+            raise RuntimeError("join boom")
+        rec = {"id_parent": id_parent, "id_child": id_child, "time_from": time_from}
+        self.join_calls.append(rec)
+        return {"id_connection": 9000, **rec}
+
+
+def _run_cli(argv: List[str], configure=None) -> int:
+    from tostools import location as location_mod
+    from tostools import power as power_mod
+    from tostools.tos import _station_main
+
+    _FakeWriter.last_instance = None
+
+    class _Configured(_FakeWriter):
+        def __init__(self, *a: Any, **k: Any) -> None:
+            super().__init__(*a, **k)
+            if configure:
+                configure(self)
+
+    with (
+        patch("tostools.api.tos_writer.TOSWriter", _Configured),
+        patch.object(
+            location_mod, "summarize_location_children", lambda w, lid, **k: []
+        ),
+        patch.object(power_mod, "summarize_site_power", lambda w, lid, **k: []),
+    ):
+        return _station_main(["add", *argv])
+
+
+def _base_args() -> List[str]:
+    return [
+        "--marker",
+        "ZZZZ",
+        "--name",
+        "Teststaður",
+        "--lat",
+        "65.1",
+        "--lon",
+        "-19.2",
+        "--altitude",
+        "120",
+        "--date-start",
+        "2026-06-08",
+        "--continuity",
+        "continuous",
+    ]
+
+
+def test_cli_duplicate_marker_refused(capsys) -> None:
+    rc = _run_cli(_base_args(), configure=lambda w: setattr(w, "marker_id", 4316))
+    assert rc == 1
+    assert "already exists" in capsys.readouterr().err
+    assert _FakeWriter.last_instance.create_calls == []
+
+
+def test_cli_force_overrides_duplicate_marker() -> None:
+    def cfg(w: _FakeWriter) -> None:
+        w.marker_id = 4316
+        w.land_id = 4360  # reuse existing site
+
+    rc = _run_cli(_base_args() + ["--force"], configure=cfg)
+    assert rc == 0
+    # Station create happened despite the existing marker.
+    assert any(s == "geophysical" for s, _ in _FakeWriter.last_instance.create_calls)
+
+
+def test_cli_attaches_to_existing_site_no_site_create(capsys) -> None:
+    def cfg(w: _FakeWriter) -> None:
+        w.land_id = 4360  # site found by name
+
+    rc = _run_cli(_base_args(), configure=cfg)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "already exists" in out
+    w = _FakeWriter.last_instance
+    # Only the geophysical create — no land create when site is reused.
+    subtypes = [s for s, _ in w.create_calls]
+    assert subtypes == ["geophysical"]
+
+
+def test_cli_auto_mints_site_then_station(capsys) -> None:
+    # land_id stays None → no site found → mint land, then station.
+    rc = _run_cli(_base_args())
+    out = capsys.readouterr().out
+    assert rc == 0
+    w = _FakeWriter.last_instance
+    subtypes = [s for s, _ in w.create_calls]
+    assert subtypes == ["land", "geophysical"]
+    assert "Created station" in out
+
+
+def test_cli_create_location_conflict_when_name_exists(capsys) -> None:
+    def cfg(w: _FakeWriter) -> None:
+        w.land_id = 4360
+
+    rc = _run_cli(_base_args() + ["--create-location"], configure=cfg)
+    assert rc == 2
+    assert "already exists" in capsys.readouterr().err
+    # No writes attempted on the conflict.
+    assert _FakeWriter.last_instance.create_calls == []
+
+
+def test_cli_location_id_must_be_land(capsys) -> None:
+    def cfg(w: _FakeWriter) -> None:
+        w.location_history = {7777: {"code_entity_subtype": "geophysical"}}
+
+    rc = _run_cli(_base_args() + ["--location-id", "7777"], configure=cfg)
+    assert rc == 2
+    assert "not a `land` site" in capsys.readouterr().err
+    assert _FakeWriter.last_instance.create_calls == []
+
+
+def test_cli_location_id_land_attaches() -> None:
+    def cfg(w: _FakeWriter) -> None:
+        w.location_history = {
+            4360: {"code_entity_subtype": "land", "children_connections": []}
+        }
+
+    rc = _run_cli(_base_args() + ["--location-id", "4360"], configure=cfg)
+    assert rc == 0
+    w = _FakeWriter.last_instance
+    assert [s for s, _ in w.create_calls] == ["geophysical"]
+
+
+def test_cli_live_creates_and_joins() -> None:
+    def cfg(w: _FakeWriter) -> None:
+        w.land_id = 4360
+        w.create_responses = [{"id_entity": 8888}]  # the station
+
+    rc = _run_cli(_base_args() + ["--no-dry-run"], configure=cfg)
+    assert rc == 0
+    w = _FakeWriter.last_instance
+    assert w.join_calls == [
+        {"id_parent": 4360, "id_child": 8888, "time_from": "2026-06-08T00:00:00"}
+    ]
+
+
+def test_cli_join_failure_reports_orphaned_station(capsys) -> None:
+    def cfg(w: _FakeWriter) -> None:
+        w.land_id = 4360
+        w.create_responses = [{"id_entity": 8888}]
+        w.join_raises = True
+
+    rc = _run_cli(_base_args() + ["--no-dry-run"], configure=cfg)
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "8888" in err and "create-join" in err
+
+
+def test_cli_station_create_failure_after_mint_flags_orphan_site(capsys) -> None:
+    def cfg(w: _FakeWriter) -> None:
+        # No existing site → mint a fresh land site, then the station create
+        # raises. The just-minted site is irreversible — must be surfaced.
+        w.land_id = None
+        w.create_responses = [{"id_entity": 4400}]  # the minted land site
+        w.create_raises_on = "geophysical"
+
+    rc = _run_cli(_base_args() + ["--no-dry-run"], configure=cfg)
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "4400" in err
+    assert "--location-id 4400" in err
+
+
+def test_cli_missing_required_no_default_exits_2(capsys) -> None:
+    # Drop --continuity (no catalog default). argparse marks it required, so
+    # the parser exits 2 before our code runs.
+    argv = [
+        "--marker",
+        "ZZZZ",
+        "--name",
+        "X",
+        "--lat",
+        "65",
+        "--lon",
+        "-19",
+        "--altitude",
+        "1",
+        "--date-start",
+        "2026-06-08",
+    ]
+    with pytest.raises(SystemExit) as exc:
+        _run_cli(argv)
+    assert exc.value.code == 2
+
+
+def test_cli_invalid_date_exits_2(capsys) -> None:
+    argv = _base_args()
+    argv[argv.index("--date-start") + 1] = "not-a-date"
+    rc = _run_cli(argv)
+    assert rc == 2
+    assert "Invalid --date-start" in capsys.readouterr().err
+
+
+def test_cli_triage_substitutes_station_id(tmp_path) -> None:
+    triage = tmp_path / "onboard.txt"
+    triage.write_text("ACTION <STN_ID> create-join 4360 2026-06-08\n", encoding="utf-8")
+
+    def cfg(w: _FakeWriter) -> None:
+        w.land_id = 4360
+        w.create_responses = [{"id_entity": 8888}]
+
+    rc = _run_cli(
+        _base_args()
+        + ["--no-dry-run", "--triage", str(triage), "--placeholder", "STN_ID"],
+        configure=cfg,
+    )
+    assert rc == 0
+    assert triage.read_text(encoding="utf-8") == (
+        "ACTION 8888 create-join 4360 2026-06-08\n"
+    )
+
+
+def test_cli_json_output_shape(capsys) -> None:
+    import json
+
+    def cfg(w: _FakeWriter) -> None:
+        w.land_id = 4360
+
+    rc = _run_cli(_base_args() + ["--json"], configure=cfg)
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["marker"] == "ZZZZ"
+    assert payload["site_id"] == 4360
+    assert payload["site_reused"] is True
+    assert payload["dry_run"] is True
+    codes = [a["code"] for a in payload["attributes"]]
+    assert "marker" in codes and "operational_class" in codes


### PR DESCRIPTION
Adds the **station-onboarding pair** — the missing verbs to bring a new GPS station online from scratch — plus the first workstream of the shared-power model. Builds on a verified TOS model: a station (`geophysical`) must hang under a `land` **site**, which can host colocated stations (GPS + SIL) sharing one supply.

## What's in it

### `tos location add` + `TOSWriter.find_land_location_by_name`
Find-or-create the `land` site. **Idempotent** — a site that already exists (commonly because a SIL station is colocated there) is reused, its attached stations shown, never duplicated. Dry-run default, `--force` duplicate override, `--triage` handoff.

### W1 — surface shared site power (`tostools.power`)
`summarize_site_power` aggregates power devices across a site's colocated stations (power lives per-station in TOS today) and surfaces them in the reuse view with a "don't duplicate" prompt. Live-verified on Mjóaskarð (9 devices across GPS + SIL + repeater). `POWER_DEVICE_SUBTYPES` / `SENSOR_TIED_POWER_SUBTYPES` shared for the future W2 audit / W3 migration.

### `tos station add`
Creates the `geophysical` station shell, find-or-creates its site, joins them. Required attrs read **dynamically from the catalog** `stations` scope (`gps_required_for`, matching the missing-attributes audit): 7 must-provide, 7 catalog-defaulted. Duplicate-marker guard, marker lowercased to the fleet convention, both irreversible-orphan failure modes surfaced with recovery hints, `summarize_site_power` surfaced on existing-site attach.

### Catalog fix
`locations` scope `[staðsetning]` → `[land]` — `staðsetning` was the Icelandic section name, never a real subtype, so it matched nothing.

## Design docs
- `docs/architecture/station-location-add.md` — verified two-level `land → geophysical` model, locked decisions (find-or-create · shell-only · CLI + `--triage`).
- `docs/architecture/shared-power-model.md` — power belongs on the `land` site; W1 done, W2 audit + W3 migration scoped.

## ⚠️ Verification status
- **Reuse / read paths — live-verified** (HEDI, Mjóaskarð).
- **Create paths (`location add` / `station add`) — dry-run + `_FakeWriter` only, LIVE-UNVERIFIED.** A minted `land`/`geophysical` entity is **irreversible** (TOS has no entity-delete endpoint), so no throwaway test is possible — verify on first genuine use, like the contact-entity writes. The CLI prints an irreversibility caution on every create path.

## Tests
49 new (`test_location_add.py` + `test_power.py` + `test_station_add.py`), including a test that a freshly-built station passes `audit_station_missing_attributes`. **Full suite: 1078 passed**, ruff + black clean.

## Out of scope (separately tracked)
Shared-power **W2** (`tos audit shared-power`) + **W3** (site-power migration); enum allowed-value validation; fuzzy site-name matching; first live create.

🤖 Generated with [Claude Code](https://claude.com/claude-code)