### PR TITLE
fix(igs): correct mosaic-X5 IGS name + antenna identity passthrough

### DIFF
--- a/src/tostools/standards/igs_equipment.py
+++ b/src/tostools/standards/igs_equipment.py
@@ -40,8 +40,11 @@ RECEIVER_IGS: dict[str, str] = {
     # Upper-case variants seen in some contexts:
     "POLARX5": "SEPT POLARX5",
     # Septentrio mosaic-X5 -----------------------------------------------------
-    "mosaic-X5": "SEPT MOSAICX5",
-    "MOSAICX5": "SEPT MOSAICX5",
+    # rcvr_ant.tab spells this with a hyphen: "SEPT MOSAIC-X5".
+    "mosaic-X5": "SEPT MOSAIC-X5",
+    "mosaicX5": "SEPT MOSAIC-X5",
+    "MOSAIC-X5": "SEPT MOSAIC-X5",
+    "MOSAICX5": "SEPT MOSAIC-X5",
     # Septentrio PolaRX3e (historical) -----------------------------------------
     "PolaRX3e": "SEPT POLARX3E",
     "POLARX3E": "SEPT POLARX3E",
@@ -86,6 +89,7 @@ ANTENNA_IGS: dict[str, str] = {
     "TRM41249.00": "TRM41249.00",
     "TRM55971.00": "TRM55971.00",
     "TRM57971.00": "TRM57971.00",
+    "TRM115000.10": "TRM115000.10",  # deployed at GONH
     # Leica antenna ------------------------------------------------------------
     "LEIAR25.R4": "LEIAR25.R4",
     # Ashtech / pre-IGS names seen in historical data:
@@ -180,6 +184,11 @@ def to_igs_antenna(raw: Optional[str]) -> Optional[str]:
     for key, value in ANTENNA_IGS.items():
         if key.upper() == upper:
             return value
+    # Canonical-name identity — accept any value already known to the dict, so an
+    # operator/extractor can supply the rcvr_ant.tab spelling directly without a
+    # redundant identity entry (mirrors to_igs_receiver).
+    if raw in set(ANTENNA_IGS.values()):
+        return raw
     return None
 
 

--- a/tests/test_igs_equipment.py
+++ b/tests/test_igs_equipment.py
@@ -1,0 +1,29 @@
+"""Regression tests for IGS equipment-name lookups (igs_equipment)."""
+
+from tostools.standards.igs_equipment import to_igs_antenna, to_igs_receiver
+
+
+class TestMosaicX5:
+    def test_mosaic_x5_uses_hyphenated_rcvr_ant_tab_name(self):
+        # rcvr_ant.tab spells it "SEPT MOSAIC-X5" (hyphen), not "SEPT MOSAICX5".
+        assert to_igs_receiver("mosaic-X5") == "SEPT MOSAIC-X5"
+
+    def test_mosaic_x5_aliases(self):
+        for alias in ("mosaicX5", "MOSAIC-X5", "MOSAICX5"):
+            assert to_igs_receiver(alias) == "SEPT MOSAIC-X5"
+
+    def test_canonical_mosaic_passthrough(self):
+        assert to_igs_receiver("SEPT MOSAIC-X5") == "SEPT MOSAIC-X5"
+
+
+class TestAntennaPassthrough:
+    def test_listed_antenna(self):
+        assert to_igs_antenna("TRM115000.10") == "TRM115000.10"
+
+    def test_canonical_identity_passthrough(self):
+        # A name already in the table as a value resolves to itself even when not
+        # an explicit key (mirrors to_igs_receiver's identity step).
+        assert to_igs_antenna("TRM57971.00") == "TRM57971.00"
+
+    def test_unknown_antenna_still_none(self):
+        assert to_igs_antenna("DEFINITELY_NOT_AN_ANTENNA") is None


### PR DESCRIPTION
## Summary

Two `igs_equipment` lookup gaps surfaced while building TOS-sourced RINEX header
skeletons for the receivers stream-capture work (receivers PR #98):

1. **`to_igs_receiver("mosaic-X5")`** returned `"SEPT MOSAICX5"`, but rcvr_ant.tab
   (and IMO's hand-made `GONH.SKL`) spell it **`"SEPT MOSAIC-X5"`** (hyphen). Fixed
   the value and added aliases (`mosaicX5`, `MOSAIC-X5`, `MOSAICX5`).

2. **`to_igs_antenna()`** lacked the canonical-name identity passthrough that
   `to_igs_receiver` has, so valid IGS antenna names not explicitly keyed (e.g.
   **`TRM115000.10`**, deployed at GONH) returned `None`. Added `TRM115000.10` to the
   table and the identity passthrough (return raw when it matches a known value).

## Tests

6 new regression tests (`tests/test_igs_equipment.py`); existing device IGS tests
unaffected (18 pass).

> Note: branched off `feat/tos-location-add` (current working branch); retarget to
> `master` if that lands first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)