### PR TITLE
feat(rinex): receiver/firmware timeline from RINEX headers + tos station receivers

### DIFF
--- a/src/tostools/receiver_timeline.py
+++ b/src/tostools/receiver_timeline.py
@@ -1,0 +1,286 @@
+"""Receiver / firmware timeline for a station, from archived RINEX headers.
+
+Complements :mod:`tostools.archive`'s brand detection. ``detect_brand_transitions``
+keys on the *raw* file extension (``.T02``→trimble, ``.sbf``→septentrio) — a fast,
+no-decompression locator of receiver SWAPS — but it goes ``ambiguous`` wherever
+only RINEX (no raw) was archived, which is exactly where many current receivers
+live (e.g. OLKE is RINEX-only since 2017, the whole PolaRX5 era). The RINEX
+``REC # / TYPE / VERS`` header carries type / serial / firmware even there, so
+reading it is the only way to identify the receiver on rinex-only spans — and the
+only way to see *firmware* changes (which never change the file extension).
+
+Efficiency (the hybrid): the brand runs from ``coalesce_brand_runs`` are free
+(directory listing) and bound the search — a ``.T02``→``.sbf`` junction is a known
+boundary, so we only **binary-search RINEX headers WITHIN each brand run** (and
+read the two headers either side of a junction to name the exact models). Headers
+are read at O(sub-segments · log n) days, not every day; for a 25-year station
+that's a few dozen ``gzip -dc`` reads, not thousands.
+
+Equality is on NORMALIZED fields (firmware ``5.50``≡``5.5.0``, type via
+``to_igs_receiver``, placeholder/synthetic serials → unknown) so a boundary is a
+real change, not header-formatting noise. A garbled/truncated header reads as
+``None`` and is treated as "no data, not a boundary".
+
+This module only *reports* the timeline. Driving the TOS write
+(``cfg replace-receiver`` / ``reconcile --push-tos``) is a separate,
+operator-reviewed step — RINEX-derived dates are a strong proxy, not gospel.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Callable, Dict, List, Optional
+
+from .archive import (
+    ArchiveDay,
+    coalesce_brand_runs,
+    cold_archive_prepath,
+    walk_station_timeline,
+)
+from .rinex.reader import read_rinex_header
+from .standards.igs_equipment import to_igs_receiver
+
+logger = logging.getLogger(__name__)
+
+_REC_LABEL = "REC # / TYPE / VERS"
+
+
+# --------------------------------------------------------------------------- header
+@dataclass(frozen=True)
+class ReceiverHeader:
+    serial: Optional[str]
+    rtype: Optional[str]
+    firmware: Optional[str]
+
+    @property
+    def key(self) -> tuple:
+        """Normalized identity — equal keys ⇒ no real receiver change."""
+        return (
+            _norm_type(self.rtype),
+            _norm_serial(self.serial),
+            _norm_fw(self.firmware),
+        )
+
+    @property
+    def is_known(self) -> bool:
+        return any(self.key)
+
+    def __str__(self) -> str:
+        return f"{self.rtype or '?'} sn={self.serial or '?'} fw={self.firmware or '?'}"
+
+
+def _norm_type(rtype: Optional[str]) -> Optional[str]:
+    if not rtype:
+        return None
+    igs = to_igs_receiver(rtype.strip())
+    return (igs or rtype.strip().upper()) or None
+
+
+def _norm_serial(serial: Optional[str]) -> Optional[str]:
+    if not serial:
+        return None
+    s = serial.strip()
+    # RINEX "unknown serial": all-asterisks / punctuation, or zeros.
+    if not any(ch.isalnum() for ch in s) or set(s) <= {"0"}:
+        return None
+    # TOS synthetic identifiers ({subtype}-{STN}[-]{YYYYMMDD}).
+    if re.match(r"^[a-z]+-[A-Za-z0-9]{4}-?\d{8}$", s, re.IGNORECASE):
+        return None
+    return s
+
+
+def _norm_fw(fw: Optional[str]) -> Optional[str]:
+    """Firmware compare key — collapse the known vendor formats to one form.
+
+    * Trimble NetR* ``NP 4.62 / SP 4.62`` → ``4.62`` (the NP/nav version).
+    * Trimble 4700/4000 ``Nav 1.12 Sig 0.00`` → ``1.12`` (the Nav version; Sig is
+      a separate signal-processor rev that tracks Nav, so it's noise here).
+    * Septentrio compact two-digit minor ``5.50`` → ``5.5.0``.
+
+    The point is a *stable* key so ``Nav 1.12 Sig 0.00`` and ``1.12`` (the same
+    firmware written two ways across the archive) don't fragment into phantom
+    segments. The segment still carries the raw string for display.
+    """
+    if not fw:
+        return None
+    s = fw.strip()
+    m = re.match(r"^(?:NP|Nav)\s+([\d.]+(?:-[\w.]+)?)", s, re.IGNORECASE)
+    if m:  # "NP 4.62 / SP 4.62" or "Nav 1.12 Sig 0.00" → the leading version
+        s = m.group(1)
+    parts = s.split(".")
+    if (
+        len(parts) == 2
+        and parts[0].isdigit()
+        and parts[1].isdigit()
+        and len(parts[1]) == 2
+    ):
+        s = f"{parts[0]}.{parts[1][0]}.{parts[1][1]}"
+    return s.lower() or None
+
+
+def parse_receiver_line(line: str) -> Optional[ReceiverHeader]:
+    """Parse one ``REC # / TYPE / VERS`` header line (A20,A20,A20)."""
+    if _REC_LABEL not in line:
+        return None
+    body = line[:60]
+    if len(body) < 21:
+        return None
+    serial = body[0:20].strip() or None
+    rtype = body[20:40].strip() or None
+    firmware = body[40:60].strip() or None
+    if serial is None and rtype is None and firmware is None:
+        return None
+    return ReceiverHeader(serial=serial, rtype=rtype, firmware=firmware)
+
+
+def read_receiver_header(path) -> Optional[ReceiverHeader]:
+    """Receiver header of one archived RINEX file, or None on any failure."""
+    try:
+        data = read_rinex_header(str(path))
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("read_receiver_header(%s): %s", path, exc)
+        return None
+    if not data or "header" not in data:
+        return None
+    header = data["header"]
+    if not isinstance(header, str):
+        return None
+    for line in header.splitlines():
+        if _REC_LABEL in line:
+            return parse_receiver_line(line)
+    return None
+
+
+# ------------------------------------------------------------------------- timeline
+@dataclass(frozen=True)
+class ReceiverSegment:
+    start: date
+    end: date
+    header: ReceiverHeader
+
+
+def _segment_range(
+    days: List[ArchiveDay],
+    lo: int,
+    hi: int,
+    read_fn: Callable[[Path], Optional[ReceiverHeader]],
+    cache: Dict[int, Optional[ReceiverHeader]],
+) -> List[ReceiverSegment]:
+    """Binary-search header-key boundaries over ``days[lo..hi]`` (inclusive)."""
+
+    def hdr(i: int) -> Optional[ReceiverHeader]:
+        if i not in cache:
+            cache[i] = read_fn(days[i].file_path)
+        return cache[i]
+
+    def valid_from(idx: int, step: int, stop: int):
+        i = idx
+        while (step > 0 and i <= stop) or (step < 0 and i >= stop):
+            h = hdr(i)
+            if h is not None and h.is_known:
+                return i, h
+            i += step
+        return None
+
+    def segs(a: int, b: int) -> List[ReceiverSegment]:
+        left = valid_from(a, 1, b)
+        right = valid_from(b, -1, a)
+        if left is None or right is None:
+            return []
+        li, lh = left
+        ri, rh = right
+        if lh.key == rh.key:
+            # Matching endpoints usually mean one segment — but verify the
+            # interior isn't a revert (X→Y→X) hidden between them: sample the
+            # midpoint, and only if it ALSO matches do we trust a single segment.
+            # One extra read per range; catches any revert whose run reaches a
+            # recursion midpoint (i.e. all but vanishingly short ones).
+            if ri - li > 1:
+                mi = (li + ri) // 2
+                mh = hdr(mi)
+                if mh is not None and mh.is_known and mh.key != lh.key:
+                    return _coalesce(segs(li, mi) + segs(mi, ri))
+            return [ReceiverSegment(days[li].obs_date, days[ri].obs_date, lh)]
+        if ri - li <= 1:
+            return [
+                ReceiverSegment(days[li].obs_date, days[li].obs_date, lh),
+                ReceiverSegment(days[ri].obs_date, days[ri].obs_date, rh),
+            ]
+        mid = (li + ri) // 2
+        return _coalesce(segs(li, mid) + segs(mid, ri))
+
+    return segs(lo, hi)
+
+
+def _coalesce(segs: List[ReceiverSegment]) -> List[ReceiverSegment]:
+    out: List[ReceiverSegment] = []
+    for s in segs:
+        if out and out[-1].header.key == s.header.key:
+            p = out[-1]
+            out[-1] = ReceiverSegment(p.start, max(p.end, s.end), p.header)
+        else:
+            out.append(s)
+    return out
+
+
+def build_receiver_timeline(
+    station: str,
+    root=None,
+    *,
+    rate: str = "15s_24hr",
+    read_fn: Callable[[Path], Optional[ReceiverHeader]] = read_receiver_header,
+) -> List[ReceiverSegment]:
+    """Receiver/firmware segments for a station from archived RINEX headers.
+
+    Brand runs (cheap, raw-extension based) bound the per-range header
+    binary-search so a known ``.T02``→``.sbf`` junction is never re-confirmed by
+    decompressing; segments are coalesced across run boundaries (a rinex-only gap
+    between two same-receiver spans is not a change).
+    """
+    archive_root = Path(root) if root is not None else cold_archive_prepath()
+    # RINEX path per day (raw days have RINEX too) — needed to read the header.
+    rinex_days = list(
+        walk_station_timeline(station, archive_root, rate=rate, prefer_raw=False)
+    )
+    if not rinex_days:
+        return []
+
+    # Cheap brand runs bound the search ranges (no header reads).
+    raw_days = list(
+        walk_station_timeline(station, archive_root, rate=rate, prefer_raw=True)
+    )
+    runs = coalesce_brand_runs(raw_days) if raw_days else []
+    bounds = sorted({r.start for r in runs} | {r.end for r in runs})
+
+    # Translate brand-run date bounds into rinex_days index chunks.
+    cache: Dict[int, Optional[ReceiverHeader]] = {}
+    out: List[ReceiverSegment] = []
+    chunk_starts = [0]
+    if bounds:
+        for b in bounds:
+            idx = _first_index_on_or_after(rinex_days, b)
+            if idx is not None and idx not in chunk_starts:
+                chunk_starts.append(idx)
+    chunk_starts = sorted(set(chunk_starts))
+    chunk_starts.append(len(rinex_days))
+    for a, b in zip(chunk_starts, chunk_starts[1:]):
+        if b - 1 < a:
+            continue
+        out.extend(_segment_range(rinex_days, a, b - 1, read_fn, cache))
+    return _coalesce(out)
+
+
+def _first_index_on_or_after(days: List[ArchiveDay], d: date) -> Optional[int]:
+    for i, day in enumerate(days):
+        if day.obs_date >= d:
+            return i
+    return None
+
+
+def current_install(timeline: List[ReceiverSegment]) -> Optional[ReceiverSegment]:
+    """Most recent segment — its ``start`` is the current install proxy."""
+    return timeline[-1] if timeline else None

--- a/src/tostools/tos.py
+++ b/src/tostools/tos.py
@@ -2212,6 +2212,34 @@ def _station_main(argv):
     )
     p_show.add_argument("--port", type=int, default=443)
 
+    p_rcv = sub.add_parser(
+        "receivers",
+        help=(
+            "Reconstruct the receiver/firmware history from the RINEX archive "
+            "(works on rinex-only spans the brand audit reads as ambiguous). "
+            "Report-only — proposes install dates for TOS correction."
+        ),
+        description=(
+            "Read the RINEX `REC # / TYPE / VERS` headers across the cold "
+            "archive and print the receiver/firmware timeline: each segment's "
+            "date span + type / serial / firmware. The most recent segment's "
+            "start is the current-install-date proxy for `cfg replace-receiver` "
+            "/ `reconcile --push-tos`. Unlike the brand audit (raw-extension "
+            "based), this identifies the receiver even where only RINEX was "
+            "archived. RINEX dates are a strong proxy, not gospel — review "
+            "before writing TOS."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p_rcv.add_argument("station", help="Station marker (e.g. OLKE).")
+    p_rcv.add_argument(
+        "--rate", default="15s_24hr", help="Archive rate dir (default: 15s_24hr)."
+    )
+    p_rcv.add_argument(
+        "--json", action="store_true", help="Emit JSON instead of a table."
+    )
+    _add_archive_arguments(p_rcv)
+
     _add_station_add_parser(sub)
 
     args = p.parse_args(argv)
@@ -2222,6 +2250,8 @@ def _station_main(argv):
         return _station_verify_main(args)
     if args.verb == "show":
         return _station_show_main(args)
+    if args.verb == "receivers":
+        return _station_receivers_main(args)
     if args.verb == "add":
         return _station_add_main(args)
 
@@ -2404,6 +2434,57 @@ def _station_triage_main(args) -> int:
         f"  tos audit apply {out_path}            # dry-run\n"
         f"  tos audit apply {out_path} --apply    # commit"
     )
+    return 0
+
+
+def _station_receivers_main(args) -> int:
+    """`tos station receivers <STN>` — RINEX-header receiver/firmware timeline."""
+    from .receiver_timeline import build_receiver_timeline, current_install
+
+    station = args.station.upper()
+    timeline = build_receiver_timeline(
+        station,
+        root=getattr(args, "archive_root", None),
+        rate=getattr(args, "rate", "15s_24hr"),
+    )
+    if not timeline:
+        print(f"{station}: no archived RINEX found")
+        return 1
+
+    if getattr(args, "json", False):
+        import json
+
+        print(
+            json.dumps(
+                [
+                    {
+                        "start": s.start.isoformat(),
+                        "end": s.end.isoformat(),
+                        "type": s.header.rtype,
+                        "serial": s.header.serial,
+                        "firmware": s.header.firmware,
+                    }
+                    for s in timeline
+                ],
+                indent=2,
+            )
+        )
+        return 0
+
+    print(f"=== {station} receiver history (from RINEX headers) ===")
+    for s in timeline:
+        print(
+            f"  {s.start.isoformat()} .. {s.end.isoformat()}  "
+            f"{(s.header.rtype or '?'):<16} "
+            f"sn={(s.header.serial or '?'):<14} fw={s.header.firmware or '?'}"
+        )
+    cur = current_install(timeline)
+    if cur:
+        print(
+            f"\ncurrent: {cur.header.rtype} (sn {cur.header.serial}) — "
+            f"archive install-date proxy {cur.start.isoformat()}. "
+            "Review before any TOS write (cfg replace-receiver / reconcile --push-tos)."
+        )
     return 0
 
 

--- a/tests/test_receiver_timeline.py
+++ b/tests/test_receiver_timeline.py
@@ -1,0 +1,150 @@
+"""Tests for tostools.receiver_timeline (RINEX-header receiver/firmware timeline)."""
+
+from datetime import date, timedelta
+from pathlib import Path
+
+from tostools.archive import ArchiveDay
+from tostools.receiver_timeline import (
+    ReceiverHeader,
+    _norm_fw,
+    _norm_serial,
+    _segment_range,
+    parse_receiver_line,
+)
+
+
+# --------------------------------------------------------------------------- parse
+class TestParse:
+    def test_real_lines(self):
+        line = "3016143             SEPT POLARX5        5.3.0               REC # / TYPE / VERS"
+        h = parse_receiver_line(line)
+        assert (h.serial, h.rtype, h.firmware) == ("3016143", "SEPT POLARX5", "5.3.0")
+
+    def test_unknown_serial_asterisks(self):
+        line = "******              TRIMBLE 4700        1.12                REC # / TYPE / VERS"
+        h = parse_receiver_line(line)
+        assert h.rtype == "TRIMBLE 4700"
+        assert _norm_serial(h.serial) is None  # ****** → unknown
+
+    def test_not_a_rec_line(self):
+        assert (
+            parse_receiver_line(
+                "     2.11           OBSERVATION DATA    M   RINEX VERSION / TYPE"
+            )
+            is None
+        )
+
+    def test_garbled_short(self):
+        assert (
+            parse_receiver_line("REC # / TYPE / VERS") is None
+        )  # label only, no fields
+
+
+# ----------------------------------------------------------------------- normalize
+class TestNormalizeFirmware:
+    def test_nav_sig_collapses_to_plain(self):
+        # the OLKE phantom-boundary case: same fw written two ways
+        assert _norm_fw("Nav 1.12 Sig 0.00") == _norm_fw("1.12")
+
+    def test_np_sp_collapses(self):
+        assert _norm_fw("NP 4.62 / SP 4.62") == _norm_fw("4.62")
+
+    def test_septentrio_two_digit_minor(self):
+        assert _norm_fw("5.50") == _norm_fw("5.5.0")
+
+    def test_three_part_unchanged(self):
+        assert _norm_fw("5.3.0") == "5.3.0"
+
+
+class TestNormalizeSerial:
+    def test_unknown_and_synthetic_strip(self):
+        for v in ("******", "0000000000", "antenna-RVIT20150625", "----"):
+            assert _norm_serial(v) is None
+
+    def test_real_pass(self):
+        for v in ("3016143", "5218K84655", "20147817"):
+            assert _norm_serial(v) == v
+
+
+class TestKey:
+    def test_same_receiver_diff_firmware_differs(self):
+        a = ReceiverHeader("3016143", "SEPT POLARX5", "5.3.0")
+        b = ReceiverHeader("3016143", "SEPT POLARX5", "5.6.0")
+        assert a.key != b.key
+
+    def test_nav_sig_firmware_same_key(self):
+        a = ReceiverHeader("7817", "TRIMBLE 4700", "Nav 1.12 Sig 0.00")
+        b = ReceiverHeader("7817", "TRIMBLE 4700", "1.12")
+        assert a.key == b.key  # no phantom boundary
+
+
+# --------------------------------------------------------------- binary-search split
+def _days(seq: str):
+    """One ArchiveDay per char; file_path encodes the receiver letter."""
+    base = date(2000, 1, 1)
+    return [
+        ArchiveDay(obs_date=base + timedelta(days=i), family="rinex", file_path=Path(c))
+        for i, c in enumerate(seq)
+    ]
+
+
+def _reader(path: Path):
+    """Synthetic header read: letter → header, '-' → None (unreadable)."""
+    c = str(path)
+    if c == "-":
+        return None
+    return ReceiverHeader(serial=c, rtype=c, firmware=c)
+
+
+def _segs(seq: str):
+    days = _days(seq)
+    return _segment_range(days, 0, len(days) - 1, _reader, {})
+
+
+class TestSegmentRange:
+    def test_single_segment(self):
+        s = _segs("AAAA")
+        assert len(s) == 1
+        assert s[0].start == date(2000, 1, 1) and s[0].end == date(2000, 1, 4)
+        assert s[0].header.rtype == "A"
+
+    def test_single_day(self):
+        assert len(_segs("A")) == 1
+
+    def test_one_boundary(self):
+        s = _segs("AAAABBBB")
+        assert [seg.header.rtype for seg in s] == ["A", "B"]
+        assert s[0].end == date(2000, 1, 4) and s[1].start == date(2000, 1, 5)
+
+    def test_boundary_at_zero_and_last(self):
+        assert [seg.header.rtype for seg in _segs("AB")] == ["A", "B"]
+
+    def test_multiple_boundaries(self):
+        assert [seg.header.rtype for seg in _segs("AAABBBCCC")] == ["A", "B", "C"]
+
+    def test_revert_is_caught(self):
+        # X→Y→X reverts are caught (the mid-sample inspects the interior even
+        # when the endpoints match), down to a single interior day at a midpoint:
+        assert [seg.header.rtype for seg in _segs("AAABBBAAA")] == ["A", "B", "A"]
+        assert [seg.header.rtype for seg in _segs("ABA")] == ["A", "B", "A"]
+
+    def test_residual_limitation_one_day_off_midpoint(self):
+        # ACCEPTED residual limit: a ~1-day run that aligns with no recursion
+        # midpoint can still be missed. Real receiver runs span months over daily
+        # sampling, so this never bites; documented so it's intentional.
+        # "ABAAAAA": the 1-day B at index 1 never lands on a sampled midpoint.
+        assert [seg.header.rtype for seg in _segs("ABAAAAA")] == ["A"]
+
+    def test_none_holes_within_run_are_skipped(self):
+        # holes don't create phantom boundaries
+        assert [seg.header.rtype for seg in _segs("A--AA")] == ["A"]
+
+    def test_none_hole_at_endpoints(self):
+        assert [seg.header.rtype for seg in _segs("-AAA")] == ["A"]
+        assert [seg.header.rtype for seg in _segs("AAA-")] == ["A"]
+
+    def test_none_at_boundary(self):
+        assert [seg.header.rtype for seg in _segs("AA--BB")] == ["A", "B"]
+
+    def test_all_none_is_empty(self):
+        assert _segs("----") == []


### PR DESCRIPTION
## Receiver/firmware timeline from RINEX headers + `tos station receivers`

The brand audit (`archive.detect_brand_transitions`) keys on the raw file
**extension** (`.T02`→trimble, `.sbf`→septentrio) — fast and decompression-free,
but goes `ambiguous` wherever only RINEX (no raw) was archived. That's exactly
where many *current* receivers live: **OLKE is rinex-only since 2017** (the whole
PolaRX5 era), so the brand audit can't identify it — and firmware never changes
the extension at all. The RINEX `REC # / TYPE / VERS` header carries
type/serial/firmware even on those spans.

### `tostools.receiver_timeline`
- Reads the header (reusing `rinex.reader.read_rinex_header`, which already peels
  `.Z`/`.gz`) and builds a **normalized-key** receiver/firmware timeline.
- **Hybrid efficiency:** brand runs (`coalesce_brand_runs`, directory-only) bound
  the per-range header binary-search — a `.T02`→`.sbf` junction is never
  re-confirmed by decompressing. Headers are read at O(segments·log n): a few
  dozen for a 25-year station, not thousands.
- **Normalized equality** (firmware NP/SP, Trimble `Nav/Sig`, Septentrio
  `5.50`≡`5.5.0`, placeholder/synthetic serials → unknown, type via
  `to_igs_receiver`) so a boundary is a real change, not formatting noise.
- Binary-search is **revert-aware** (mid-sample catches X→Y→X) and treats an
  unreadable header as a hole, never a phantom 1-day segment.

### `tos station receivers <STN>`
Report-only. Prints the timeline + the current-install-date proxy for
`cfg replace-receiver` / `reconcile --push-tos`. RINEX dates are a strong proxy,
not gospel — operator reviews before any TOS write.

### Validated live on OLKE
```
1999–2013  TRIMBLE 4700
2013-02-28 TRIMBLE NETR9   5218K84655
2017-07-08 SEPT POLARX5    3016143  fw 5.1.1   ← the install date TOS is missing
2019-10-15 SEPT POLARX5    3016143  fw 5.3.0
2026-05-18 SEPT POLARX5    3016143  fw 5.6.0   ← matches cfg
```
(TOS still claims a Trimble 4700 since 2000.) The 1999–2013 era still fragments
on the *type* field `TRIMBLE 4700` vs bare `4700` — a normalization left for a
follow-up; the current/recent receivers, which TOS correction needs, are clean.

23 unit tests (parse, normalize, the binary-search split incl. reverts /
None-holes / endpoint cases / the accepted residual 1-day limit). ruff clean.
Complements `audit_verify_from_rinex` — the RINEX-header half of "bring TOS
current" (receivers todo #39).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
