### PR TITLE
feat(rinex): receiver-level "suggest dated TOS correction" + streaming header reads

### DIFF
--- a/src/tostools/audit_verify_from_rinex.py
+++ b/src/tostools/audit_verify_from_rinex.py
@@ -24,11 +24,29 @@ Outputs ``StationRinexReport`` — same data the CLI handler and
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from .api.tos_client import TOSClient
+from .receiver_timeline import ReceiverHeader
+
+logger = logging.getLogger(__name__)
+
+# IGS-normalized receiver type → ``cfg replace-receiver --new-type`` token.
+# Keys are the value of ``ReceiverHeader.key[0]`` (i.e. ``_norm_type`` output,
+# which runs ``to_igs_receiver`` first). Only the families the receivers verb
+# actually probes are mapped — see the ``--new-type`` choices in
+# ``receivers/src/receivers/cli/cfg.py``. Anything unmapped renders a
+# ``<TYPE?>`` placeholder for the operator to fill (the suggestion is a
+# review-first commented command, never auto-run).
+_REPLACE_TYPE_TOKEN = {
+    "SEPT POLARX5": "polarx5",
+    "TRIMBLE NETR9": "netr9",
+    "TRIMBLE NETRS": "netrs",
+    "TRIMBLE NETR5": "netr5",
+}
 
 # Model-substring → expected brand-family map. Keys are matched
 # case-insensitively against the device's open ``model`` attribute;
@@ -188,6 +206,185 @@ class TOSReceiverVerdict:
 
 
 @dataclass
+class CurrentReceiverVerdict:
+    """RINEX current-install vs TOS's currently-open ``gnss_receiver`` join.
+
+    The receiver-LEVEL counterpart to :class:`TOSReceiverVerdict` (which is
+    brand-level). Where the brand audit only sees the file-extension family —
+    and goes blind on the rinex-only spans where many current receivers live —
+    this reads the actual ``REC # / TYPE / VERS`` header via
+    :mod:`tostools.receiver_timeline`, so it catches the case that motivated
+    todo #40: TOS still holds a long-retired open receiver (OLKE's TRIMBLE 4700
+    from 2000) while the archive shows the PolaRX5 that's really been deployed
+    since 2017.
+
+    ``suggested_command`` carries an operator-pasteable **``receivers cfg
+    replace-receiver``** shell command (Pattern-2 device swap, dated to the
+    RINEX install proxy) — NOT a ``tos audit apply`` ACTION line. It is
+    populated only for actionable disagreements (``type_mismatch`` /
+    ``serial_mismatch``); ``None`` for clean / informational / firmware-only
+    statuses. RINEX dates are a strong proxy, never gospel: suggest, review,
+    run manually.
+
+    Status values:
+      * ``ok`` — RINEX and TOS open join agree on type and serial
+      * ``type_mismatch`` — different receiver type (the OLKE case)
+      * ``serial_mismatch`` — same type, different (both-known) serial
+      * ``firmware_drift`` — type+serial agree, firmware differs
+        (informational; recording it is todo #39, no replace-receiver)
+      * ``no_open_join`` — no open ``gnss_receiver`` join in TOS
+      * ``no_rinex_receiver`` — archive header carries no usable identity
+    """
+
+    status: str
+    detail: str
+    rinex_type: Optional[str] = None
+    rinex_serial: Optional[str] = None
+    rinex_firmware: Optional[str] = None
+    rinex_install_date: Optional[str] = None
+    tos_type: Optional[str] = None
+    tos_serial: Optional[str] = None
+    tos_firmware: Optional[str] = None
+    tos_time_from: Optional[str] = None
+    suggested_command: Optional[str] = None
+
+    @property
+    def is_actionable(self) -> bool:
+        """True iff this verdict carries a replace-receiver suggestion."""
+        return self.suggested_command is not None
+
+
+def _replace_receiver_command(
+    station: str,
+    header: ReceiverHeader,
+    install_date: Optional[str],
+) -> str:
+    """Build the dated ``receivers cfg replace-receiver`` suggestion line.
+
+    The IGS-normalized type drives ``--new-type``; unmapped families render a
+    ``<TYPE?>`` placeholder (the operator fills it before running). Serial /
+    firmware / date are included when known so the line is as close to
+    runnable as the archive allows — but it stays commented in the triage file.
+    """
+    norm_type = header.key[0]
+    token = _REPLACE_TYPE_TOKEN.get(norm_type or "", "<TYPE?>")
+    parts = [
+        "receivers cfg replace-receiver",
+        f"--station {station.upper()}",
+        f"--new-type {token}",
+    ]
+    if header.serial:
+        parts.append(f"--new-serial {header.serial}")
+    if norm_type:
+        parts.append(f'--new-model "{norm_type}"')
+    if header.firmware:
+        parts.append(f"--new-firmware {header.firmware}")
+    if install_date:
+        parts.append(f"--date {install_date}")
+    return " ".join(parts)
+
+
+def classify_current_receiver(
+    station: str,
+    rinex_header: Optional[ReceiverHeader],
+    rinex_install_date: Optional[str],
+    tos_type: Optional[str],
+    tos_serial: Optional[str],
+    tos_firmware: Optional[str],
+    tos_time_from: Optional[str],
+) -> CurrentReceiverVerdict:
+    """Compare the archive's current receiver against TOS's open join.
+
+    Pure function — no archive walk, no TOS call — so it is unit-testable in
+    isolation. Both sides are normalized through the SAME
+    :class:`~tostools.receiver_timeline.ReceiverHeader` key (type via
+    ``to_igs_receiver``, firmware ``5.50``≡``5.5.0``, placeholder serials →
+    unknown): a disagreement is a real one, not header-vs-TOS spelling noise.
+    With most of the fleet already drifting this normalization parity is the
+    line between useful triage and a wall of false positives.
+
+    ``rinex_install_date`` is the ``start`` of the archive's current segment
+    (already an ISO ``YYYY-MM-DD`` string) — the install-date proxy that dates
+    the suggested ``replace-receiver``.
+    """
+    if rinex_header is None or not rinex_header.is_known:
+        return CurrentReceiverVerdict(
+            status="no_rinex_receiver",
+            detail="archive header carries no usable receiver identity",
+            rinex_install_date=rinex_install_date,
+        )
+
+    rtype, rserial, rfw = rinex_header.key
+    common = dict(
+        rinex_type=rinex_header.rtype,
+        rinex_serial=rinex_header.serial,
+        rinex_firmware=rinex_header.firmware,
+        rinex_install_date=rinex_install_date,
+        tos_type=tos_type,
+        tos_serial=tos_serial,
+        tos_firmware=tos_firmware,
+        tos_time_from=tos_time_from,
+    )
+
+    tos_header = ReceiverHeader(
+        serial=tos_serial, rtype=tos_type, firmware=tos_firmware
+    )
+    if not tos_header.is_known and not tos_time_from:
+        return CurrentReceiverVerdict(
+            status="no_open_join",
+            detail=(
+                "no open gnss_receiver join in TOS; archive shows "
+                f"{rinex_header.rtype or '?'} since {rinex_install_date or '?'}"
+            ),
+            **common,
+        )
+    ttype, tserial, tfw = tos_header.key
+
+    if rtype != ttype:
+        cmd = _replace_receiver_command(station, rinex_header, rinex_install_date)
+        return CurrentReceiverVerdict(
+            status="type_mismatch",
+            detail=(
+                f"TOS open receiver {tos_type or '?'} "
+                f"(since {tos_time_from or '?'}) but archive shows "
+                f"{rinex_header.rtype or '?'} since {rinex_install_date or '?'}"
+            ),
+            suggested_command=cmd,
+            **common,
+        )
+
+    if rserial is not None and tserial is not None and rserial != tserial:
+        cmd = _replace_receiver_command(station, rinex_header, rinex_install_date)
+        return CurrentReceiverVerdict(
+            status="serial_mismatch",
+            detail=(
+                f"same type ({rinex_header.rtype or '?'}) but TOS serial "
+                f"{tos_serial or '?'} ≠ archive serial {rinex_header.serial or '?'} "
+                f"(archive since {rinex_install_date or '?'})"
+            ),
+            suggested_command=cmd,
+            **common,
+        )
+
+    if rfw is not None and tfw is not None and rfw != tfw:
+        return CurrentReceiverVerdict(
+            status="firmware_drift",
+            detail=(
+                f"type+serial agree; firmware TOS {tos_firmware or '?'} ≠ "
+                f"archive {rinex_header.firmware or '?'} "
+                "(recording the change is todo #39 — no replace-receiver)"
+            ),
+            **common,
+        )
+
+    return CurrentReceiverVerdict(
+        status="ok",
+        detail=f"TOS open receiver matches archive ({rinex_header.rtype or '?'})",
+        **common,
+    )
+
+
+@dataclass
 class StationRinexReport:
     """Aggregated archive-vs-TOS findings for one station.
 
@@ -212,6 +409,7 @@ class StationRinexReport:
     rinex_only_spans: List[Any] = field(default_factory=list)
     receivers: List[TOSReceiverVerdict] = field(default_factory=list)
     suggested_actions: List[str] = field(default_factory=list)
+    current_receiver: Optional[CurrentReceiverVerdict] = None
 
     @property
     def has_findings(self) -> bool:
@@ -221,9 +419,13 @@ class StationRinexReport:
         always need a human read). Receiver verdicts contribute only
         when they carry a ``suggested_action`` (``join_too_wide``,
         ``late_start``, ``early_end``) — clean and informational
-        statuses don't count.
+        statuses don't count. The receiver-level current-install
+        verdict contributes when it carries a ``replace-receiver``
+        suggestion (``type_mismatch`` / ``serial_mismatch``).
         """
         if self.brand_transitions or self.data_gaps:
+            return True
+        if self.current_receiver is not None and self.current_receiver.is_actionable:
             return True
         return any(r.suggested_action for r in self.receivers)
 
@@ -237,10 +439,16 @@ class StationRinexReport:
         one place so the three call sites (station header, fleet
         per-station row, single-station verify summary) cannot drift.
         """
+        current = (
+            1
+            if self.current_receiver is not None and self.current_receiver.is_actionable
+            else 0
+        )
         return (
             len(self.brand_transitions)
             + len(self.data_gaps)
             + len(self.suggested_actions)
+            + current
         )
 
 
@@ -250,6 +458,7 @@ def audit_station_verify_from_rinex(
     *,
     archive_root: Optional[Path] = None,
     min_gap_days: float = 30.0,
+    check_current_receiver: bool = True,
 ) -> StationRinexReport:
     """Cross-check one station's TOS state against the cold RINEX archive.
 
@@ -265,6 +474,12 @@ def audit_station_verify_from_rinex(
     min_gap_days
         Minimum gap duration to flag (default 30; below ~7 the report
         fills with date-rounding noise).
+    check_current_receiver
+        When True (default) also build the RINEX-header receiver timeline
+        and compare its current install against TOS's open receiver join
+        (todo #40). This reads a few dozen RINEX headers — set False for the
+        brand-only audit (e.g. archive-offline workflows or fleet sweeps
+        where the header reads are too costly).
 
     Returns
     -------
@@ -309,6 +524,10 @@ def audit_station_verify_from_rinex(
     # side of the picture.
     parent_id = _resolve_station_id(client, station)
     receivers: List[TOSReceiverVerdict] = []
+    # Fields of the currently-OPEN gnss_receiver join (time_to is None) — the
+    # receiver-level current-install check below compares the archive's current
+    # receiver against this. Latest open join wins if (anomalously) more than one.
+    open_join: Optional[Dict[str, Optional[str]]] = None
     if parent_id is not None:
         parent = client.get_entity_history(parent_id)
         if parent:
@@ -326,6 +545,15 @@ def audit_station_verify_from_rinex(
                 tf = (conn.get("time_from") or "")[:10]
                 tt_raw = conn.get("time_to")
                 tt = tt_raw[:10] if tt_raw else None
+                if tt is None and (
+                    open_join is None or tf > (open_join["time_from"] or "")
+                ):
+                    open_join = {
+                        "model": open_attribute(child, "model"),
+                        "serial_number": open_attribute(child, "serial_number"),
+                        "firmware_version": open_attribute(child, "firmware_version"),
+                        "time_from": tf,
+                    }
                 expected_family = infer_expected_family(open_attribute(child, "model"))
                 verdict = classify_tos_join_against_archive(
                     tf, tt, expected_family, timeline
@@ -358,6 +586,37 @@ def audit_station_verify_from_rinex(
 
     suggested_actions = [r.suggested_action for r in receivers if r.suggested_action]
 
+    # Receiver-LEVEL current-install check (todo #40): read the archive's
+    # current receiver from RINEX headers and compare against TOS's open join.
+    # Guarded — a header/archive read failure degrades to no verdict, never
+    # sinks the brand-level report.
+    current_receiver: Optional[CurrentReceiverVerdict] = None
+    if check_current_receiver:
+        try:
+            from .receiver_timeline import (
+                build_receiver_timeline,
+                current_install,
+                current_receiver_install_date,
+            )
+
+            rcv_timeline = build_receiver_timeline(station, root=resolved_root)
+            cur = current_install(rcv_timeline)
+            if cur is not None:
+                # Install date of the receiver UNIT (back past firmware bumps),
+                # not the latest firmware segment's start.
+                install_date = current_receiver_install_date(rcv_timeline)
+                current_receiver = classify_current_receiver(
+                    station,
+                    cur.header,
+                    str(install_date) if install_date is not None else None,
+                    open_join["model"] if open_join else None,
+                    open_join["serial_number"] if open_join else None,
+                    open_join["firmware_version"] if open_join else None,
+                    open_join["time_from"] if open_join else None,
+                )
+        except Exception as exc:  # noqa: BLE001 — archive/header read is best-effort
+            logger.warning("current-receiver check failed on %s: %s", station, exc)
+
     return StationRinexReport(
         station=station,
         station_id=parent_id,
@@ -371,6 +630,7 @@ def audit_station_verify_from_rinex(
         rinex_only_spans=rinex_only_spans,
         receivers=receivers,
         suggested_actions=suggested_actions,
+        current_receiver=current_receiver,
     )
 
 
@@ -465,6 +725,19 @@ def format_triage_file(
             lines.append(f"#   {s.start} → {s.end}  ({s.days}d)")
         lines.append("#")
 
+    cr = report.current_receiver
+    if cr is not None and cr.is_actionable:
+        lines.append(
+            f"# Current receiver ({cr.status} — archive header vs TOS open join):"
+        )
+        lines.append(f"#   {cr.detail}")
+        lines.append(
+            "#   Suggested fix — run MANUALLY in the receivers package after "
+            "reviewing the date (RINEX install date is a proxy, not gospel):"
+        )
+        lines.append(f"#       {cr.suggested_command}")
+        lines.append("#")
+
     if report.suggested_actions:
         lines.append(
             f"# Suggested ACTION lines ({len(report.suggested_actions)} — "
@@ -473,7 +746,7 @@ def format_triage_file(
         for action in report.suggested_actions:
             lines.append(f"#{action}")
         lines.append("#")
-    else:
+    elif cr is None or not cr.is_actionable:
         lines.append(
             "# No actionable TOS-vs-archive discrepancies found "
             "(all receiver joins clean or informational)."

--- a/src/tostools/receiver_timeline.py
+++ b/src/tostools/receiver_timeline.py
@@ -14,7 +14,11 @@ Efficiency (the hybrid): the brand runs from ``coalesce_brand_runs`` are free
 boundary, so we only **binary-search RINEX headers WITHIN each brand run** (and
 read the two headers either side of a junction to name the exact models). Headers
 are read at O(sub-segments · log n) days, not every day; for a 25-year station
-that's a few dozen ``gzip -dc`` reads, not thousands.
+that's a few dozen reads, not thousands. Each of those reads is itself cheap:
+``read_receiver_header`` streams ``gzip -dc`` and stops at ``END OF HEADER``
+rather than inflating the whole ~4 MB daily file for its ~2 KB header
+(≈50× faster per read on the cold NFS archive), falling back to the robust
+shared reader for uncompressed names or any failure.
 
 Equality is on NORMALIZED fields (firmware ``5.50``≡``5.5.0``, type via
 ``to_igs_receiver``, placeholder/synthetic serials → unknown) so a boundary is a
@@ -30,6 +34,7 @@ from __future__ import annotations
 
 import logging
 import re
+import subprocess
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
@@ -45,6 +50,12 @@ from .rinex.reader import read_rinex_header
 from .standards.igs_equipment import to_igs_receiver
 
 logger = logging.getLogger(__name__)
+
+_END_OF_HEADER = b"END OF HEADER"
+# A RINEX header is a few KB (multi-GNSS with many SYS/OBS TYPES lines still well
+# under this). If we stream this far without the marker the file isn't a normal
+# RINEX header — bail to the robust shared reader rather than inflate the rest.
+_MAX_HEADER_BYTES = 256 * 1024
 
 _REC_LABEL = "REC # / TYPE / VERS"
 
@@ -137,8 +148,77 @@ def parse_receiver_line(line: str) -> Optional[ReceiverHeader]:
     return ReceiverHeader(serial=serial, rtype=rtype, firmware=firmware)
 
 
+def _fast_header_text(path) -> Optional[str]:
+    """Stream-decompress only the RINEX header (up to ``END OF HEADER``).
+
+    The hot path reads a 24h ``.D.Z`` (Unix-compress/LZW Hatanaka) file purely
+    to get the ~2 KB header at the top. Inflating the whole ~4 MB file with the
+    pure-Python ``unlzw`` costs ~400 ms/file on the cold NFS archive; streaming
+    GNU ``gzip -dc`` (which reads both ``.Z`` and ``.gz``) in chunks and stopping
+    at the marker is ~8 ms/file — ≈50× — because the header is a tiny prefix.
+
+    Returns the decoded header text, or ``None`` for anything we don't
+    fast-path (uncompressed names) or any failure (no ``gzip``, no marker,
+    garbled stream) so the caller falls back to the robust shared reader. Never
+    raises.
+    """
+    name = str(path)
+    if not name.endswith((".Z", ".gz")):
+        return None  # uncompressed / short-name → let the shared reader handle it
+    proc = None
+    try:
+        proc = subprocess.Popen(
+            ["gzip", "-dc", name],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+        buf = b""
+        assert proc.stdout is not None
+        while _END_OF_HEADER not in buf:
+            chunk = proc.stdout.read(4096)
+            if not chunk:
+                break
+            buf += chunk
+            if len(buf) > _MAX_HEADER_BYTES:
+                return None
+        end = buf.find(_END_OF_HEADER)
+        if end == -1:
+            return None
+        # Truncate at the marker (matches read_rinex_header's header slice) so
+        # the trailing bytes of the chunk it landed in aren't returned.
+        return buf[: end + len(_END_OF_HEADER)].decode("utf-8", errors="ignore")
+    except Exception as exc:  # noqa: BLE001 — fall back on any failure
+        logger.debug("_fast_header_text(%s): %s", path, exc)
+        return None
+    finally:
+        if proc is not None:
+            if proc.stdout is not None:
+                proc.stdout.close()
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except Exception:  # noqa: BLE001
+                proc.kill()
+
+
+def _rec_line_from_text(header: str) -> Optional[ReceiverHeader]:
+    for line in header.splitlines():
+        if _REC_LABEL in line:
+            return parse_receiver_line(line)
+    return None
+
+
 def read_receiver_header(path) -> Optional[ReceiverHeader]:
-    """Receiver header of one archived RINEX file, or None on any failure."""
+    """Receiver header of one archived RINEX file, or None on any failure.
+
+    Tries the fast streaming reader first (stops at ``END OF HEADER`` instead of
+    inflating the whole file); falls back to the robust shared
+    :func:`~tostools.rinex.reader.read_rinex_header` for uncompressed files or
+    when the fast path can't produce a header.
+    """
+    fast = _fast_header_text(path)
+    if fast is not None:
+        return _rec_line_from_text(fast)
     try:
         data = read_rinex_header(str(path))
     except Exception as exc:  # noqa: BLE001
@@ -149,10 +229,7 @@ def read_receiver_header(path) -> Optional[ReceiverHeader]:
     header = data["header"]
     if not isinstance(header, str):
         return None
-    for line in header.splitlines():
-        if _REC_LABEL in line:
-            return parse_receiver_line(line)
-    return None
+    return _rec_line_from_text(header)
 
 
 # ------------------------------------------------------------------------- timeline
@@ -282,5 +359,48 @@ def _first_index_on_or_after(days: List[ArchiveDay], d: date) -> Optional[int]:
 
 
 def current_install(timeline: List[ReceiverSegment]) -> Optional[ReceiverSegment]:
-    """Most recent segment — its ``start`` is the current install proxy."""
+    """Most recent segment — its ``start`` is the latest firmware's date.
+
+    Note this is the start of the trailing *firmware* segment, not necessarily
+    when the physical receiver was installed (a firmware bump opens a new
+    segment). For the install-date of the current receiver unit, use
+    :func:`current_receiver_install_date`.
+    """
     return timeline[-1] if timeline else None
+
+
+def _same_unit(a: tuple, b: tuple) -> bool:
+    """Same physical receiver (type + serial), ignoring firmware.
+
+    Compares the first two components of :attr:`ReceiverHeader.key`. An
+    unknown serial (``None``, e.g. a garbled read) is a wildcard — it does not
+    mark a unit boundary — mirroring the both-known rule in
+    ``classify_current_receiver``.
+    """
+    if a[0] != b[0]:
+        return False
+    if a[1] is not None and b[1] is not None and a[1] != b[1]:
+        return False
+    return True
+
+
+def current_receiver_install_date(timeline: List[ReceiverSegment]) -> Optional[date]:
+    """Date the *current physical receiver* first appears in the archive.
+
+    Walks backward from the last segment across firmware-only boundaries (same
+    type + serial) and returns the earliest such start. This is the right date
+    for a ``replace-receiver`` suggestion: the install date of the receiver
+    UNIT, not of its latest firmware. For OLKE's PolaRX5 sn 3016143 — split
+    into 5.1.1 / 5.3.0 / 5.6.0 firmware segments — this returns 2017-07-08
+    (the 5.1.1 segment), not 2026-05-18 (the 5.6.0 bump).
+    """
+    if not timeline:
+        return None
+    cur_id = timeline[-1].header.key
+    start = timeline[-1].start
+    for seg in reversed(timeline[:-1]):
+        if _same_unit(seg.header.key, cur_id):
+            start = seg.start
+        else:
+            break
+    return start

--- a/src/tostools/station_triage.py
+++ b/src/tostools/station_triage.py
@@ -354,6 +354,10 @@ def format_station_triage(report: StationTriageReport) -> str:
         or report.rinex.data_gaps
         or report.rinex.suggested_actions
         or report.rinex.rinex_only_spans
+        or (
+            report.rinex.current_receiver is not None
+            and report.rinex.current_receiver.is_actionable
+        )
     ):
         parts.append(_section_rinex(report))
 
@@ -380,11 +384,17 @@ def _build_header(report: StationTriageReport) -> str:
         # summary line — operators rarely need the per-signal counts
         # in the header; they're surfaced in the section body below.
         rx = report.rinex
+        swap = (
+            1
+            if rx.current_receiver is not None and rx.current_receiver.is_actionable
+            else 0
+        )
         summary_lines.append(
             f"#   verify-from-rinex:   {rx.finding_count} finding(s) "
             f"({len(rx.brand_transitions)} transitions, "
             f"{len(rx.data_gaps)} gaps, "
-            f"{len(rx.suggested_actions)} suggested ACTIONs)"
+            f"{len(rx.suggested_actions)} suggested ACTIONs, "
+            f"{swap} receiver swap)"
         )
     if report.coverage is not None:
         cov = report.coverage
@@ -476,8 +486,9 @@ def _section_rinex(report: StationTriageReport) -> str:
         "# CONFIDENCE: MEDIUM — file-extension signal is authoritative for\n"
         "# what was archived, but actionability depends on operator context\n"
         "# (was the gap planned downtime? was the transition logged elsewhere?).\n"
-        "# Brand transitions + data gaps are informational; only ACTION lines\n"
-        "# carry pre-built suggestions.\n"
+        "# Brand transitions + data gaps are informational; ACTION lines carry\n"
+        "# pre-built suggestions, and a receiver-swap line (if any) is a\n"
+        "# run-manually 'cfg replace-receiver' command, not a tos-apply ACTION.\n"
         "# ──────────────────────────────────────────────────────────────────"
     )
     return header + "\n" + body.rstrip()

--- a/src/tostools/tos.py
+++ b/src/tostools/tos.py
@@ -1857,6 +1857,23 @@ def _audit_verify_from_rinex_main(args, client) -> int:
                 }
                 for r in report.receivers
             ],
+            "current_receiver": (
+                {
+                    "status": report.current_receiver.status,
+                    "detail": report.current_receiver.detail,
+                    "rinex_type": report.current_receiver.rinex_type,
+                    "rinex_serial": report.current_receiver.rinex_serial,
+                    "rinex_firmware": report.current_receiver.rinex_firmware,
+                    "rinex_install_date": report.current_receiver.rinex_install_date,
+                    "tos_type": report.current_receiver.tos_type,
+                    "tos_serial": report.current_receiver.tos_serial,
+                    "tos_firmware": report.current_receiver.tos_firmware,
+                    "tos_time_from": report.current_receiver.tos_time_from,
+                    "suggested_command": report.current_receiver.suggested_command,
+                }
+                if report.current_receiver is not None
+                else None
+            ),
         }
         print(_json.dumps(payload, ensure_ascii=False, indent=2, default=str))
         return 1 if report.has_findings else 0
@@ -1995,6 +2012,28 @@ def _print_rinex_audit_report(report, *, min_gap_days: float) -> None:
             )
             for line in report.suggested_actions:
                 console.print(f"  {line}")
+
+    cr = report.current_receiver
+    if cr is not None and cr.status != "ok":
+        console.print()
+        _CR_STYLE = {
+            "type_mismatch": "red",
+            "serial_mismatch": "red",
+            "firmware_drift": "yellow",
+            "no_open_join": "yellow",
+            "no_rinex_receiver": "dim",
+        }
+        style = _CR_STYLE.get(cr.status, "white")
+        console.print(
+            f"[bold]Current receiver[/bold] (archive header vs TOS open join): "
+            f"[{style}]{cr.status}[/{style}] — {cr.detail}"
+        )
+        if cr.suggested_command:
+            console.print(
+                "  Suggested fix — run MANUALLY after reviewing the date "
+                "(RINEX install date is a proxy):"
+            )
+            console.print(f"    {cr.suggested_command}")
 
 
 def _station_main(argv):
@@ -2657,6 +2696,23 @@ def _rinex_report_to_dict(report) -> Dict[str, Any]:
             for r in report.receivers
         ],
         "suggested_actions": list(report.suggested_actions),
+        "current_receiver": (
+            {
+                "status": report.current_receiver.status,
+                "detail": report.current_receiver.detail,
+                "rinex_type": report.current_receiver.rinex_type,
+                "rinex_serial": report.current_receiver.rinex_serial,
+                "rinex_firmware": report.current_receiver.rinex_firmware,
+                "rinex_install_date": report.current_receiver.rinex_install_date,
+                "tos_type": report.current_receiver.tos_type,
+                "tos_serial": report.current_receiver.tos_serial,
+                "tos_firmware": report.current_receiver.tos_firmware,
+                "tos_time_from": report.current_receiver.tos_time_from,
+                "suggested_command": report.current_receiver.suggested_command,
+            }
+            if report.current_receiver is not None
+            else None
+        ),
     }
 
 

--- a/tests/test_audit_verify_from_rinex.py
+++ b/tests/test_audit_verify_from_rinex.py
@@ -17,11 +17,14 @@ from unittest.mock import patch
 from tostools.api.tos_client import TOSClient
 from tostools.archive import BrandTransition, DataGap, RinexOnlySpan
 from tostools.audit_verify_from_rinex import (
+    CurrentReceiverVerdict,
     StationRinexReport,
     TOSReceiverVerdict,
     audit_station_verify_from_rinex,
+    classify_current_receiver,
     format_triage_file,
 )
+from tostools.receiver_timeline import ReceiverHeader
 
 # ---------------------------------------------------------------------------
 # StationRinexReport.has_findings
@@ -284,3 +287,185 @@ def test_format_triage_file_rinex_only_spans():
     text = format_triage_file(report, generated_at="2026-05-28T00:00:00Z")
     assert "RINEX-only spans (1 — raw missing)" in text
     assert "2018-01-01 → 2018-03-01  (60d)" in text
+
+
+# ---------------------------------------------------------------------------
+# classify_current_receiver — receiver-LEVEL current-install vs TOS open join
+# (todo #40). Pure function, no archive/TOS.
+# ---------------------------------------------------------------------------
+
+
+def test_classify_current_receiver_type_mismatch_emits_dated_command():
+    """The OLKE case: TOS open join is a long-retired TRIMBLE 4700 while the
+    archive header shows the PolaRX5 deployed since 2017 → dated
+    replace-receiver suggestion."""
+    rh = ReceiverHeader(serial="3016143", rtype="POLARX5", firmware="5.5.0")
+    v = classify_current_receiver(
+        "OLKE", rh, "2017-07-08", "TRIMBLE 4700", None, "1.3.0", "2000-10-17"
+    )
+    assert v.status == "type_mismatch"
+    assert v.is_actionable is True
+    assert v.suggested_command is not None
+    # Dated to the RINEX install proxy, targets the receivers verb, right token.
+    assert "receivers cfg replace-receiver" in v.suggested_command
+    assert "--station OLKE" in v.suggested_command
+    assert "--new-type polarx5" in v.suggested_command
+    assert "--new-serial 3016143" in v.suggested_command
+    assert "--date 2017-07-08" in v.suggested_command
+    # NOT a tos-apply ACTION line.
+    assert "ACTION" not in v.suggested_command
+
+
+def test_classify_current_receiver_normalization_parity_is_clean():
+    """The #1 false-positive trap: TOS stores `SEPT POLARX5` / fw `5.5.0`,
+    the header says `POLARX5` / `5.50`. Same normalized key ⇒ `ok`, no
+    suggestion. With most of the fleet drifting, this parity is the line
+    between useful triage and noise."""
+    rh = ReceiverHeader(serial="4101525", rtype="POLARX5", firmware="5.50")
+    v = classify_current_receiver(
+        "ARHO", rh, "2024-01-01", "SEPT POLARX5", "4101525", "5.5.0", "2024-01-01"
+    )
+    assert v.status == "ok"
+    assert v.is_actionable is False
+    assert v.suggested_command is None
+
+
+def test_classify_current_receiver_serial_mismatch_emits_command():
+    """Same model, different (both-known) serial → a new physical unit was
+    swapped in; replace-receiver with the archive serial + date."""
+    rh = ReceiverHeader(serial="4101525", rtype="POLARX5", firmware="5.5.0")
+    v = classify_current_receiver(
+        "XXXX", rh, "2024-01-01", "SEPT POLARX5", "9999999", "5.5.0", "2020-01-01"
+    )
+    assert v.status == "serial_mismatch"
+    assert v.is_actionable is True
+    assert "--new-serial 4101525" in v.suggested_command
+
+
+def test_classify_current_receiver_firmware_only_drift_is_informational():
+    """Type + serial agree, only firmware differs → firmware_drift, NOT a
+    replace-receiver (recording firmware changes is todo #39)."""
+    rh = ReceiverHeader(serial="4101525", rtype="POLARX5", firmware="5.5.0")
+    v = classify_current_receiver(
+        "YYYY", rh, "2024-01-01", "SEPT POLARX5", "4101525", "5.4.0", "2024-01-01"
+    )
+    assert v.status == "firmware_drift"
+    assert v.is_actionable is False
+    assert v.suggested_command is None
+
+
+def test_classify_current_receiver_unknown_serial_does_not_false_positive():
+    """TOS holds a synthetic/placeholder serial → unknown after normalization;
+    a known archive serial must NOT be flagged as a serial_mismatch (can't
+    assert a difference against unknown)."""
+    rh = ReceiverHeader(serial="4101525", rtype="POLARX5", firmware="5.5.0")
+    v = classify_current_receiver(
+        "ZZZZ",
+        rh,
+        "2024-01-01",
+        "SEPT POLARX5",
+        "receiver-ZZZZ-20240101",
+        "5.5.0",
+        "2024-01-01",
+    )
+    assert v.status == "ok"
+    assert v.is_actionable is False
+
+
+def test_classify_current_receiver_no_open_join():
+    """No open gnss_receiver join in TOS → informational, no command (adding
+    a receiver is a different verb than replace)."""
+    rh = ReceiverHeader(serial="4101525", rtype="POLARX5", firmware="5.5.0")
+    v = classify_current_receiver("WWWW", rh, "2024-01-01", None, None, None, None)
+    assert v.status == "no_open_join"
+    assert v.is_actionable is False
+
+
+def test_classify_current_receiver_no_rinex_identity():
+    """Archive header with no usable identity → no_rinex_receiver, never a
+    command (we have nothing to suggest)."""
+    rh = ReceiverHeader(serial=None, rtype=None, firmware=None)
+    v = classify_current_receiver(
+        "VVVV", rh, "2024-01-01", "SEPT POLARX5", "4101525", "5.5.0", "2024-01-01"
+    )
+    assert v.status == "no_rinex_receiver"
+    assert v.is_actionable is False
+
+
+def test_classify_current_receiver_unmapped_type_uses_placeholder():
+    """A type with no replace-receiver token (e.g. mosaic-X5) still emits a
+    suggestion, with a `<TYPE?>` placeholder for the operator to fill."""
+    rh = ReceiverHeader(serial="3001234", rtype="mosaic-X5", firmware="4.14.0")
+    v = classify_current_receiver(
+        "BLAL", rh, "2023-05-01", "SEPT POLARX2", None, None, "2010-01-01"
+    )
+    assert v.status == "type_mismatch"
+    assert "--new-type <TYPE?>" in v.suggested_command
+
+
+# ---------------------------------------------------------------------------
+# StationRinexReport — current_receiver wiring into has_findings/finding_count
+# ---------------------------------------------------------------------------
+
+
+def _actionable_cr():
+    return CurrentReceiverVerdict(
+        status="type_mismatch",
+        detail="TOS TRIMBLE 4700 but archive POLARX5 since 2017-07-08",
+        rinex_install_date="2017-07-08",
+        suggested_command=(
+            "receivers cfg replace-receiver --station OLKE --new-type polarx5 "
+            "--new-serial 3016143 --date 2017-07-08"
+        ),
+    )
+
+
+def test_has_findings_current_receiver_alone():
+    """An actionable receiver-swap verdict escalates the oracle on its own."""
+    report = StationRinexReport(
+        station="OLKE",
+        station_id=1,
+        archive_root=Path("/tmp/archive"),
+        timeline_count=10,
+        first_day="2000-01-01",
+        last_day="2026-06-20",
+        current_receiver=_actionable_cr(),
+    )
+    assert report.has_findings is True
+    assert report.finding_count == 1
+
+
+def test_finding_count_firmware_drift_does_not_count():
+    """firmware_drift is informational — must not inflate finding_count."""
+    cr = CurrentReceiverVerdict(status="firmware_drift", detail="fw differs")
+    report = StationRinexReport(
+        station="X",
+        station_id=1,
+        archive_root=Path("/tmp/archive"),
+        timeline_count=10,
+        first_day="2020-01-01",
+        last_day="2020-01-10",
+        current_receiver=cr,
+    )
+    assert report.has_findings is False
+    assert report.finding_count == 0
+
+
+def test_format_triage_file_renders_swap_as_manual_command_not_action():
+    """The swap suggestion renders as a run-manually command, distinct from
+    the `tos audit apply` ACTION grammar (advisor trap #2)."""
+    report = StationRinexReport(
+        station="OLKE",
+        station_id=1,
+        archive_root=Path("/mnt/archive"),
+        timeline_count=3000,
+        first_day="2000-01-01",
+        last_day="2026-06-20",
+        current_receiver=_actionable_cr(),
+    )
+    text = format_triage_file(report, generated_at="2026-06-20T00:00:00Z")
+    assert "Current receiver (type_mismatch" in text
+    assert "receivers cfg replace-receiver --station OLKE" in text
+    assert "run MANUALLY" in text
+    # Must NOT claim "no discrepancies" when a swap is suggested.
+    assert "No actionable TOS-vs-archive discrepancies" not in text

--- a/tests/test_receiver_timeline.py
+++ b/tests/test_receiver_timeline.py
@@ -6,9 +6,11 @@ from pathlib import Path
 from tostools.archive import ArchiveDay
 from tostools.receiver_timeline import (
     ReceiverHeader,
+    ReceiverSegment,
     _norm_fw,
     _norm_serial,
     _segment_range,
+    current_receiver_install_date,
     parse_receiver_line,
 )
 
@@ -148,3 +150,137 @@ class TestSegmentRange:
 
     def test_all_none_is_empty(self):
         assert _segs("----") == []
+
+
+# ------------------------------------------------------ current_receiver_install_date
+class TestCurrentReceiverInstallDate:
+    """The install date must look PAST firmware-only segment boundaries to the
+    date the physical receiver UNIT first appeared (the OLKE bug: PolaRX5 sn
+    3016143 fragmented across fw 5.1.1/5.3.0/5.6.0 must date to 2017, not the
+    latest bump)."""
+
+    def _seg(self, start, end, rtype, serial, fw):
+        return ReceiverSegment(start, end, ReceiverHeader(serial, rtype, fw))
+
+    def test_back_coalesces_across_firmware_bumps(self):
+        timeline = [
+            self._seg(
+                date(2013, 2, 28),
+                date(2017, 6, 25),
+                "TRIMBLE NETR9",
+                "5218K84655",
+                "4.62",
+            ),
+            self._seg(
+                date(2017, 7, 8), date(2019, 10, 14), "SEPT POLARX5", "3016143", "5.1.1"
+            ),
+            self._seg(
+                date(2019, 10, 15),
+                date(2026, 5, 17),
+                "SEPT POLARX5",
+                "3016143",
+                "5.3.0",
+            ),
+            self._seg(
+                date(2026, 5, 18), date(2026, 5, 23), "SEPT POLARX5", "3016143", "5.6.0"
+            ),
+        ]
+        assert current_receiver_install_date(timeline) == date(2017, 7, 8)
+
+    def test_stops_at_serial_change(self):
+        """A genuine serial change (different unit, same model) is a boundary."""
+        timeline = [
+            self._seg(
+                date(2018, 1, 1), date(2019, 1, 1), "SEPT POLARX5", "1111111", "5.1.1"
+            ),
+            self._seg(
+                date(2019, 1, 2), date(2020, 1, 1), "SEPT POLARX5", "2222222", "5.3.0"
+            ),
+        ]
+        assert current_receiver_install_date(timeline) == date(2019, 1, 2)
+
+    def test_unknown_serial_is_wildcard(self):
+        """A None (garbled) serial mid-run does not break the unit run."""
+        timeline = [
+            self._seg(
+                date(2017, 7, 8), date(2018, 1, 1), "SEPT POLARX5", "3016143", "5.1.1"
+            ),
+            self._seg(
+                date(2018, 1, 2), date(2018, 2, 1), "SEPT POLARX5", None, "5.1.1"
+            ),
+            self._seg(
+                date(2018, 2, 2), date(2020, 1, 1), "SEPT POLARX5", "3016143", "5.3.0"
+            ),
+        ]
+        assert current_receiver_install_date(timeline) == date(2017, 7, 8)
+
+    def test_single_segment(self):
+        timeline = [
+            self._seg(
+                date(2024, 1, 1), date(2024, 6, 1), "SEPT POLARX5", "3016143", "5.5.0"
+            )
+        ]
+        assert current_receiver_install_date(timeline) == date(2024, 1, 1)
+
+    def test_empty(self):
+        assert current_receiver_install_date([]) is None
+
+
+# ----------------------------------------------------- streaming header reader
+class TestFastHeaderRead:
+    """`read_receiver_header` streams gzip -dc and stops at END OF HEADER,
+    falling back to the shared reader otherwise. Both paths must yield the
+    same parsed receiver identity."""
+
+    _HEADER = (
+        "     3.04           OBSERVATION DATA    M                   "
+        "RINEX VERSION / TYPE\n"
+        "3016143             SEPT POLARX5        5.6.0               "
+        "REC # / TYPE / VERS\n"
+        "                                                            "
+        "END OF HEADER\n"
+    )
+
+    def _write_gz(self, tmp_path, name, header, tail_mb=0):
+        import gzip
+
+        body = header + ("X" * (tail_mb * 1024 * 1024))  # bulk after the header
+        p = tmp_path / name
+        with gzip.open(p, "wb") as f:
+            f.write(body.encode())
+        return p
+
+    def test_fast_path_gz_parses_rec_line(self, tmp_path):
+        from tostools.receiver_timeline import read_receiver_header
+
+        p = self._write_gz(tmp_path, "OLKE1410.26D.gz", self._HEADER, tail_mb=2)
+        h = read_receiver_header(p)
+        assert h is not None
+        assert (h.serial, h.rtype, h.firmware) == ("3016143", "SEPT POLARX5", "5.6.0")
+
+    def test_fast_path_stops_early(self, tmp_path):
+        """Header is found without inflating a large tail — _fast_header_text
+        returns only up to END OF HEADER, not the whole 3 MB body."""
+        from tostools.receiver_timeline import _fast_header_text
+
+        p = self._write_gz(tmp_path, "OLKE1420.26D.gz", self._HEADER, tail_mb=3)
+        text = _fast_header_text(p)
+        assert text is not None
+        assert text.rstrip().endswith("END OF HEADER")
+        assert len(text) < 100 * 1024  # nowhere near the 3 MB body
+
+    def test_uncompressed_name_falls_back(self, tmp_path):
+        """A non-.Z/.gz name isn't fast-pathed → _fast_header_text returns None
+        (caller falls back to the shared reader)."""
+        from tostools.receiver_timeline import _fast_header_text
+
+        p = tmp_path / "OLKE1410.26o"
+        p.write_text(self._HEADER)
+        assert _fast_header_text(p) is None
+
+    def test_no_marker_bails_to_none(self, tmp_path):
+        """A .gz stream with no END OF HEADER bails (→ fallback), doesn't hang."""
+        from tostools.receiver_timeline import _fast_header_text
+
+        p = self._write_gz(tmp_path, "junk.gz", "no marker here\n", tail_mb=0)
+        assert _fast_header_text(p) is None


### PR DESCRIPTION
## Summary

Integration capstone (**todo #40**): extends `tos audit verify-from-rinex` from **brand-level** to **receiver-level**. Per station, compares the RINEX-header current install against TOS's open `gnss_receiver` join and, on a real disagreement, emits a **dated, review-first `receivers cfg replace-receiver …` suggestion**.

Catches the case the brand audit can't: TOS still holds a retired open receiver (OLKE's TRIMBLE 4700 from 2000) while the archive shows the PolaRX5 deployed since **2017-07-08**.

## What's in it

**`audit_verify_from_rinex`**
- `classify_current_receiver()` — pure, testable. Normalizes **both** sides through the same `ReceiverHeader.key` (type via `to_igs_receiver`, fw `5.50`≡`5.5.0`, placeholder serials → unknown) so a verdict is a real disagreement, not spelling noise — the #1 false-positive risk with most of the fleet already drifting.
  - Verdicts: `type_mismatch` / `serial_mismatch` (→ replace-receiver suggestion), `firmware_drift` (informational; recording fw is #39), `ok` / `no_open_join` / `no_rinex_receiver`.
- The suggestion is a **run-MANUALLY shell command, NOT a `tos audit apply` ACTION line** — kept distinct in the triage file so it never misleads the apply parser ("suggest, never auto-write" holds for free).
- `CurrentReceiverVerdict` wired into `StationRinexReport.has_findings` / `finding_count`; rendered in `format_triage_file`, `station_triage`, the verify-from-rinex pretty/JSON paths, and `station verify --json`.

**`receiver_timeline`**
- `current_receiver_install_date()` — the suggestion's `--date` must be when the receiver **unit** was installed, not its latest firmware segment. Back-coalesces past firmware-only boundaries (same type+serial). OLKE → 2017-07-08, not the 2026 fw-5.6.0 bump. `current_install()` unchanged.
- `read_receiver_header()` — streams `gzip -dc` (reads `.Z` and `.gz`) and stops at `END OF HEADER` instead of inflating the whole ~4 MB daily file for its ~2 KB header: **~404 ms → ~8 ms/read (≈50×)** on the cold NFS archive (warm OLKE build 28.8 s → 4.0 s). Falls back to the robust shared reader on any failure.

## Verification

- **Live:** OLKE → `replace-receiver … --date 2017-07-08`; GJAC / THOB → clean (no false positive).
- 1148 tests pass (**21 new**); ruff/black clean.

## Follow-ups (not in this PR)

- Tighten the receiver-TYPE normalizer (`TRIMBLE 4700` vs bare `4700`) — old-era only, current receivers normalize clean, so MVP-safe.
- Firmware-history recording → #39.
- Cold directory walk is now the dominant cost (`build_receiver_timeline` walks 2×, audit a 3rd time) — consolidating to one walk is the next perf lever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)