### PR TITLE
perf(history): single-device fast path for decommission open-join lookup

### DIFF
--- a/src/tostools/history.py
+++ b/src/tostools/history.py
@@ -678,6 +678,52 @@ def build_join_index(
     return index
 
 
+def device_timeline_via_parent_history(client, id_entity: int) -> DeviceTimeline:
+    """One device's :class:`DeviceTimeline`, built straight from its
+    ``parent_history`` — O(1) TOS calls, **no** global :func:`build_join_index`.
+
+    The global index walks every known parent's ``children_connections``
+    (``enumerate_known_parents`` + ~200 fetches, ~110 s on the live IMO fleet)
+    so that *any* device's timeline becomes a dict lookup. When you only need
+    ONE — or a handful of — device(s) (the decommission apply path, a
+    single-device ``device show``), that whole-fleet cost is wasted:
+    ``GET /entity/parent_history/{id}`` returns the same joins from the child's
+    side in a single call. It is also strictly *more* complete than the index,
+    which silently omits joins to parents outside ``enumerate_known_parents``.
+
+    The connection id is the row's ``id`` here (``children_connections`` names
+    it ``id_entity_connection``); we accept either. ``time_to`` is ``None`` for
+    an open join. Rows with no usable connection id are skipped.
+    """
+    joins: List[Join] = []
+    for row in client.get_parent_history(int(id_entity)) or []:
+        conn_raw = row.get("id_entity_connection")
+        if conn_raw is None:
+            conn_raw = row.get("id")
+        if conn_raw is None:
+            continue
+        try:
+            conn_id = int(conn_raw)
+            parent_id = int(row.get("id_entity_parent") or 0)
+        except (TypeError, ValueError):
+            continue
+        time_to = row.get("time_to")
+        # The endpoint returns JSON null → None for open joins, but be
+        # defensive about a stringified "None"/"" leaking through.
+        if time_to is not None and str(time_to).strip() in ("", "None"):
+            time_to = None
+        joins.append(
+            Join(
+                id_entity_connection=conn_id,
+                id_entity_parent=parent_id,
+                id_entity_child=int(id_entity),
+                time_from=str(row.get("time_from") or ""),
+                time_to=time_to,
+            )
+        )
+    return DeviceTimeline(int(id_entity), joins)
+
+
 # ---------------------------------------------------------------------------
 # Fleet-wide gap report (synthesis plan §5 step 4)
 # ---------------------------------------------------------------------------

--- a/src/tostools/tos.py
+++ b/src/tostools/tos.py
@@ -9213,21 +9213,40 @@ def _dispatch_action(
     )
 
 
+# Above this many decommission targets, one global join index (~200 parent
+# fetches) is cheaper than per-device parent_history calls; at or below it the
+# per-device path wins big (1 fetch each vs the whole-fleet ~110s build). The
+# real break-even is ~200 (the parent count); 50 is a safe, conservative floor.
+_OPEN_JOINS_FASTPATH_MAX = 50
+
+
 def _build_open_joins_lookup(client, *, target_ids):
-    """Build ``{device_id: open_join_or_None}`` via the global join index.
+    """Build ``{device_id: open_join_or_None}`` for the decommission apply path.
 
-    The ~110s cost is the marker-resolution + parent walk inside
-    :func:`tostools.history.build_join_index`. For the apply workflow
-    this is the price of a decommission action — we need to know *which
-    join* to close (it's keyed by ``id_entity_connection``, which only
-    the parent's ``children_connections`` carries).
+    We need each target's currently-open join to close it (keyed by
+    ``id_entity_connection``). Two ways to get there:
 
-    Only includes devices in ``target_ids``; the rest of the index
-    contents are discarded. The returned dict has one entry per target
-    id; the value is the device's currently-open :class:`Join` or
-    ``None`` if the device has no open join (already orphan).
+    * **Fast path (small target set):** ``GET /entity/parent_history/{id}`` per
+      device — O(targets) calls, no fleet walk. Used when ``len(target_ids) <=``
+      :data:`_OPEN_JOINS_FASTPATH_MAX`. A single-device decommission drops from
+      ~110s to sub-second, and parent_history is strictly more complete than the
+      index (it never omits joins to un-enumerated parents).
+    * **Global index (large target set):** :func:`history.build_join_index`
+      walks every known parent once (~110s) so a big batch amortises the cost.
+
+    The returned dict has one entry per target id; the value is the device's
+    currently-open :class:`Join` or ``None`` if it has no open join.
     """
-    from .history import build_join_index
+    from .history import build_join_index, device_timeline_via_parent_history
+
+    targets = [int(t) for t in target_ids]
+
+    if len(targets) <= _OPEN_JOINS_FASTPATH_MAX:
+        out: Dict[int, Any] = {}
+        for did in targets:
+            open_joins = device_timeline_via_parent_history(client, did).open_joins
+            out[did] = open_joins[0] if open_joins else None
+        return out
 
     progress_to_stderr = sys.stderr.isatty()
     if progress_to_stderr:
@@ -9237,11 +9256,10 @@ def _build_open_joins_lookup(client, *, target_ids):
         )
         sys.stderr.flush()
     index = build_join_index(client)
-    out: Dict[int, Any] = {}
-    for did in target_ids:
-        timeline = index.timeline(int(did))
-        open_joins = timeline.open_joins
-        out[int(did)] = open_joins[0] if open_joins else None
+    out = {}
+    for did in targets:
+        open_joins = index.timeline(did).open_joins
+        out[did] = open_joins[0] if open_joins else None
     return out
 
 

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -480,6 +480,7 @@ from tostools.history import (  # noqa: E402  re-import to keep step-3 block sel
     _connection_to_join,
     _parse_iso,
     build_join_index,
+    device_timeline_via_parent_history,
 )
 
 
@@ -1828,3 +1829,101 @@ def test_device_timeline_report_is_frozen():
 
     with pytest.raises(dataclasses.FrozenInstanceError):
         tl.id_entity = 999  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# device_timeline_via_parent_history — single-device fast path (no fleet index)
+# ---------------------------------------------------------------------------
+
+
+def test_parent_history_timeline_open_and_closed():
+    """Builds a device's timeline straight from parent_history; the connection
+    id comes from the row's `id` field, and the open join is detected."""
+    client = MagicMock()
+    client.get_parent_history.return_value = [
+        {
+            "id": 5821,
+            "id_entity_parent": 4370,
+            "id_entity_child": 100,
+            "time_from": "1999-05-24T00:00:00",
+            "time_to": "2013-02-28T00:00:00",
+        },
+        {
+            "id": 6120,
+            "id_entity_parent": 4,
+            "id_entity_child": 100,
+            "time_from": "2013-02-28T00:00:00",
+            "time_to": None,
+        },
+    ]
+    tl = device_timeline_via_parent_history(client, 100)
+    client.get_parent_history.assert_called_once_with(100)
+    assert len(tl.joins) == 2
+    opens = tl.open_joins
+    assert len(opens) == 1
+    assert opens[0].id_entity_connection == 6120
+    assert opens[0].id_entity_parent == 4
+    assert opens[0].id_entity_child == 100
+
+
+def test_parent_history_timeline_accepts_id_entity_connection_key():
+    """A children_connections-shaped row (id_entity_connection) also works."""
+    client = MagicMock()
+    client.get_parent_history.return_value = [
+        {
+            "id_entity_connection": 999,
+            "id_entity_parent": 4370,
+            "id_entity_child": 7,
+            "time_from": "2020-01-01",
+            "time_to": None,
+        },
+    ]
+    tl = device_timeline_via_parent_history(client, 7)
+    assert tl.open_joins[0].id_entity_connection == 999
+
+
+def test_parent_history_timeline_stringified_none_is_open():
+    """A leaked stringy 'None'/'' time_to is normalised to an open join."""
+    client = MagicMock()
+    client.get_parent_history.return_value = [
+        {
+            "id": 1,
+            "id_entity_parent": 4,
+            "id_entity_child": 7,
+            "time_from": "2020-01-01",
+            "time_to": "None",
+        },
+    ]
+    tl = device_timeline_via_parent_history(client, 7)
+    assert tl.open_joins and tl.open_joins[0].id_entity_connection == 1
+
+
+def test_parent_history_timeline_skips_rows_without_conn_id():
+    """A row carrying no usable connection id is skipped, not crashed on."""
+    client = MagicMock()
+    client.get_parent_history.return_value = [
+        {
+            "id_entity_parent": 4,
+            "id_entity_child": 7,
+            "time_from": "2020-01-01",
+            "time_to": None,
+        },
+        {
+            "id": 2,
+            "id_entity_parent": 4,
+            "id_entity_child": 7,
+            "time_from": "2021-01-01",
+            "time_to": None,
+        },
+    ]
+    tl = device_timeline_via_parent_history(client, 7)
+    assert [j.id_entity_connection for j in tl.joins] == [2]
+
+
+def test_parent_history_timeline_empty_means_no_open_join():
+    """No parent history → empty timeline, no open join (orphan / unknown)."""
+    client = MagicMock()
+    client.get_parent_history.return_value = []
+    tl = device_timeline_via_parent_history(client, 7)
+    assert tl.joins == []
+    assert tl.open_joins == []


### PR DESCRIPTION
## Problem
`tos audit apply` decommission actions call `_build_open_joins_lookup`, which builds the **whole-fleet** join index — `enumerate_known_parents` + ~200 `children_connections` fetches, **~110s** on the live IMO fleet — purely to discover each target device's open join to close, then throws the rest away. For a single-device decommission (the common case) that's ~110s of wasted work, surfaced when reconstructing OLKE.

## Fix
New `history.device_timeline_via_parent_history(client, id_entity)` builds one device's `DeviceTimeline` directly from `GET /entity/parent_history/{id}` — **one call, no fleet walk**, and strictly *more* complete than the index (which silently omits joins to parents outside `enumerate_known_parents`).

`_build_open_joins_lookup` uses it when `len(target_ids) <= 50` (well under the ~200-parent break-even), falling back to the global index for large batches.

## Result
Measured live on the OLKE single-device decommission dry-run: **~110s → 1.6s (~70×)**, no index-build message.

- 5 new unit tests (`device_timeline_via_parent_history`: `id`/`id_entity_connection` keys, stringy-None normalization, conn-less row skip, empty history).
- Full suite 1153 pass, ruff/black clean.

## Follow-up (not in this PR)
The `device show --with-joins` chronology path (`tos.py:~10730`) pays the same ~110s index build for one device, but also needs parent *names* (currently from `enumerate_known_parents`). Converting it needs lightweight per-parent name resolution — separate, smaller change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)