### PR TITLE
feat(apply): guard against duplicate open singular device on a station

### DIFF
--- a/src/tostools/tos.py
+++ b/src/tostools/tos.py
@@ -9359,6 +9359,70 @@ def _print_apply_preflight_table(actions, meta, *, mode_tag: str) -> None:
     print()
 
 
+# Subtypes a station may hold only ONE open instance of at a time. A 2nd open
+# join of one of these means a swap didn't close the old device — the failure
+# mode that left OLKE with two open gnss_receivers when a `delete-join` silently
+# failed at runtime. Deliberately small: solar_panel / battery / windmill /
+# sim_card / modem legitimately repeat on one station, so they're NOT listed.
+_SINGULAR_STATION_SUBTYPES = ("gnss_receiver", "antenna", "radome", "monument")
+
+
+def _verify_no_duplicate_open_singular(client, actions):
+    """Post-apply guard: no station left with >1 open join of a singular subtype.
+
+    Catches the runtime partial-failure case — an action set whose *intent* is a
+    clean swap (close old + open new) but where the close didn't land, so the
+    station ends with two open same-subtype devices and apply still prints a
+    success-ish summary. A pre-flight set-simulation can't see this (the intent
+    was correct); only re-reading the post-apply state can.
+
+    Follows each receiver-opening action's child (`create-join` / `move` /
+    `fill-gap`) to its current open parent via parent_history (the fast,
+    no-fleet-index path), then re-reads each such parent that is a STATION
+    (warehouses / graveyard legitimately hold multiples) and counts open
+    children per singular subtype. A closed join — e.g. OLKE's zero-duration
+    phantom stub — has ``time_to != None`` and is not counted. Returns a list
+    of human-readable violation strings; empty means clean.
+    """
+    from .history import ParentEntity, device_timeline_via_parent_history
+
+    opening_verbs = {"create-join", "move", "fill-gap"}
+    children = {a.id_entity for a in actions if a.verb in opening_verbs}
+    station_ids: set = set()
+    for cid in children:
+        for j in device_timeline_via_parent_history(client, cid).open_joins:
+            station_ids.add(j.id_entity_parent)
+
+    violations: List[str] = []
+    for pid in sorted(station_ids):
+        h = client.get_entity_history(pid)
+        if not h:
+            continue
+        parent = ParentEntity.from_history(pid, h)
+        if parent.role != "station":
+            continue  # warehouses / graveyard hold multiples by design
+        open_by_subtype: Dict[str, List[int]] = {}
+        for conn in h.get("children_connections") or []:
+            if conn.get("time_to") is not None:
+                continue  # closed join (e.g. the zero-duration phantom stub)
+            cid_raw = conn.get("id_entity_child")
+            if cid_raw is None:
+                continue
+            child = client.get_entity_history(int(cid_raw)) or {}
+            st = child.get("code_entity_subtype")
+            if st in _SINGULAR_STATION_SUBTYPES:
+                open_by_subtype.setdefault(st, []).append(int(cid_raw))
+        for st, devs in sorted(open_by_subtype.items()):
+            if len(devs) > 1:
+                violations.append(
+                    f"{parent.name or f'id={pid}'}: {len(devs)} open {st} joins "
+                    f"(devices {', '.join(map(str, sorted(devs)))}) — a station "
+                    f"may have only one; the prior device's join was not closed "
+                    f"during the swap."
+                )
+    return violations
+
+
 def _apply_main(args) -> int:
     """Handle ``tos audit apply <file>``.
 
@@ -9437,6 +9501,14 @@ def _apply_main(args) -> int:
             )
         )
 
+    # Post-apply guard: re-read affected stations and refuse to call the run
+    # clean if a swap left two open joins of a singular subtype (e.g. a
+    # delete-join that silently failed). Apply-mode only — dry-run sent no
+    # writes, so there is no post-state to verify.
+    post_violations: List[str] = []
+    if not dry_run:
+        post_violations = _verify_no_duplicate_open_singular(client, actions)
+
     if args.json:
         payload = {
             "file": str(path),
@@ -9456,6 +9528,7 @@ def _apply_main(args) -> int:
                 }
                 for r in results
             ],
+            "post_apply_violations": post_violations,
         }
         print(_json.dumps(payload, ensure_ascii=False, indent=2))
     else:
@@ -9484,8 +9557,22 @@ def _apply_main(args) -> int:
         )
         if dry_run:
             print("(no writes were sent — re-run with --apply to commit)")
+        if post_violations:
+            print(
+                f"\n✗ POST-APPLY GUARD: {len(post_violations)} station(s) left "
+                f"with a duplicate open singular device:",
+                file=sys.stderr,
+            )
+            for v in post_violations:
+                print(f"    {v}", file=sys.stderr)
+            print(
+                "  Close the stale join (e.g. `cfg move-device --serial <OLD> "
+                "--to <warehouse>` or a `decommission` action) and re-verify.",
+                file=sys.stderr,
+            )
 
-    return 0 if all(r.status != "failed" for r in results) else 1
+    ok = all(r.status != "failed" for r in results) and not post_violations
+    return 0 if ok else 1
 
 
 def _stderr_progress(unit: str):

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -2498,3 +2498,121 @@ def test_dispatch_delete_contact_relationship_non_int_rejected():
     assert result.status == "failed"
     assert "integer id_relationship" in result.detail
     writer.delete_contact_relationship.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Post-apply guard: no duplicate open singular device on a station
+# ---------------------------------------------------------------------------
+from tostools.tos import _verify_no_duplicate_open_singular  # noqa: E402
+
+
+def _dev_hist(did, subtype="gnss_receiver"):
+    return {"id_entity": did, "code_entity_subtype": subtype, "attributes": []}
+
+
+def _station_hist(
+    pid, *, subtype="geophysical", name="OLKE", open_children=(), closed_children=()
+):
+    conns = [{"id_entity_child": c, "time_to": None} for c in open_children]
+    conns += [
+        {"id_entity_child": c, "time_to": "2000-10-17T00:00:00"}
+        for c in closed_children
+    ]
+    return {
+        "id_entity": pid,
+        "code_entity_subtype": subtype,
+        "attributes": [{"code": "name", "value_varchar": name, "time_to": None}],
+        "children_connections": conns,
+    }
+
+
+def _guard_client(station, child_subtypes, opening_child_parent):
+    histories = {station["id_entity"]: station}
+    for cid, st in child_subtypes.items():
+        histories[cid] = _dev_hist(cid, st)
+    c = MagicMock()
+    c.get_entity_history.side_effect = lambda i: histories.get(int(i))
+
+    def _ph(cid):
+        pid = opening_child_parent.get(int(cid))
+        return (
+            []
+            if pid is None
+            else [
+                {
+                    "id": 9000 + int(cid),
+                    "id_entity_parent": pid,
+                    "id_entity_child": int(cid),
+                    "time_from": "2017-06-26",
+                    "time_to": None,
+                }
+            ]
+        )
+
+    c.get_parent_history.side_effect = _ph
+    return c
+
+
+def test_guard_clean_single_open_receiver():
+    """One open gnss_receiver (+ a closed phantom stub) → no violation."""
+    station = _station_hist(4370, open_children=[21580], closed_children=[4979])
+    c = _guard_client(
+        station, {21580: "gnss_receiver", 4979: "gnss_receiver"}, {21580: 4370}
+    )
+    assert (
+        _verify_no_duplicate_open_singular(
+            c, [_make_action(21580, "create-join", "4370", "2017-06-26")]
+        )
+        == []
+    )
+
+
+def test_guard_flags_two_open_receivers():
+    """Two open gnss_receivers (the failed-delete case) → violation."""
+    station = _station_hist(4370, open_children=[21580, 4979])
+    c = _guard_client(
+        station, {21580: "gnss_receiver", 4979: "gnss_receiver"}, {21580: 4370}
+    )
+    v = _verify_no_duplicate_open_singular(
+        c, [_make_action(21580, "create-join", "4370", "2017-06-26")]
+    )
+    assert len(v) == 1
+    assert "2 open gnss_receiver" in v[0]
+    assert "4979" in v[0] and "21580" in v[0]
+
+
+def test_guard_ignores_warehouse_parent():
+    """Warehouses hold multiple receivers by design → no violation."""
+    wh = _station_hist(
+        4, subtype="area", name="B9 - Kjallari - Jörð", open_children=[100, 200]
+    )
+    c = _guard_client(wh, {100: "gnss_receiver", 200: "gnss_receiver"}, {100: 4})
+    assert _verify_no_duplicate_open_singular(c, [_make_action(100, "move", "4")]) == []
+
+
+def test_guard_ignores_non_singular_subtype():
+    """Two open solar_panels on a station is legitimate → no violation."""
+    station = _station_hist(4370, open_children=[100, 200])
+    c = _guard_client(station, {100: "solar_panel", 200: "solar_panel"}, {100: 4370})
+    assert (
+        _verify_no_duplicate_open_singular(
+            c, [_make_action(100, "create-join", "4370", "2020-01-01")]
+        )
+        == []
+    )
+
+
+def test_guard_closed_stub_not_counted():
+    """A zero-duration / closed join doesn't count toward the open total."""
+    station = _station_hist(4370, open_children=[21580], closed_children=[4979, 4798])
+    c = _guard_client(
+        station,
+        {21580: "gnss_receiver", 4979: "gnss_receiver", 4798: "gnss_receiver"},
+        {21580: 4370},
+    )
+    assert (
+        _verify_no_duplicate_open_singular(
+            c, [_make_action(21580, "create-join", "4370", "2017-06-26")]
+        )
+        == []
+    )


### PR DESCRIPTION
## Problem
`tos audit apply` printed a success-ish summary even when a receiver swap left a station with **two open `gnss_receiver`s** — exactly the OLKE failure: the action set correctly did `delete-join <old>` + `create-join <new>` open, but the `delete-join` silently failed at runtime, leaving the retired phantom **and** the new PolaRX5 both open. The set's *intent* was correct, so a pre-flight simulation would have passed; only re-reading the post-apply state catches a write that didn't land.

## Fix
New `_verify_no_duplicate_open_singular(client, actions)`, run after an `--apply` run:
- follows each receiver-opening action's child (`create-join` / `move` / `fill-gap`) to its current open parent via `parent_history` (the no-fleet-index fast path from #60),
- re-reads each **station** parent (warehouses / graveyard hold multiples by design — skipped),
- asserts ≤1 open join per **singular** subtype: `gnss_receiver`, `antenna`, `radome`, `monument` (repeating subtypes — solar_panel/battery/windmill/sim/modem — are deliberately excluded),
- on violation: a loud stderr report naming the conflicting devices + **non-zero exit**.

Closed joins (e.g. OLKE's zero-duration phantom stub) aren't counted. **Reports, never auto-closes** — in an error-riddled domain an inferred close date would manufacture new errors; the operator's set must carry the explicit close, and the guard verifies it landed.

Apply-mode only (dry-run sends no writes, so there's no post-state). Verified live: OLKE (now correctly fixed) reports clean.

## Tests
5 new (`test_apply.py`): clean single receiver, two-open violation, warehouse-parent skip, non-singular subtype skip, closed-stub-not-counted. Full suite 1158 pass, ruff/black clean.

## Follow-ups (not in this PR)
- A pre-flight set-simulation (current open − same-run closes + same-run opens) for **dry-run** feedback.
- Surface an existing double-open as a `tos station verify` finding (detection, complementing this prevention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)