### PR TITLE
feat: duplicate-open-singular detection (station verify) + dry-run pre-flight

### DIFF
--- a/data/triage/hofn/hofn_audit_20260528.txt
+++ b/data/triage/hofn/hofn_audit_20260528.txt
@@ -1,0 +1,343 @@
+# === HOFN station triage — auto-generated 2026-05-28T06:34:15Z ===
+#
+# Station id_entity=4328  (54 total finding(s))
+# Audit summary:
+#   missing-attributes:  36 violation(s)
+#   attribute-dates:     16 violation(s)
+#   verify-from-rinex:   2 finding(s) (0 transitions, 2 gaps, 0 suggested ACTIONs)
+#
+# Run:
+#   tos audit apply <this_file>          # dry-run (safe default)
+#   tos audit apply <this_file> --apply  # commit
+#
+# Convention: ACTION lines below are SUGGESTED, COMMENTED OUT by
+# default. To accept, remove the leading '#'. To customize, edit
+# values + uncomment. To skip, leave commented or delete the line.
+# Replace any <FILL_VALUE> placeholders before --apply.
+#
+# Date tokens: `start` (entity's earliest_known) and `now` (today
+# UTC) are resolved at apply-time by `tos audit apply` — operators
+# don't need to look up concrete dates for the common case.
+
+# ──────────────────────────────────────────────────────────────────
+# Section: suspicious attribute dates
+# CONFIDENCE: HIGH — date_from=2014-10-17 is the fleet-wide bulk-load
+# pattern (see memory project_2014_10_17_metadata_cleanup_artifacts).
+# Backdating to actual install date typically uncontroversial.
+# ──────────────────────────────────────────────────────────────────
+# === tos audit attribute-dates — triage action file ===
+# Generated:  2026-05-28T06:34:15Z
+# Station:    'Höfn' (id_entity=4328)
+# Audit cmd:  tos audit attribute-dates HOFN
+# Violations: 16
+#
+# Format: one ACTION per line, '#' for comments.
+#
+#   ACTION <id_entity> patch-attribute-date \
+#          <code> <old_date_from> <new_date_from>
+#
+# Workflow:
+#   1. Review each block below — verify the suggested
+#      new_date_from is correct. Edit if needed.
+#   2. Uncomment the ACTION line(s) you want to fire.
+#   3. tos audit apply <file>          # dry-run preview
+#   4. tos audit apply <file> --apply  # commit writes
+#
+# Alternative for known-good entries: copy the SUPPRESS hint into
+# data/audit_suppressions/attribute_dates.txt instead.
+
+# --- antenna id_entity=4449 SN '0220008914' ---
+# violation: serial_number date_from=2014-10-17  (earliest_known=1997-05-27, anchor=attribute)  value='0220008914'
+#ACTION 4449 patch-attribute-date serial_number 2014-10-17 1997-05-27
+# (or suppress: SUPPRESS 4449 serial_number 2014-10-17)
+
+# --- antenna id_entity=4459 SN '0220181800' ---
+# violation: serial_number date_from=2014-10-17  (earliest_known=2001-09-21, anchor=attribute)  value='0220181800'
+#ACTION 4459 patch-attribute-date serial_number 2014-10-17 2001-09-21
+# (or suppress: SUPPRESS 4459 serial_number 2014-10-17)
+
+# --- antenna id_entity=4522 SN '217-0218' ---
+# violation: serial_number date_from=2014-10-17  (earliest_known=2007-09-23, anchor=attribute)  value='217-0218'
+#ACTION 4522 patch-attribute-date serial_number 2014-10-17 2007-09-23
+# (or suppress: SUPPRESS 4522 serial_number 2014-10-17)
+
+# --- antenna id_entity=4621 SN '7252843' ---
+# violation: serial_number date_from=2014-10-17  (earliest_known=2013-05-05, anchor=attribute)  value='7252843'
+#ACTION 4621 patch-attribute-date serial_number 2014-10-17 2013-05-05
+# (or suppress: SUPPRESS 4621 serial_number 2014-10-17)
+
+# --- gnss_receiver id_entity=4737 SN '00024908' ---
+# violation: serial_number date_from=2014-10-17  (earliest_known=2007-02-13, anchor=attribute)  value='00024908'
+#ACTION 4737 patch-attribute-date serial_number 2014-10-17 2007-02-13
+# (or suppress: SUPPRESS 4737 serial_number 2014-10-17)
+
+# --- gnss_receiver id_entity=4791 SN '1830199' ---
+# violation: serial_number date_from=2014-10-17  (earliest_known=2013-05-05, anchor=attribute)  value='1830199'
+#ACTION 4791 patch-attribute-date serial_number 2014-10-17 2013-05-05
+# (or suppress: SUPPRESS 4791 serial_number 2014-10-17)
+
+# --- gnss_receiver id_entity=4846 SN '3503A09374' ---
+# violation: serial_number date_from=2014-10-17  (earliest_known=1997-05-27, anchor=attribute)  value='3503A09374'
+#ACTION 4846 patch-attribute-date serial_number 2014-10-17 1997-05-27
+# (or suppress: SUPPRESS 4846 serial_number 2014-10-17)
+
+# --- gnss_receiver id_entity=4951 SN 'AGL2LHV3XMO' ---
+# violation: serial_number date_from=2014-10-17  (earliest_known=2007-09-23, anchor=attribute)  value='AGL2LHV3XMO'
+#ACTION 4951 patch-attribute-date serial_number 2014-10-17 2007-09-23
+# (or suppress: SUPPRESS 4951 serial_number 2014-10-17)
+
+# --- monument id_entity=5114 SN 'monument-HOFN-19970527' ---
+# violation: serial_number date_from=2014-10-17  (earliest_known=1997-05-27, anchor=attribute)  value='monument-HOFN-19970527'
+#ACTION 5114 patch-attribute-date serial_number 2014-10-17 1997-05-27
+# (or suppress: SUPPRESS 5114 serial_number 2014-10-17)
+
+# --- monument id_entity=5115 SN 'monument-HOFN-20010921' ---
+# violation: serial_number date_from=2014-10-17  (earliest_known=2001-09-21, anchor=attribute)  value='monument-HOFN-20010921'
+#ACTION 5115 patch-attribute-date serial_number 2014-10-17 2001-09-21
+# (or suppress: SUPPRESS 5115 serial_number 2014-10-17)
+
+# --- monument id_entity=5116 SN 'monument-HOFN-20070923' ---
+# violation: serial_number date_from=2014-10-17  (earliest_known=2007-09-23, anchor=attribute)  value='monument-HOFN-20070923'
+#ACTION 5116 patch-attribute-date serial_number 2014-10-17 2007-09-23
+# (or suppress: SUPPRESS 5116 serial_number 2014-10-17)
+
+# --- monument id_entity=5117 SN 'monument-HOFN-20100326' ---
+# violation: serial_number date_from=2014-10-17  (earliest_known=2010-03-26, anchor=attribute)  value='monument-HOFN-20100326'
+#ACTION 5117 patch-attribute-date serial_number 2014-10-17 2010-03-26
+# (or suppress: SUPPRESS 5117 serial_number 2014-10-17)
+
+# --- monument id_entity=5118 SN 'monument-HOFN-20130505' ---
+# violation: serial_number date_from=2014-10-17  (earliest_known=2013-05-05, anchor=attribute)  value='monument-HOFN-20130505'
+#ACTION 5118 patch-attribute-date serial_number 2014-10-17 2013-05-05
+# (or suppress: SUPPRESS 5118 serial_number 2014-10-17)
+
+# --- radome id_entity=5303 SN 'radome-HOFN-19970527' ---
+# violation: serial_number date_from=2014-10-17  (earliest_known=1997-05-27, anchor=attribute)  value='radome-HOFN-19970527'
+#ACTION 5303 patch-attribute-date serial_number 2014-10-17 1997-05-27
+# (or suppress: SUPPRESS 5303 serial_number 2014-10-17)
+
+# --- radome id_entity=5304 SN 'radome-HOFN-20070923' ---
+# violation: serial_number date_from=2014-10-17  (earliest_known=2007-09-23, anchor=attribute)  value='radome-HOFN-20070923'
+#ACTION 5304 patch-attribute-date serial_number 2014-10-17 2007-09-23
+# (or suppress: SUPPRESS 5304 serial_number 2014-10-17)
+
+# --- radome id_entity=5305 SN 'radome-HOFN-20130505' ---
+# violation: serial_number date_from=2014-10-17  (earliest_known=2013-05-05, anchor=attribute)  value='radome-HOFN-20130505'
+#ACTION 5305 patch-attribute-date serial_number 2014-10-17 2013-05-05
+# (or suppress: SUPPRESS 5305 serial_number 2014-10-17)
+
+# ──────────────────────────────────────────────────────────────────
+# Section: missing required attributes
+# CONFIDENCE: MEDIUM/LOW — lines with concrete suggested values are
+# MEDIUM (catalog default; verify against site). Lines with <FILL_VALUE>
+# are LOW — operator MUST replace before --apply.
+#
+# Date tokens (resolved at apply-time by `tos audit apply`):
+#   `start` = entity's earliest_known date (audit anchor)
+#   `now`   = today UTC
+# `<FILL_DATE>` placeholders below have been pre-substituted with
+# `start` — operator can edit if a different date is correct.
+# ──────────────────────────────────────────────────────────────────
+# === tos audit missing-attributes — triage action file ===
+# Generated:  2026-05-28T06:34:15Z
+# Station:    'Höfn' (id_entity=4328)
+# Audit cmd:  tos audit missing-attributes HOFN
+# Violations: 36
+#
+# Format: one ACTION per line, '#' for comments.
+#
+#   ACTION <id_entity> add-attribute \
+#          <code> <value> <date_from>
+#
+# Workflow:
+#   1. Review each block below. Replace any
+#      <FILL_VALUE> / start placeholders with the value/date you
+#      know is correct for the entity.
+#   2. Uncomment the ACTION line(s) you want to fire.
+#   3. tos audit apply <file>          # dry-run preview
+#   4. tos audit apply <file> --apply  # commit writes
+#
+# Alternative for known-good gaps: copy the SUPPRESS hint into
+# data/audit_suppressions/missing_attributes.txt instead.
+
+# --- geophysical id_entity=4328 'Höfn' ---
+# missing: visit_class  (default: 'B')
+#ACTION 4328 add-attribute visit_class B start
+# (or suppress: SUPPRESS 4328 visit_class)
+
+# missing: date_start
+#ACTION 4328 add-attribute date_start <FILL_VALUE> start
+# (or suppress: SUPPRESS 4328 date_start)
+
+# missing: description
+#ACTION 4328 add-attribute description <FILL_VALUE> start
+# (or suppress: SUPPRESS 4328 description)
+
+# missing: close_date
+#ACTION 4328 add-attribute close_date <FILL_VALUE> start
+# (or suppress: SUPPRESS 4328 close_date)
+
+# missing: geological_characteristic  (default: 'bedrock')
+#ACTION 4328 add-attribute geological_characteristic bedrock start
+# (or suppress: SUPPRESS 4328 geological_characteristic)
+
+# missing: is_near_fault_zones  (default: 'yes')
+#ACTION 4328 add-attribute is_near_fault_zones yes start
+# (or suppress: SUPPRESS 4328 is_near_fault_zones)
+
+# missing: bedrock_condition  (default: 'weathered')
+#ACTION 4328 add-attribute bedrock_condition weathered start
+# (or suppress: SUPPRESS 4328 bedrock_condition)
+
+# missing: bedrock_type  (default: 'igneous')
+#ACTION 4328 add-attribute bedrock_type igneous start
+# (or suppress: SUPPRESS 4328 bedrock_type)
+
+# missing: in_network_epos  (default: 'nei')
+#ACTION 4328 add-attribute in_network_epos nei start
+# (or suppress: SUPPRESS 4328 in_network_epos)
+
+# missing: continuity
+#ACTION 4328 add-attribute continuity <FILL_VALUE> start
+# (or suppress: SUPPRESS 4328 continuity)
+
+# --- antenna id_entity=4621 '7252843' ---
+# missing: status  (default: 'virk')
+#ACTION 4621 add-attribute status virk 2013-05-05
+# (or suppress: SUPPRESS 4621 status)
+
+# missing: antenna_height  (date hint: 2013-05-05)
+#ACTION 4621 add-attribute antenna_height <FILL_VALUE> 2013-05-05
+# (or suppress: SUPPRESS 4621 antenna_height)
+
+# missing: antenna_offset_north  (default: '0.0')
+#ACTION 4621 add-attribute antenna_offset_north 0.0 2013-05-05
+# (or suppress: SUPPRESS 4621 antenna_offset_north)
+
+# missing: antenna_offset_east  (default: '0.0')
+#ACTION 4621 add-attribute antenna_offset_east 0.0 2013-05-05
+# (or suppress: SUPPRESS 4621 antenna_offset_east)
+
+# missing: azimuth  (default: '0.0')
+#ACTION 4621 add-attribute azimuth 0.0 2013-05-05
+# (or suppress: SUPPRESS 4621 azimuth)
+
+# missing: manufacturer  (date hint: 2013-05-05)
+#ACTION 4621 add-attribute manufacturer <FILL_VALUE> 2013-05-05
+# (or suppress: SUPPRESS 4621 manufacturer)
+
+# --- gnss_receiver id_entity=4791 '1830199' ---
+# missing: status  (default: 'virk')
+#ACTION 4791 add-attribute status virk 2013-05-05
+# (or suppress: SUPPRESS 4791 status)
+
+# missing: GPS  (default: 'true')
+#ACTION 4791 add-attribute GPS true 2013-05-05
+# (or suppress: SUPPRESS 4791 GPS)
+
+# missing: GLO  (default: 'true')
+#ACTION 4791 add-attribute GLO true 2013-05-05
+# (or suppress: SUPPRESS 4791 GLO)
+
+# missing: GAL  (date hint: 2013-05-05)
+#ACTION 4791 add-attribute GAL <FILL_VALUE> 2013-05-05
+# (or suppress: SUPPRESS 4791 GAL)
+
+# missing: BDS  (date hint: 2013-05-05)
+#ACTION 4791 add-attribute BDS <FILL_VALUE> 2013-05-05
+# (or suppress: SUPPRESS 4791 BDS)
+
+# missing: QZSS  (date hint: 2013-05-05)
+#ACTION 4791 add-attribute QZSS <FILL_VALUE> 2013-05-05
+# (or suppress: SUPPRESS 4791 QZSS)
+
+# missing: SBAS  (date hint: 2013-05-05)
+#ACTION 4791 add-attribute SBAS <FILL_VALUE> 2013-05-05
+# (or suppress: SUPPRESS 4791 SBAS)
+
+# missing: IRN  (date hint: 2013-05-05)
+#ACTION 4791 add-attribute IRN <FILL_VALUE> 2013-05-05
+# (or suppress: SUPPRESS 4791 IRN)
+
+# missing: http_port  (default: '80')
+#ACTION 4791 add-attribute http_port 80 2013-05-05
+# (or suppress: SUPPRESS 4791 http_port)
+
+# missing: manufacturer  (date hint: 2013-05-05)
+#ACTION 4791 add-attribute manufacturer <FILL_VALUE> 2013-05-05
+# (or suppress: SUPPRESS 4791 manufacturer)
+
+# missing: ip_address  (default: '192.168.100.60')
+#ACTION 4791 add-attribute ip_address 192.168.100.60 2013-05-05
+# (or suppress: SUPPRESS 4791 ip_address)
+
+# --- monument id_entity=5118 'monument-HOFN-20130505' ---
+# missing: model  (date hint: 2013-05-05)
+#ACTION 5118 add-attribute model <FILL_VALUE> 2013-05-05
+# (or suppress: SUPPRESS 5118 model)
+
+# missing: status  (default: 'virk')
+#ACTION 5118 add-attribute status virk 2013-05-05
+# (or suppress: SUPPRESS 5118 status)
+
+# missing: antenna_offset_north  (default: '0.0')
+#ACTION 5118 add-attribute antenna_offset_north 0.0 2013-05-05
+# (or suppress: SUPPRESS 5118 antenna_offset_north)
+
+# missing: antenna_offset_east  (default: '0.0')
+#ACTION 5118 add-attribute antenna_offset_east 0.0 2013-05-05
+# (or suppress: SUPPRESS 5118 antenna_offset_east)
+
+# missing: monument_height  (default: '0.0')
+#ACTION 5118 add-attribute monument_height 0.0 2013-05-05
+# (or suppress: SUPPRESS 5118 monument_height)
+
+# missing: foundation_depth  (date hint: 2013-05-05)
+#ACTION 5118 add-attribute foundation_depth <FILL_VALUE> 2013-05-05
+# (or suppress: SUPPRESS 5118 foundation_depth)
+
+# missing: infrastructure_subtype  (default: 'GPS undirstaða')
+#ACTION 5118 add-attribute infrastructure_subtype 'GPS undirstaða' 2013-05-05
+# (or suppress: SUPPRESS 5118 infrastructure_subtype)
+
+# missing: infrastructure_type  (default: 'GPS stál-fjórfótur')
+#ACTION 5118 add-attribute infrastructure_type 'GPS stál-fjórfótur' 2013-05-05
+# (or suppress: SUPPRESS 5118 infrastructure_type)
+
+# --- radome id_entity=5305 'radome-HOFN-20130505' ---
+# missing: status  (default: 'virk')
+#ACTION 5305 add-attribute status virk 2013-05-05
+# (or suppress: SUPPRESS 5305 status)
+
+# ──────────────────────────────────────────────────────────────────
+# Section: archive verification (verify-from-rinex)
+# CONFIDENCE: MEDIUM — file-extension signal is authoritative for
+# what was archived, but actionability depends on operator context
+# (was the gap planned downtime? was the transition logged elsewhere?).
+# Brand transitions + data gaps are informational; only ACTION lines
+# carry pre-built suggestions.
+# ──────────────────────────────────────────────────────────────────
+# Section: archive verification — HOFN
+# Audit command: tos audit verify-from-rinex --station HOFN
+# Generated: 2026-05-28T06:34:15Z
+# Archive root: /mnt_data/rawgpsdata
+# Timeline: 5852 archived day(s) (1997-09-29 → 2025-04-02)
+#
+# Data gaps (2 ≥30d — dormant periods):
+#   2006-12-10 → 2007-02-13  (64d)
+#   2014-02-19 → 2025-01-01  (3968d)
+#
+# RINEX-only spans (1 — raw missing):
+#   1997-09-29 → 2025-04-02  (10048d)
+#
+# No actionable TOS-vs-archive discrepancies found (all receiver joins clean or informational).
+
+# ──────────────────────────────────────────────────────────────────
+# Verify (run after --apply lands)
+# ──────────────────────────────────────────────────────────────────
+#
+#   tos audit missing-attributes HOFN
+#   tos audit attribute-dates HOFN
+#   tos audit verify-from-rinex --station HOFN
+#   tos device list --station HOFN --all
+#   tosGPS PrintTOS HOFN

--- a/docs/architecture/shared-power-model.md
+++ b/docs/architecture/shared-power-model.md
@@ -90,37 +90,117 @@ prompt). Pinned by `tests/test_power.py` (8) + `tests/test_location_add.py`
 site-power cases. `SENSOR_TIED_POWER_SUBTYPES` (`anemometer_power_pack`) is
 flagged in each row so the W2 audit can exclude instrument-private power.
 
-### W2 — Audit invariant: colocated stations must share power (Q2b)
+### W2 — Audit `tos audit shared-power` (Q2b) — SCOPED 2026-06-09
 
-`tos audit shared-power <STN>` (and a fleet sweep) flags a site where
-colocated stations have:
-  * **separate/duplicate** power systems (each station its own battery+solar —
-    the duplication the requirement forbids), or
-  * **missing** power (the HEDI "neither models any power" case), or
-  * power that should be site-level still sitting on a station (drift signal
-    feeding the W3 migration).
+> **W2 and W3 are one piece.** The audit's `--triage` output *is* the migration
+> tool — it emits the `move <power_id> <site_id> <date>` ACTIONs that reparent
+> power station→site. There is no separate "W3 migration" step; running the
+> triage performs it. The old W3 section below is folded in here.
 
-Off-by-default / `--with-power` opt-in at first (mirrors `--with-coverage`),
-because until the W3 migration runs every site will look "wrong." SUPPRESS
-file `data/audit_suppressions/shared_power.txt`. `--triage` emits the
-reparent ACTIONs (see W3).
+#### Discriminating findings (read-only fleet probe, 2026-06-09)
 
-### W3 — Site-power model + migration (Q1a) — fleet-wide, heavy
+These numbers reshaped the invariant — the naive checks the original stub
+proposed are mostly false positives.
 
-Make `land` the parent of shared power:
-  * **Write path:** attach a power device to the `land` site via the existing
-    `create_entity_connection(parent=land, child=power_device)` — no new writer
-    primitive needed. New `move`-style ACTION reparents an existing
-    station-parented power device to the site (`move_device(power_id,
-    to_id_entity=land_id, …)` — already exists).
-  * **Migration:** reparent the ~35+ deployed power devices station → site.
-    Phased, per-site, through committed triage files (the canonical
-    retrospective-write trail). Per-site: confirm which station(s) the power
-    actually served, move to the `land` parent, leave a vitjun if a physical
-    visit was involved.
-  * **Decision point:** does *every* power device move to the site, or only the
-    genuinely-shared ones (a station-private UPS in a hut might legitimately
-    stay per-station)? Resolve in the W3 design, not here.
+- **110 distinct `land` sites already carry ≥1 power device.** Power is
+  *broadly* modelled per-station. The total land-site count is **not
+  established** (both enumeration probes returned 0 — no working
+  list-all-land endpoint found yet), and weather/hydro sites are in the
+  universe, so MISSING **prevalence is unknown** — could be a minority gap or
+  common. The audit itself will reveal it; do not pre-judge. Either way MISSING
+  at a *true colocation* (below) is a meaningful finding.
+- **Of 11 sites with power on ≥2 colocated stations, only 1 is a repeater.**
+  The rest exposed that **a `land` site is overloaded**: sometimes a true
+  single-point colocation (HEDI, Mjóaskarð GPS+SIL), sometimes a **regional
+  administrative grouping** spanning kilometres — `Reykjanes` (site 5495)
+  groups **7** stations (Herdísarvík … Litla-Skógfell, tens of km apart);
+  `Askja`, `Geldingadalir`, `Gígjukvísl` likewise. At a grouping site,
+  "colocated stations share power" is simply **false**.
+
+**Consequence:** the core invariant cannot key on "stations share a `land`
+site." It needs a **coordinate-proximity gate** — only stations physically
+close (all within a small radius of each other / the site coordinate) are a
+genuine colocation that should share power. This gate is the linchpin of the
+whole audit; without it ~90 % of "duplication" findings are wrong.
+
+#### The proximity gate — VERIFIED + calibrated (2026-06-09)
+
+Every station carries `lat`/`lon`; the `land` site carries one `lat`/`lon`.
+Classify each multi-station site by the **max pairwise distance** among its
+colocated stations:
+  * **colocation** — all stations within `--proximity-m` of each other. Power
+    *is* expected to be shared here.
+  * **grouping** — stations spread beyond the threshold. Skip entirely (not a
+    shared-power site; it's an admin grouping). Surface in a separate
+    "skipped — regional grouping" list so the operator sees what was excluded
+    (no silent truncation).
+
+**The gate was the design's linchpin, so it was verified against the 11
+multi-station sites before this scope shipped** — and the worry that station
+coords might just be copied from the site (HEDI showed station==site coord)
+was *refuted*: coords are independently measured and spread cleanly.
+
+| Site | kind | max pairwise child distance |
+|------|------|------------------------------|
+| Eldey | true colocation | **2 m** |
+| Mjóaskarð | colocation + repeater | GPS+SIL **7 m**; repeater **1,106 m** offset |
+| Hekla | grouping | 6.7 km |
+| Askja | grouping | 21 km |
+| Reykjanes | grouping (7+ stns) | **52 km** |
+
+The separation is huge — true colocations are **≤7 m**, the next thing up is
+**>1 km** — so any threshold in ~100 m–1 km works; **default 150 m** is safe.
+Two consequences this resolved: (a) HEDI's station==site coordinate was a
+genuine colocation, not coordinate-copying — the gate is real; (b) the
+**repeater is auto-separated by proximity** (1.1 km > threshold), so the
+repeater/aux false-positive needs **no name-regex** — proximity handles it.
+
+Distance via a haversine over the `lat`/`lon` decimal degrees (reuse `geofunc`
+if a primitive exists; otherwise a small local haversine — same coord shape as
+`location.validate_*`).
+
+#### Findings the audit emits (per colocation site only)
+
+  * **A — MISSING power.** A colocation with ≥1 station and **zero** power
+    devices anywhere (HEDI). Split by likely supply:
+      - *off-grid-suspected* → triage hint to add the real battery/solar via
+        existing `tos device add` (operator knows what's installed).
+      - *mains-suspected* → there may be **no device to add** (grid power). The
+        fix is the `power_source` attribute (see §6.1) →
+        `#ACTION <site> add-attribute power_source mains <date>`.
+    The audit can't tell off-grid from mains automatically — emit both hints
+    commented, operator picks. (HEDI = mains/farm, the flagship case.)
+  * **B — UNCONSOLIDATED power** (the migration worklist). Power sits on a
+    station at a genuine colocation. Emit a reparent ACTION per device:
+    `#ACTION <power_id> move <site_id> <date>` (the existing `move` verb —
+    `_dispatch_move` / `move_device`). **Excludes** `SENSOR_TIED_POWER_SUBTYPES`
+    (`anemometer_power_pack`) — those stay on their instrument. Running the
+    triage *is* the W3 migration.
+  * **(dropped) naive duplication.** "≥2 stations each with power" is **not**
+    emitted as a standalone violation — it collapses into B (consolidate to the
+    site) once proximity-gated, and the repeater/aux case is operator-judgement
+    (a repeater on its own panel may legitimately stay — flag, don't prescribe).
+
+#### Shape + integration
+
+Module `audit_shared_power.py`, mirroring `audit_visit_coverage.py`:
+frozen `SharedPowerViolation` / `SharedPowerReport` dataclasses, a
+`load_shared_power_suppressions()` reader for
+`data/audit_suppressions/shared_power.txt` (key `SUPPRESS <site_id>
+<device_id>`), `audit_station_shared_power(client, station, *, proximity_m=…,
+…)`, and `format_triage_file(report)`. Reuses `power.summarize_site_power`
+(already aggregates power across colocated stations + the site-direct W3 target
+state) and `power.SENSOR_TIED_POWER_SUBTYPES`.
+
+**Standalone first — no verify-oracle / fleet plumbing yet.** Unlike
+`--with-coverage` (where each finding can be suppressed *to reach* clean), the
+UNCONSOLIDATED worklist is dirty fleet-wide *by definition* until the migration
+runs — an oracle check that can never pass pre-migration isn't an invariant,
+it's a worklist. Ship `tos audit shared-power <STN>` + `--triage` standalone;
+add `--with-power` to the verify oracle / `tos fleet status` **only after** the
+migration establishes a baseline (then MISSING-at-a-colocation becomes a real
+recurring invariant). `--proximity-m`, `--no-suppressions`, `--triage PATH`
+are the v1 flags.
 
 ## 5. Boundary with `tos station add`
 
@@ -133,17 +213,36 @@ responsibility.
 
 ## 6. Open questions
 
-1. **Power-source representation.** "Powered from the farm" (mains) vs off-grid
-   (solar+battery) is a real distinction. Options: a `land` attribute
-   (`power_source: mains|solar_battery|generator|…`), a dedicated power-source
-   entity the site references, or purely implicit in the attached power
-   devices. The farm itself may warrant being an entity (external mains
-   supplier). Decide before W3.
-2. **Migration completeness — all vs shared-only** (see W3 decision point).
-3. **Meteorological / hydrological colocation.** The requirement was framed for
-   GPS+SIL, but sites host weather/hydro stations too (and they carry the bulk
-   of power devices). Does site-level power span *all* domains at a site, or
-   just the geophysical ones? Almost certainly all — confirm.
-4. **`anemometer_power_pack` and sensor-specific power.** Some power devices are
-   tied to one instrument (an anemometer's own pack). Those are genuinely
-   per-device, not site-shared — the audit/migration must not flag them.
+1. **Power-source representation — minimal answer adopted.** "Powered from the
+   farm" (mains) vs off-grid (solar+battery) is real and W2's MISSING finding
+   can't prescribe a fix without it. **Decision: a `power_source` attribute on
+   the `land` site** (`mains | solar_battery | generator | …`) — the lightest
+   representation that turns a mains-MISSING site (HEDI) from an un-actionable
+   flag into `add-attribute <site> power_source mains`. A dedicated
+   power-source *entity* (the farm as an external supplier) is heavier and
+   deferred — revisit only if mains suppliers need their own metadata. The
+   `power_source` code must be added to `attribute_codes.yaml` (`locations`
+   scope) as part of W2.
+2. **The `land` overloading (NEW, from the 2026-06-09 probe).** A `land` site
+   is sometimes a true colocation, sometimes a regional admin grouping
+   (`Reykjanes` = 7 stations over tens of km). The proximity gate handles it
+   *for this audit*, but it's a latent data-modelling smell: arguably the
+   groupings should be a different entity layer than single-point sites.
+   Out of scope here; flag for a future TOS-model review.
+3. ~~**Proximity threshold value.**~~ **RESOLVED 2026-06-09** — calibrated
+   against the 11 multi-station sites: true colocations ≤7 m, next-up >1 km, so
+   **default 150 m** (kept tunable via `--proximity-m`). See the gate table.
+4. ~~**Repeater / aux exclusion.**~~ **RESOLVED 2026-06-09** — the proximity
+   gate handles it: Mjóaskarð's repeater is 1.1 km offset, so it falls outside
+   the colocation radius automatically. No name-regex needed. Genuine
+   on-radius consolidation stays operator judgement (commented ACTIONs).
+5. **Migration completeness — all vs shared-only** (a station-private UPS in a
+   hut may stay per-station). Operator decides per reparent ACTION (they're
+   commented by default).
+6. **Meteorological / hydrological colocation.** Sites host weather/hydro
+   stations too (they carry the bulk of power devices). Site-level power almost
+   certainly spans *all* domains at a true colocation — `summarize_site_power`
+   already aggregates across domains; confirm the audit shouldn't GPS-restrict.
+7. **`anemometer_power_pack` and sensor-specific power.** Tied to one
+   instrument, not site-shared — already flagged via
+   `SENSOR_TIED_POWER_SUBTYPES`; the reparent worklist excludes it.

--- a/src/tostools/devices.py
+++ b/src/tostools/devices.py
@@ -1364,3 +1364,49 @@ def replace_device(
         initial_attributes=initial_attributes,
     )
     return {"decommissioned": decommission, "installed": install}
+
+
+# Subtypes a station may hold only ONE open join of at a time. A 2nd open join
+# of one of these means a swap didn't close the old device (the failure mode
+# that left OLKE with two open gnss_receivers when a delete-join silently
+# failed). Deliberately small: solar_panel / battery / windmill / sim_card /
+# modem_gsm legitimately repeat on one station, so they are NOT listed.
+SINGULAR_STATION_SUBTYPES: Tuple[str, ...] = (
+    "gnss_receiver",
+    "antenna",
+    "radome",
+    "monument",
+)
+
+
+def open_singular_conflicts(
+    client, station_history: Dict[str, Any]
+) -> List[Tuple[str, List[int]]]:
+    """Singular subtypes this station has more than one OPEN join of.
+
+    Pure per-station check: walks ``station_history['children_connections']``,
+    keeps the open ones (``time_to is None`` — a closed/zero-duration join such
+    as the OLKE phantom stub is ignored), reads each child's subtype, and
+    returns ``[(subtype, [device_ids…]), …]`` for every
+    :data:`SINGULAR_STATION_SUBTYPES` with >1 open join. Empty list = clean.
+
+    Does NOT decide whether the parent *is* a station — callers that may pass a
+    warehouse (which legitimately holds many) must role-filter first. One
+    ``get_entity_history`` per open child to read its subtype.
+    """
+    open_by_subtype: Dict[str, List[int]] = {}
+    for conn in station_history.get("children_connections") or []:
+        if conn.get("time_to") is not None:
+            continue
+        cid_raw = conn.get("id_entity_child")
+        if cid_raw is None:
+            continue
+        child = client.get_entity_history(int(cid_raw)) or {}
+        subtype = child.get("code_entity_subtype")
+        if subtype in SINGULAR_STATION_SUBTYPES:
+            open_by_subtype.setdefault(subtype, []).append(int(cid_raw))
+    return [
+        (subtype, sorted(ids))
+        for subtype, ids in sorted(open_by_subtype.items())
+        if len(ids) > 1
+    ]

--- a/src/tostools/station_triage.py
+++ b/src/tostools/station_triage.py
@@ -91,6 +91,11 @@ class StationTriageReport:
     dates: Optional[StationAttributeDateReport] = None
     rinex: Optional[StationRinexReport] = None
     coverage: Optional[StationVisitCoverageReport] = None
+    # Structural device-graph findings — currently "this station has >1 open
+    # join of a singular subtype" (gnss_receiver/antenna/radome/monument). One
+    # human-readable string per conflict. Detection complement to the
+    # apply-time guard in ``tos audit apply``.
+    device_conflicts: List[str] = field(default_factory=list)
     notes: List[str] = field(default_factory=list)
 
     @property
@@ -113,6 +118,7 @@ class StationTriageReport:
             n += self.rinex.finding_count
         if self.coverage is not None:
             n += len(self.coverage.violations)
+        n += len(self.device_conflicts)
         return n
 
 
@@ -312,6 +318,27 @@ def generate_station_triage(
     elif coverage_report is not None:
         station_id = coverage_report.station_id
 
+    # === Section: structural device-graph conflicts (always on) ===
+    # Detection complement to the apply-time guard: a station with >1 open join
+    # of a singular subtype (gnss_receiver/antenna/radome/monument) means an
+    # earlier swap's old-device close never landed. Cheap read; failures noted
+    # like the other audits.
+    device_conflicts: List[str] = []
+    if station_id is not None:
+        try:
+            from .devices import open_singular_conflicts
+
+            station_history = client.get_entity_history(station_id) or {}
+            for subtype, ids in open_singular_conflicts(client, station_history):
+                device_conflicts.append(
+                    f"{station}: {len(ids)} open {subtype} joins (devices "
+                    f"{', '.join(map(str, ids))}) — a station may have only one; "
+                    f"a prior device's join was never closed."
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("device-conflicts check failed on %s: %s", station, exc)
+            notes.append(f"device-conflicts check FAILED: {exc}")
+
     return StationTriageReport(
         station=station,
         station_id=station_id,
@@ -320,6 +347,7 @@ def generate_station_triage(
         dates=dates_report,
         rinex=rinex_report,
         coverage=coverage_report,
+        device_conflicts=device_conflicts,
         notes=notes,
     )
 
@@ -364,6 +392,9 @@ def format_station_triage(report: StationTriageReport) -> str:
     if report.coverage is not None and report.coverage.violations:
         parts.append(_section_coverage(report))
 
+    if report.device_conflicts:
+        parts.append(_section_device_conflicts(report))
+
     if report.notes:
         parts.append(_section_notes(report))
 
@@ -403,6 +434,10 @@ def _build_header(report: StationTriageReport) -> str:
             f"(±{cov.coverage_window_days}d window, since {cov.since}, "
             f"{cov.audited_events} events audited)"
         )
+    summary_lines.append(
+        f"#   device-conflicts:    {len(report.device_conflicts)} "
+        "duplicate open singular device(s)"
+    )
     return (
         f"# === {report.station} station triage — auto-generated "
         f"{report.generated_at} ===\n"
@@ -552,6 +587,19 @@ def _section_missing(report: StationTriageReport) -> str:
         "# ──────────────────────────────────────────────────────────────────"
     )
     return header + "\n" + body.rstrip()
+
+
+def _section_device_conflicts(report: StationTriageReport) -> str:
+    return (
+        "# ──────────────────────────────────────────────────────────────────\n"
+        "# Device-graph conflicts (HIGH — invalid TOS state)\n"
+        "# A station may have only one open join per singular subtype\n"
+        "# (gnss_receiver/antenna/radome/monument). >1 means a swap's old\n"
+        "# device was never closed. Fix: close the stale join (cfg move-device\n"
+        "# --serial <OLD> --to <warehouse>, or a `decommission` action).\n"
+        "# ──────────────────────────────────────────────────────────────────\n#\n"
+        + "\n".join(f"#   {c}" for c in report.device_conflicts)
+    )
 
 
 def _section_notes(report: StationTriageReport) -> str:

--- a/src/tostools/tos.py
+++ b/src/tostools/tos.py
@@ -2595,6 +2595,7 @@ def _station_verify_main(args) -> int:
             "status": status,
             "exit_code": exit_code,
             "audits": audits_payload,
+            "device_conflicts": list(report.device_conflicts),
             "notes": list(report.notes),
         }
         print(_json.dumps(payload, ensure_ascii=False, indent=2))
@@ -2622,6 +2623,9 @@ def _station_verify_main(args) -> int:
             )
         else:
             summary_bits.append("verify-from-rinex: (failed)")
+    summary_bits.append(
+        f"device-conflicts: {len(report.device_conflicts)} duplicate open singular"
+    )
 
     print(
         f"VERIFY {report.station} (id_entity={report.station_id}): "
@@ -2629,6 +2633,12 @@ def _station_verify_main(args) -> int:
     )
     for bit in summary_bits:
         print(f"  {bit}")
+
+    if report.device_conflicts:
+        print()
+        print("Device-graph conflicts (invalid TOS state):")
+        for c in report.device_conflicts:
+            print(f"  ✗ {c}")
 
     if report.notes:
         print()
@@ -9359,12 +9369,106 @@ def _print_apply_preflight_table(actions, meta, *, mode_tag: str) -> None:
     print()
 
 
-# Subtypes a station may hold only ONE open instance of at a time. A 2nd open
-# join of one of these means a swap didn't close the old device — the failure
-# mode that left OLKE with two open gnss_receivers when a `delete-join` silently
-# failed at runtime. Deliberately small: solar_panel / battery / windmill /
-# sim_card / modem legitimately repeat on one station, so they're NOT listed.
-_SINGULAR_STATION_SUBTYPES = ("gnss_receiver", "antenna", "radome", "monument")
+def _fmt_open_singular_conflict(label, subtype: str, ids: "List[int]") -> str:
+    """One human-readable line for a station with >1 open join of a subtype."""
+    return (
+        f"{label}: {len(ids)} open {subtype} joins (devices "
+        f"{', '.join(map(str, ids))}) — a station may have only one; the prior "
+        f"device's join was not closed during the swap."
+    )
+
+
+def _preflight_open_singular_conflicts(client, actions):
+    """Dry-run pre-flight: would this action SET leave a station with >1 open
+    join of a singular subtype?
+
+    The complement to :func:`_verify_no_duplicate_open_singular`: that one
+    re-reads the post-apply state (catches a close that failed at runtime); this
+    one simulates the set's net effect against the *current* state, so a dry-run
+    can warn before any write that the operator opened a second receiver without
+    closing the first. Conservative — it subtracts the set's own closes
+    (``delete-join`` / ``decommission`` / ``patch-join-date … time_to`` /
+    ``move`` away) so a correct swap does NOT false-positive.
+
+    Final open set per opened-into station P =
+        (current open singular children at P, minus those the set closes at P)
+        ∪ (children the set opens at P via create-join / move).
+    """
+    from .devices import SINGULAR_STATION_SUBTYPES
+    from .history import ParentEntity
+
+    def _int(v):
+        try:
+            return int(v)
+        except (TypeError, ValueError):
+            return None
+
+    opens_by_parent: Dict[int, set] = {}
+    move_dest: Dict[int, int] = {}
+    decommissioned: set = set()
+    conn_closes: set = set()
+    for a in actions:
+        if a.verb == "create-join" and len(a.args) == 2:
+            p = _int(a.args[0])
+            if p is not None:
+                opens_by_parent.setdefault(p, set()).add(a.id_entity)
+        elif a.verb == "move" and a.args:
+            dest = _int(a.args[0])
+            if dest is not None:
+                opens_by_parent.setdefault(dest, set()).add(a.id_entity)
+                move_dest[a.id_entity] = dest
+        elif a.verb == "decommission":
+            decommissioned.add(a.id_entity)
+        elif a.verb == "delete-join" and a.args:
+            cc = _int(a.args[0])
+            if cc is not None:
+                conn_closes.add(cc)
+        elif (
+            a.verb == "patch-join-date" and len(a.args) >= 3 and a.args[1] == "time_to"
+        ):
+            cc = _int(a.args[0])
+            if cc is not None:
+                conn_closes.add(cc)
+
+    def _subtype(cid: int) -> Optional[str]:
+        return (client.get_entity_history(cid) or {}).get("code_entity_subtype")
+
+    warnings: List[str] = []
+    for pid, opened in sorted(opens_by_parent.items()):
+        h = client.get_entity_history(pid)
+        if not h or ParentEntity.from_history(pid, h).role != "station":
+            continue
+        final: Dict[str, set] = {}
+        for conn in h.get("children_connections") or []:
+            if conn.get("time_to") is not None:
+                continue
+            cid = _int(conn.get("id_entity_child"))
+            if cid is None:
+                continue
+            connid = _int(conn.get("id_entity_connection"))
+            if cid in decommissioned:
+                continue
+            if connid is not None and connid in conn_closes:
+                continue
+            if cid in move_dest and move_dest[cid] != pid:
+                continue  # moved away from P by this set
+            st = _subtype(cid)
+            if st is not None and st in SINGULAR_STATION_SUBTYPES:
+                final.setdefault(st, set()).add(cid)
+        for cid in opened:
+            st = _subtype(cid)
+            if st is not None and st in SINGULAR_STATION_SUBTYPES:
+                final.setdefault(st, set()).add(cid)
+        name = ParentEntity.from_history(pid, h).name or f"id={pid}"
+        for st, ids in sorted(final.items()):
+            if len(ids) > 1:
+                warnings.append(
+                    f"{name}: this set would leave {len(ids)} open {st} joins "
+                    f"(devices {', '.join(map(str, sorted(ids)))}) — add a close "
+                    f"for the prior device (delete-join / decommission / move) "
+                    f"or apply will be blocked by the post-apply guard."
+                )
+    return warnings
 
 
 def _verify_no_duplicate_open_singular(client, actions):
@@ -9379,11 +9483,11 @@ def _verify_no_duplicate_open_singular(client, actions):
     Follows each receiver-opening action's child (`create-join` / `move` /
     `fill-gap`) to its current open parent via parent_history (the fast,
     no-fleet-index path), then re-reads each such parent that is a STATION
-    (warehouses / graveyard legitimately hold multiples) and counts open
-    children per singular subtype. A closed join — e.g. OLKE's zero-duration
-    phantom stub — has ``time_to != None`` and is not counted. Returns a list
-    of human-readable violation strings; empty means clean.
+    (warehouses / graveyard legitimately hold multiples) and applies the shared
+    :func:`devices.open_singular_conflicts` check. Returns human-readable
+    violation strings; empty means clean.
     """
+    from .devices import open_singular_conflicts
     from .history import ParentEntity, device_timeline_via_parent_history
 
     opening_verbs = {"create-join", "move", "fill-gap"}
@@ -9401,25 +9505,10 @@ def _verify_no_duplicate_open_singular(client, actions):
         parent = ParentEntity.from_history(pid, h)
         if parent.role != "station":
             continue  # warehouses / graveyard hold multiples by design
-        open_by_subtype: Dict[str, List[int]] = {}
-        for conn in h.get("children_connections") or []:
-            if conn.get("time_to") is not None:
-                continue  # closed join (e.g. the zero-duration phantom stub)
-            cid_raw = conn.get("id_entity_child")
-            if cid_raw is None:
-                continue
-            child = client.get_entity_history(int(cid_raw)) or {}
-            st = child.get("code_entity_subtype")
-            if st in _SINGULAR_STATION_SUBTYPES:
-                open_by_subtype.setdefault(st, []).append(int(cid_raw))
-        for st, devs in sorted(open_by_subtype.items()):
-            if len(devs) > 1:
-                violations.append(
-                    f"{parent.name or f'id={pid}'}: {len(devs)} open {st} joins "
-                    f"(devices {', '.join(map(str, sorted(devs)))}) — a station "
-                    f"may have only one; the prior device's join was not closed "
-                    f"during the swap."
-                )
+        for subtype, ids in open_singular_conflicts(client, h):
+            violations.append(
+                _fmt_open_singular_conflict(parent.name or f"id={pid}", subtype, ids)
+            )
     return violations
 
 
@@ -9501,12 +9590,14 @@ def _apply_main(args) -> int:
             )
         )
 
-    # Post-apply guard: re-read affected stations and refuse to call the run
-    # clean if a swap left two open joins of a singular subtype (e.g. a
-    # delete-join that silently failed). Apply-mode only — dry-run sent no
-    # writes, so there is no post-state to verify.
+    # Singular-subtype duplicate guard, split by mode:
+    #  * dry-run → pre-flight SIMULATION of the action set (no post-state exists);
+    #  * apply  → post-apply RE-READ (catches a close that failed at runtime).
     post_violations: List[str] = []
-    if not dry_run:
+    preflight_warnings: List[str] = []
+    if dry_run:
+        preflight_warnings = _preflight_open_singular_conflicts(client, actions)
+    else:
         post_violations = _verify_no_duplicate_open_singular(client, actions)
 
     if args.json:
@@ -9529,6 +9620,7 @@ def _apply_main(args) -> int:
                 for r in results
             ],
             "post_apply_violations": post_violations,
+            "preflight_warnings": preflight_warnings,
         }
         print(_json.dumps(payload, ensure_ascii=False, indent=2))
     else:
@@ -9557,6 +9649,14 @@ def _apply_main(args) -> int:
         )
         if dry_run:
             print("(no writes were sent — re-run with --apply to commit)")
+        if preflight_warnings:
+            print(
+                f"\n⚠ PRE-FLIGHT: {len(preflight_warnings)} station(s) would be "
+                f"left with a duplicate open singular device:",
+                file=sys.stderr,
+            )
+            for w in preflight_warnings:
+                print(f"    {w}", file=sys.stderr)
         if post_violations:
             print(
                 f"\n✗ POST-APPLY GUARD: {len(post_violations)} station(s) left "
@@ -9571,7 +9671,11 @@ def _apply_main(args) -> int:
                 file=sys.stderr,
             )
 
-    ok = all(r.status != "failed" for r in results) and not post_violations
+    ok = (
+        all(r.status != "failed" for r in results)
+        and not post_violations
+        and not preflight_warnings
+    )
     return 0 if ok else 1
 
 

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -2616,3 +2616,90 @@ def test_guard_closed_stub_not_counted():
         )
         == []
     )
+
+
+# ---------------------------------------------------------------------------
+# Dry-run pre-flight: would the action SET leave a duplicate open singular?
+# ---------------------------------------------------------------------------
+from tostools.tos import _preflight_open_singular_conflicts  # noqa: E402
+
+
+def _preflight_client(pid, open_children, child_subtypes, *, subtype="geophysical"):
+    """open_children: list of (child_id, conn_id) currently open at the station."""
+    conns = [
+        {"id_entity_child": c, "id_entity_connection": cn, "time_to": None}
+        for c, cn in open_children
+    ]
+    station = {
+        "id_entity": pid,
+        "code_entity_subtype": subtype,
+        "attributes": [{"code": "name", "value_varchar": "OLKE", "time_to": None}],
+        "children_connections": conns,
+    }
+    histories = {pid: station}
+    for cid, st in child_subtypes.items():
+        histories[cid] = {"id_entity": cid, "code_entity_subtype": st, "attributes": []}
+    c = MagicMock()
+    c.get_entity_history.side_effect = lambda i: histories.get(int(i))
+    return c
+
+
+def test_preflight_flags_open_without_close():
+    """create-join a 2nd receiver without closing the 1st → warning."""
+    c = _preflight_client(
+        4370, [(4979, 6120)], {4979: "gnss_receiver", 21580: "gnss_receiver"}
+    )
+    w = _preflight_open_singular_conflicts(
+        c, [_make_action(21580, "create-join", "4370", "2017-06-26")]
+    )
+    assert len(w) == 1
+    assert "would leave 2 open gnss_receiver" in w[0]
+
+
+def test_preflight_clean_swap_delete_join_no_warning():
+    """delete-join old + create-join new = a clean swap → no warning."""
+    c = _preflight_client(
+        4370, [(4979, 6120)], {4979: "gnss_receiver", 21580: "gnss_receiver"}
+    )
+    actions = [
+        _make_action(4979, "delete-join", "6120"),
+        _make_action(21580, "create-join", "4370", "2017-06-26"),
+    ]
+    assert _preflight_open_singular_conflicts(c, actions) == []
+
+
+def test_preflight_clean_swap_decommission_no_warning():
+    """decommission old + create-join new → no warning."""
+    c = _preflight_client(
+        4370, [(4979, 6120)], {4979: "gnss_receiver", 21580: "gnss_receiver"}
+    )
+    actions = [
+        _make_action(4979, "decommission", "2000-10-17"),
+        _make_action(21580, "create-join", "4370", "2017-06-26"),
+    ]
+    assert _preflight_open_singular_conflicts(c, actions) == []
+
+
+def test_preflight_clean_swap_patch_join_date_no_warning():
+    """patch-join-date <conn> time_to <date> closes the old → no warning."""
+    c = _preflight_client(
+        4370, [(4979, 6120)], {4979: "gnss_receiver", 21580: "gnss_receiver"}
+    )
+    actions = [
+        _make_action(4979, "patch-join-date", "6120", "time_to", "2013-02-28"),
+        _make_action(21580, "create-join", "4370", "2017-06-26"),
+    ]
+    assert _preflight_open_singular_conflicts(c, actions) == []
+
+
+def test_preflight_warehouse_destination_ignored():
+    """Opening a receiver join at a warehouse is fine (holds many)."""
+    c = _preflight_client(
+        4, [(100, 7000)], {100: "gnss_receiver", 200: "gnss_receiver"}, subtype="area"
+    )
+    assert (
+        _preflight_open_singular_conflicts(
+            c, [_make_action(200, "create-join", "4", "2020-01-01")]
+        )
+        == []
+    )

--- a/tests/test_station_triage.py
+++ b/tests/test_station_triage.py
@@ -16,7 +16,7 @@ station_triage is tested only at the wiring layer.
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from tostools.audit_attribute_dates import StationAttributeDateReport
 from tostools.audit_missing_attributes import StationMissingAttributesReport
@@ -33,6 +33,14 @@ from tostools.station_triage import (
 )
 
 FROZEN_TS = "2026-05-26T00:00:00Z"
+
+
+def _stub_client():
+    """A client whose only real use here is the device-conflicts read; an empty
+    station history yields no conflicts (the audits themselves are patched)."""
+    c = MagicMock()
+    c.get_entity_history.return_value = {"children_connections": []}
+    return c
 
 
 # ---------------------------------------------------------------------------
@@ -84,7 +92,7 @@ def test_generate_aggregates_both_audits_when_both_succeed(tmp_path):
         ),
     ):
         report = generate_station_triage(
-            "SAVI", client=object(), generated_at=FROZEN_TS
+            "SAVI", client=_stub_client(), generated_at=FROZEN_TS
         )
 
     assert report.station == "SAVI"
@@ -111,7 +119,7 @@ def test_generate_records_failure_and_keeps_other_audit(tmp_path):
         ),
     ):
         report = generate_station_triage(
-            "HEDI", client=object(), generated_at=FROZEN_TS
+            "HEDI", client=_stub_client(), generated_at=FROZEN_TS
         )
 
     assert report.missing is None
@@ -138,7 +146,7 @@ def test_generate_returns_station_id_from_first_successful_audit():
         ),
     ):
         report = generate_station_triage(
-            "SAVI", client=object(), generated_at=FROZEN_TS
+            "SAVI", client=_stub_client(), generated_at=FROZEN_TS
         )
 
     assert report.station_id == 4440
@@ -548,3 +556,42 @@ def test_now_iso_utc_renders_with_z_suffix_no_microseconds():
     assert "." not in s  # no microsecond fraction
     # Format: YYYY-MM-DDTHH:MM:SSZ — 20 chars
     assert len(s) == 20
+
+
+# ---------------------------------------------------------------------------
+# device_conflicts — duplicate-open-singular detection wiring
+# ---------------------------------------------------------------------------
+
+
+def test_device_conflicts_count_toward_total_findings():
+    """A structural device-graph conflict is a finding (escalates verify)."""
+    rpt = StationTriageReport(
+        station="OLKE",
+        station_id=4370,
+        generated_at=FROZEN_TS,
+        device_conflicts=[
+            "OLKE: 2 open gnss_receiver joins (devices 4979, 21580) — a station "
+            "may have only one; a prior device's join was never closed."
+        ],
+    )
+    assert rpt.total_findings == 1
+
+
+def test_format_renders_device_conflicts_section():
+    rpt = StationTriageReport(
+        station="OLKE",
+        station_id=4370,
+        generated_at=FROZEN_TS,
+        device_conflicts=["OLKE: 2 open gnss_receiver joins (devices 4979, 21580)"],
+    )
+    out = format_station_triage(rpt)
+    assert "Device-graph conflicts" in out
+    assert "2 open gnss_receiver joins" in out
+    assert "device-conflicts:    1" in out  # header summary line
+
+
+def test_format_omits_device_conflicts_section_when_clean():
+    rpt = StationTriageReport(station="OLKE", station_id=4370, generated_at=FROZEN_TS)
+    out = format_station_triage(rpt)
+    assert "Device-graph conflicts" not in out
+    assert "device-conflicts:    0" in out  # still summarised in the header


### PR DESCRIPTION
Completes the singular-device guardrail (post-apply guard landed in #61) across the two surfaces the review flagged as follow-ups.

## Shared core
`devices.open_singular_conflicts(client, station_history)` + `devices.SINGULAR_STATION_SUBTYPES` (`gnss_receiver` / `antenna` / `radome` / `monument`) — the single place that counts a station's open joins per singular subtype. The post-apply guard now reuses it (previously inline).

## (b) Detection — `tos station verify` / `station triage`
New `StationTriageReport.device_conflicts`, populated always-on from a cheap station read, counted in `total_findings`, rendered as a HIGH-confidence section + header summary line + `device_conflicts` JSON field. This surfaces a double-open that **already exists** in TOS — directly answering "the triage should flag this", complementing the apply-time prevention.

## (a) Prevention (dry-run) — `tos audit apply` pre-flight
Simulates the action set's net effect — current open **minus** same-run closes (`delete-join` / `decommission` / `patch-join-date … time_to` / `move`-away) **plus** same-run opens (`create-join` / `move`) — and warns when a station would be left with >1 open singular. **Conservative**: an explicit close in the same file means no false positive (verified: the OLKE clean-swap set pre-flights silent). Complements the post-apply re-read (which stays the authoritative apply-mode block); both flip the exit code.

## Verification
- Live: `tos station verify OLKE` → `device-conflicts: 0` (now clean); the no-opens decommission set pre-flights silent.
- 11 new tests (5 pre-flight, 3 station-verify wiring, +reuse of the guard tests). Full suite 1166 pass; ruff/black clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)