### PR TITLE
fix(api): adapt to new TOS backend — /internal path, no trailing slash, None guard

### DIFF
--- a/src/tostools/api/_http.py
+++ b/src/tostools/api/_http.py
@@ -1,0 +1,46 @@
+"""Shared HTTP helpers for the TOS API clients (:class:`TOSClient`, :class:`TOSWriter`)."""
+
+from __future__ import annotations
+
+# Path segments that mean a None/Null value leaked into URL string formatting
+# (e.g. ``/entity/None`` when an id_entity is None). The TOS backend rejects
+# these with 422 — we fail fast with a clear error instead.
+_NULL_SEGMENTS = frozenset({"None", "Null", "null", "NULL"})
+
+
+def canonical_tos_url(base_url: str, endpoint: str) -> str:
+    """Join ``base_url`` + ``endpoint`` into the canonical TOS request URL.
+
+    The TOS backend (revised 2026-06) canonicalizes paths **without** a trailing
+    slash: a ``/``-terminated path 308-redirects to the slashless form. That
+    redirect both adds noise to backend monitoring and can drop the
+    ``Authorization`` header on mutating calls (a likely cause of intermittent
+    401s on PATCH/POST). So strip a trailing slash here, at the single point
+    every request flows through — endpoint string literals can keep their
+    historical trailing slash; the wire request is normalized.
+
+    It also returns 422 for a ``None``/``Null`` path segment. Refuse to send
+    such a URL with an explicit error that names the offending path, rather than
+    letting it fail server-side as an opaque 422.
+
+    Args:
+        base_url: API base, e.g. ``https://vi-api.vedur.is/tos/internal``.
+        endpoint: Path part, with or without leading/trailing slashes.
+
+    Returns:
+        The normalized absolute URL (no trailing slash, any inline query kept).
+
+    Raises:
+        ValueError: If a path segment is ``None``/``Null`` (formatting bug).
+    """
+    url = f"{base_url.rstrip('/')}/{endpoint.lstrip('/')}"
+    # Split off any (rare) inline query string before trimming the path.
+    head, sep, query = url.partition("?")
+    head = head.rstrip("/")
+    for segment in head.split("/"):
+        if segment in _NULL_SEGMENTS:
+            raise ValueError(
+                f"Refusing TOS request with a {segment!r} path segment "
+                f"({url!r}) — a None/Null value leaked into URL formatting."
+            )
+    return head + sep + query

--- a/src/tostools/api/tos_client.py
+++ b/src/tostools/api/tos_client.py
@@ -11,9 +11,10 @@ from typing import Any, Dict, List, Optional
 import requests
 
 from ..utils.logging import get_logger
+from ._http import canonical_tos_url
 
 # TOS API Configuration
-DEFAULT_TOS_URL = "https://vi-api.vedur.is/tos/v1"
+DEFAULT_TOS_URL = "https://vi-api.vedur.is/tos/internal"
 DEFAULT_TIMEOUT = 10
 
 
@@ -57,7 +58,7 @@ class TOSClient:
         Returns:
             Response data as dictionary, or None if error
         """
-        url = f"{self.base_url}/{endpoint.lstrip('/')}"
+        url = canonical_tos_url(self.base_url, endpoint)
         self.logger.info(f'Sending request "{url}"')
 
         try:

--- a/src/tostools/api/tos_writer.py
+++ b/src/tostools/api/tos_writer.py
@@ -37,8 +37,9 @@ from typing import Any, Dict, List, Optional
 import requests
 
 from ..utils.logging import get_logger
+from ._http import canonical_tos_url
 
-DEFAULT_TOS_URL = "https://vi-api.vedur.is/tos/v1"
+DEFAULT_TOS_URL = "https://vi-api.vedur.is/tos/internal"
 DEFAULT_TIMEOUT = 15
 _TOKEN_EXPIRY_BUFFER_S = 60  # re-login this many seconds before expiry
 
@@ -410,7 +411,7 @@ class TOSWriter:
         """
         self._ensure_authenticated()
 
-        url = f"{self.base_url}/{endpoint.lstrip('/')}"
+        url = canonical_tos_url(self.base_url, endpoint)
         is_mutating = method.upper() not in ("GET", "HEAD", "OPTIONS")
 
         if is_mutating and self.dry_run and not _force_send:

--- a/src/tostools/cli/main.py
+++ b/src/tostools/cli/main.py
@@ -110,7 +110,7 @@ def build_tos_url(server: str, port: int) -> str:
         Complete TOS API URL
     """
     protocol = "https" if port == 443 else "http"
-    return f"{protocol}://{server}:{port}/tos/v1"
+    return f"{protocol}://{server}:{port}/tos/internal"
 
 
 def process_stations(

--- a/src/tostools/gps_metadata_qc.py
+++ b/src/tostools/gps_metadata_qc.py
@@ -19,6 +19,7 @@ from pyproj import CRS, Transformer
 from . import gps_metadata_functions as gpsf
 
 # Import new modular components
+from .api._http import canonical_tos_url
 from .api.tos_client import TOSClient
 from .io.file_utils import read_gzip_file as new_read_gzip_file
 from .io.file_utils import read_text_file as new_read_text_file
@@ -45,7 +46,7 @@ from .utils.logging import get_logger
 #     + DZEND
 # )
 # HACK: This should be handled in a config with a config file
-URL_REST_TOS = "https://vi-api.vedur.is/tos/v1"
+URL_REST_TOS = "https://vi-api.vedur.is/tos/internal"
 REMOTE_FILE_PATH = "/mnt_data/rawgpsdata"
 LOCAL_FILE_PATH = "/tmp/gpsdata"
 REQUEST_TIMEOUT = 10
@@ -121,7 +122,9 @@ def search_station(
 
             # Query TOS api
             try:
-                url = url_rest + "/entity/search/" + entity_type + "/" + domain + "/"
+                url = canonical_tos_url(
+                    url_rest, "/entity/search/" + entity_type + "/" + domain + "/"
+                )
                 module_logger.info("sending the post request: %s", url)
                 response = requests.post(
                     url,
@@ -442,7 +445,7 @@ def get_contacts(id_entity_parent, url_rest, loglevel=logging.WARNING):
     owner_addition = {}
 
     owner_response = requests.get(
-        url_rest + "/entity_contacts/" + str(id_entity_parent) + "/",
+        canonical_tos_url(url_rest, "/entity_contacts/" + str(id_entity_parent) + "/"),
         timeout=REQUEST_TIMEOUT,
     )
     owners = owner_response.json()
@@ -697,7 +700,8 @@ def get_station_metadata(station_identifier, url_rest, loglevel=logging.WARNING)
     )
 
     response = requests.get(
-        url_rest + "/history/entity/" + str(id_entity) + "/", timeout=REQUEST_TIMEOUT
+        canonical_tos_url(url_rest, "/history/entity/" + str(id_entity) + "/"),
+        timeout=REQUEST_TIMEOUT,
     )
     devices_history = response.json()
     module_logger.debug(
@@ -837,7 +841,9 @@ def get_device_sessions(devices_history, url_rest, loglevel=logging.WARNING):
 
         # NOTE: sending a request for device history
         id_entity_child = connection["id_entity_child"]
-        request_url = f"{url_rest}/history/entity/{str(id_entity_child)}/"
+        request_url = canonical_tos_url(
+            url_rest, f"/history/entity/{str(id_entity_child)}/"
+        )
         try:
             devices_response = requests.get(request_url, timeout=REQUEST_TIMEOUT)
             device = devices_response.json()

--- a/src/tostools/legacy/gps_metadata_qc.py
+++ b/src/tostools/legacy/gps_metadata_qc.py
@@ -17,6 +17,7 @@ import requests
 from pyproj import CRS, Transformer
 from unlzw3 import unlzw
 
+from ..api._http import canonical_tos_url
 from . import gps_metadata_functions as gpsf
 
 # TODO: Move formatstring from file_list to a config file
@@ -39,7 +40,7 @@ from . import gps_metadata_functions as gpsf
 #     + DZEND
 # )
 # HACK: This should be handled in a config with a config file
-URL_REST_TOS = "https://vi-api.vedur.is/tos/v1"
+URL_REST_TOS = "https://vi-api.vedur.is/tos/internal"
 REMOTE_FILE_PATH = "/mnt_data/rawgpsdata"
 LOCAL_FILE_PATH = "/tmp/gpsdata"
 REQUEST_TIMEOUT = 10
@@ -113,7 +114,9 @@ def search_station(
 
             # Query TOS api
             try:
-                url = url_rest + "/entity/search/" + entity_type + "/" + domain + "/"
+                url = canonical_tos_url(
+                    url_rest, "/entity/search/" + entity_type + "/" + domain + "/"
+                )
                 module_logger.info("sending the post request: %s", url)
                 response = requests.post(
                     url,
@@ -439,7 +442,7 @@ def get_contacts(id_entity_parent, url_rest, loglevel=logging.WARNING):
     owner_addition = {}
 
     owner_response = requests.get(
-        url_rest + "/entity_contacts/" + str(id_entity_parent) + "/",
+        canonical_tos_url(url_rest, "/entity_contacts/" + str(id_entity_parent) + "/"),
         timeout=REQUEST_TIMEOUT,
     )
     owners = owner_response.json()
@@ -606,7 +609,8 @@ def get_station_metadata(station_identifier, url_rest, loglevel=logging.WARNING)
     )
 
     response = requests.get(
-        url_rest + "/history/entity/" + str(id_entity) + "/", timeout=REQUEST_TIMEOUT
+        canonical_tos_url(url_rest, "/history/entity/" + str(id_entity) + "/"),
+        timeout=REQUEST_TIMEOUT,
     )
     devices_history = response.json()
     module_logger.debug(
@@ -747,7 +751,9 @@ def get_device_sessions(devices_history, url_rest, loglevel=logging.WARNING):
 
         # NOTE: sending a request for device history
         id_entity_child = connection["id_entity_child"]
-        request_url = f"{url_rest}/history/entity/{str(id_entity_child)}/"
+        request_url = canonical_tos_url(
+            url_rest, f"/history/entity/{str(id_entity_child)}/"
+        )
         try:
             devices_response = requests.get(request_url, timeout=REQUEST_TIMEOUT)
             device = devices_response.json()

--- a/src/tostools/tos.py
+++ b/src/tostools/tos.py
@@ -64,7 +64,7 @@ def _owners_main(argv):
 
     if args.refresh:
         scheme = "https" if args.port == 443 else "http"
-        base_url = f"{scheme}://{args.server}:{args.port}/tos/v1"
+        base_url = f"{scheme}://{args.server}:{args.port}/tos/internal"
         client = TOSClient(base_url=base_url)
         result = cache.refresh(client)
         owners = result.in_use
@@ -553,7 +553,7 @@ def _device_list_main(args) -> int:
     from .devices import open_attribute
 
     scheme = "https" if args.port == 443 else "http"
-    base_url = f"{scheme}://{args.server}:{args.port}/tos/v1"
+    base_url = f"{scheme}://{args.server}:{args.port}/tos/internal"
     client = TOSClient(base_url=base_url)
 
     parent_id = _resolve_parent_id(
@@ -1188,7 +1188,7 @@ def _device_show_main(args) -> int:
         return 2
 
     scheme = "https" if args.port == 443 else "http"
-    base_url = f"{scheme}://{args.server}:{args.port}/tos/v1"
+    base_url = f"{scheme}://{args.server}:{args.port}/tos/internal"
     client = TOSClient(base_url=base_url)
 
     try:
@@ -1612,7 +1612,7 @@ def _device_main(argv):
 
     # ---- Writer setup ----------------------------------------------------
     scheme = "https" if args.port == 443 else "http"
-    base_url = f"{scheme}://{args.server}:{args.port}/tos/v1"
+    base_url = f"{scheme}://{args.server}:{args.port}/tos/internal"
     dry_run = not args.no_dry_run
     writer = TOSWriter(base_url=base_url, dry_run=dry_run)
 
@@ -2760,7 +2760,7 @@ def _station_show_main(args) -> int:
         return _device_list_main(delegated)
 
     scheme = "https" if args.port == 443 else "http"
-    base_url = f"{scheme}://{args.server}:{args.port}/tos/v1"
+    base_url = f"{scheme}://{args.server}:{args.port}/tos/internal"
     client = TOSClient(base_url=base_url)
 
     station_id = _resolve_parent_id(client, station_marker=args.station)
@@ -3515,7 +3515,7 @@ def _station_add_main(args) -> int:
 
     # ---- Writer setup ----------------------------------------------------
     scheme = "https" if args.port == 443 else "http"
-    base_url = f"{scheme}://{args.server}:{args.port}/tos/v1"
+    base_url = f"{scheme}://{args.server}:{args.port}/tos/internal"
     dry_run = not args.no_dry_run
     writer = TOSWriter(base_url=base_url, dry_run=dry_run)
 
@@ -3801,7 +3801,7 @@ def _location_add_main(args) -> int:
 
     # ---- Writer setup ----------------------------------------------------
     scheme = "https" if args.port == 443 else "http"
-    base_url = f"{scheme}://{args.server}:{args.port}/tos/v1"
+    base_url = f"{scheme}://{args.server}:{args.port}/tos/internal"
     dry_run = not args.no_dry_run
     writer = TOSWriter(base_url=base_url, dry_run=dry_run)
 
@@ -4294,7 +4294,7 @@ def _contact_main(argv):
     args = p.parse_args(argv)
 
     scheme = "https" if args.port == 443 else "http"
-    base_url = f"{scheme}://{args.server}:{args.port}/tos/v1"
+    base_url = f"{scheme}://{args.server}:{args.port}/tos/internal"
     client = TOSClient(base_url=base_url)
 
     if args.verb == "show":
@@ -4997,7 +4997,7 @@ def _visit_main(argv):
     args = p.parse_args(argv)
 
     scheme = "https" if args.port == 443 else "http"
-    base_url = f"{scheme}://{args.server}:{args.port}/tos/v1"
+    base_url = f"{scheme}://{args.server}:{args.port}/tos/internal"
     client = TOSClient(base_url=base_url)
 
     if args.verb == "list":
@@ -6997,7 +6997,7 @@ def _audit_main(argv):
     args = p.parse_args(argv)
 
     scheme = "https" if args.port == 443 else "http"
-    base_url = f"{scheme}://{args.server}:{args.port}/tos/v1"
+    base_url = f"{scheme}://{args.server}:{args.port}/tos/internal"
     client = TOSClient(base_url=base_url)
 
     if args.kind == "device":
@@ -9548,7 +9548,7 @@ def _apply_main(args) -> int:
         return 2
 
     scheme = "https" if args.port == 443 else "http"
-    base_url = f"{scheme}://{args.server}:{args.port}/tos/v1"
+    base_url = f"{scheme}://{args.server}:{args.port}/tos/internal"
     dry_run = not args.apply
 
     # Pre-flight metadata lookup. Read-only client (no auth needed) — separate

--- a/src/tostools/tosGPS.py
+++ b/src/tostools/tosGPS.py
@@ -437,7 +437,7 @@ Contact: Benni (bgo@vedur.is) or Hildur (hildur@vedur.is)
     )
     server_options.add_argument("-p", "--port", type=int, default=443, help="Port:")
     server_options.add_argument(
-        "-r", "--rest", type=str, default="/tos/v1", help="Top levels REST path"
+        "-r", "--rest", type=str, default="/tos/internal", help="Top levels REST path"
     )
     server_options.add_argument(
         "-t", "--timeout", type=int, default=4, help="Connection timeout:"

--- a/tests/cassettes/test_composer_oracle/test_aust_station_sessions_locked.yaml
+++ b/tests/cassettes/test_composer_oracle/test_aust_station_sessions_locked.yaml
@@ -15,7 +15,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: POST
-    uri: https://vi-api.vedur.is/tos/v1/entity/search/station/geophysical/
+    uri: https://vi-api.vedur.is/tos/internal/entity/search/station/geophysical
   response:
     body:
       string: "[\n  {\n    \"attributes\": [\n      {\n        \"attribute_datatype_code\":
@@ -183,7 +183,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: POST
-    uri: https://vi-api.vedur.is/tos/v1/entity/search/station/geophysical/
+    uri: https://vi-api.vedur.is/tos/internal/entity/search/station/geophysical
   response:
     body:
       string: '[]
@@ -217,7 +217,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4235/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4235
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"boolean\",\n
@@ -527,7 +527,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/6296/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/6296
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -601,7 +601,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4515/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4515
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -703,7 +703,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4524/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4524
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"numeric\",\n
@@ -789,7 +789,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4515/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4515
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -891,7 +891,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4507/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4507
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"numeric\",\n
@@ -991,7 +991,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4515/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4515
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -1093,7 +1093,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4633/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4633
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -1183,7 +1183,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4815/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4815
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -1292,7 +1292,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4751/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4751
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -1373,7 +1373,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4632/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4632
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -1454,7 +1454,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4824/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4824
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -1572,7 +1572,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4821/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4821
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"timestamp\",\n
@@ -1654,7 +1654,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4825/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4825
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -1757,7 +1757,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4777/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4777
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -1904,7 +1904,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4761/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4761
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -1992,7 +1992,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4823/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4823
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -2145,7 +2145,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/5003/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/5003
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"numeric\",\n
@@ -2250,7 +2250,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4880/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4880
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"timestamp\",\n
@@ -2346,7 +2346,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/5004/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/5004
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -2445,7 +2445,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/5002/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/5002
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"timestamp\",\n
@@ -2543,7 +2543,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/19098/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/19098
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -2632,7 +2632,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/19880/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/19880
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -2721,7 +2721,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/19714/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/19714
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -2788,7 +2788,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4619/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4619
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -2882,7 +2882,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/5000/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/5000
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"numeric\",\n
@@ -2987,7 +2987,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/5009/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/5009
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -3092,7 +3092,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/5006/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/5006
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -3182,7 +3182,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4821/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4821
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"timestamp\",\n
@@ -3264,7 +3264,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4511/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4511
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -3373,7 +3373,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4631/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4631
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"timestamp\",\n
@@ -3469,7 +3469,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/5001/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/5001
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"numeric\",\n
@@ -3574,7 +3574,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4821/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4821
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"timestamp\",\n
@@ -3656,7 +3656,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4777/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4777
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -3803,7 +3803,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4510/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4510
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"numeric\",\n
@@ -3918,7 +3918,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4510/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4510
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"numeric\",\n
@@ -4033,7 +4033,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/5007/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/5007
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -4123,7 +4123,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4510/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4510
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"numeric\",\n
@@ -4238,7 +4238,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/19720/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/19720
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -4313,7 +4313,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4749/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4749
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -4401,7 +4401,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4612/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4612
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -4509,7 +4509,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/19726/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/19726
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -4584,7 +4584,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4612/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4612
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -4692,7 +4692,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4964/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4964
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -4781,7 +4781,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/19725/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/19725
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -4856,7 +4856,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4752/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4752
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -4967,7 +4967,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/19727/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/19727
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -5042,7 +5042,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/19728/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/19728
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -5117,7 +5117,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4523/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4523
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -5189,7 +5189,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/19729/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/19729
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"timestamp\",\n
@@ -5264,7 +5264,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4525/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4525
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -5337,7 +5337,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/19730/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/19730
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -5412,7 +5412,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/19733/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/19733
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -5501,7 +5501,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/19731/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/19731
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -5591,7 +5591,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4936/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4936
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -5671,7 +5671,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/18845/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/18845
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -5776,7 +5776,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/5807/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/5807
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -5839,7 +5839,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/19645/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/19645
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"timestamp\",\n
@@ -5920,7 +5920,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/19712/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/19712
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -6019,7 +6019,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4783/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4783
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -6099,7 +6099,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/5005/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/5005
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"numeric\",\n
@@ -6197,7 +6197,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4520/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4520
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n

--- a/tests/cassettes/test_composer_oracle/test_rhof_gps_metadata_via_devices_matches_legacy_snapshot.yaml
+++ b/tests/cassettes/test_composer_oracle/test_rhof_gps_metadata_via_devices_matches_legacy_snapshot.yaml
@@ -15,7 +15,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: POST
-    uri: https://vi-api.vedur.is/tos/v1/entity/search/station/geophysical/
+    uri: https://vi-api.vedur.is/tos/internal/entity/search/station/geophysical
   response:
     body:
       string: '[]
@@ -53,7 +53,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: POST
-    uri: https://vi-api.vedur.is/tos/v1/entity/search/station/geophysical/
+    uri: https://vi-api.vedur.is/tos/internal/entity/search/station/geophysical
   response:
     body:
       string: "[\n  {\n    \"attributes\": [\n      {\n        \"attribute_datatype_code\":
@@ -209,7 +209,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4390/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4390
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -385,7 +385,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/entity_contacts/4390/
+    uri: https://vi-api.vedur.is/tos/internal/entity_contacts/4390
   response:
     body:
       string: "[\n  {\n    \"address\": \"B\\u00fasta\\u00f0arvegur 7-9, 105 Reykjav\\u00edk,
@@ -443,7 +443,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4390/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4390
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -619,7 +619,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4521/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4521
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -699,7 +699,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4704/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4704
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"timestamp\",\n
@@ -793,7 +793,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4804/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4804
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -880,7 +880,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4945/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4945
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -954,7 +954,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4981/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4981
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"boolean\",\n
@@ -1057,7 +1057,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/5318/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/5318
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -1131,7 +1131,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/5228/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/5228
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -1206,7 +1206,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/18662/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/18662
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -1281,7 +1281,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/5823/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/5823
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -1359,7 +1359,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/18659/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/18659
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n

--- a/tests/cassettes/test_composer_oracle/test_rhof_legacy_synthesis_matches_snapshot.yaml
+++ b/tests/cassettes/test_composer_oracle/test_rhof_legacy_synthesis_matches_snapshot.yaml
@@ -15,7 +15,7 @@ interactions:
       User-Agent:
       - python-requests/2.34.0
     method: POST
-    uri: https://vi-api.vedur.is/tos/v1/entity/search/station/geophysical/
+    uri: https://vi-api.vedur.is/tos/internal/entity/search/station/geophysical
   response:
     body:
       string: '[]
@@ -53,7 +53,7 @@ interactions:
       User-Agent:
       - python-requests/2.34.0
     method: POST
-    uri: https://vi-api.vedur.is/tos/v1/entity/search/station/geophysical/
+    uri: https://vi-api.vedur.is/tos/internal/entity/search/station/geophysical
   response:
     body:
       string: "[\n  {\n    \"attributes\": [\n      {\n        \"attribute_datatype_code\":
@@ -209,7 +209,7 @@ interactions:
       User-Agent:
       - python-requests/2.34.0
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4390/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4390
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -385,7 +385,7 @@ interactions:
       User-Agent:
       - python-requests/2.34.0
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/entity_contacts/4390/
+    uri: https://vi-api.vedur.is/tos/internal/entity_contacts/4390
   response:
     body:
       string: "[\n  {\n    \"address\": \"B\\u00fasta\\u00f0arvegur 7-9, 105 Reykjav\\u00edk,
@@ -443,7 +443,7 @@ interactions:
       User-Agent:
       - python-requests/2.34.0
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4521/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4521
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -523,7 +523,7 @@ interactions:
       User-Agent:
       - python-requests/2.34.0
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4704/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4704
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"timestamp\",\n
@@ -617,7 +617,7 @@ interactions:
       User-Agent:
       - python-requests/2.34.0
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4804/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4804
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -704,7 +704,7 @@ interactions:
       User-Agent:
       - python-requests/2.34.0
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4945/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4945
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -778,7 +778,7 @@ interactions:
       User-Agent:
       - python-requests/2.34.0
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4981/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4981
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"boolean\",\n
@@ -881,7 +881,7 @@ interactions:
       User-Agent:
       - python-requests/2.34.0
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/5318/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/5318
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -955,7 +955,7 @@ interactions:
       User-Agent:
       - python-requests/2.34.0
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/5228/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/5228
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -1030,7 +1030,7 @@ interactions:
       User-Agent:
       - python-requests/2.34.0
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/18662/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/18662
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -1105,7 +1105,7 @@ interactions:
       User-Agent:
       - python-requests/2.34.0
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/5823/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/5823
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -1183,7 +1183,7 @@ interactions:
       User-Agent:
       - python-requests/2.34.0
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/18659/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/18659
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n

--- a/tests/cassettes/test_composer_oracle/test_rhof_station_sessions_matches_legacy_device_history.yaml
+++ b/tests/cassettes/test_composer_oracle/test_rhof_station_sessions_matches_legacy_device_history.yaml
@@ -15,7 +15,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: POST
-    uri: https://vi-api.vedur.is/tos/v1/entity/search/station/geophysical/
+    uri: https://vi-api.vedur.is/tos/internal/entity/search/station/geophysical
   response:
     body:
       string: "[\n  {\n    \"attributes\": [\n      {\n        \"attribute_datatype_code\":
@@ -175,7 +175,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: POST
-    uri: https://vi-api.vedur.is/tos/v1/entity/search/station/geophysical/
+    uri: https://vi-api.vedur.is/tos/internal/entity/search/station/geophysical
   response:
     body:
       string: '[]
@@ -209,7 +209,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4390/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4390
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -385,7 +385,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4521/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4521
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -465,7 +465,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4704/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4704
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"timestamp\",\n
@@ -559,7 +559,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4804/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4804
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -646,7 +646,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4945/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4945
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -720,7 +720,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/4981/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/4981
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"boolean\",\n
@@ -823,7 +823,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/5318/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/5318
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -897,7 +897,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/5228/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/5228
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -972,7 +972,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/18662/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/18662
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -1047,7 +1047,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/5823/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/5823
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n
@@ -1125,7 +1125,7 @@ interactions:
       User-Agent:
       - python-requests/2.32.5
     method: GET
-    uri: https://vi-api.vedur.is/tos/v1/history/entity/18659/
+    uri: https://vi-api.vedur.is/tos/internal/history/entity/18659
   response:
     body:
       string: "{\n  \"attributes\": [\n    {\n      \"attribute_datatype_code\": \"text\",\n

--- a/tests/test_http_url.py
+++ b/tests/test_http_url.py
@@ -1,0 +1,64 @@
+"""Tests for :func:`tostools.api._http.canonical_tos_url`.
+
+Covers the 2026-06 TOS backend migration: trailing-slash stripping (the new
+backend 308-redirects ``/``-terminated paths, dropping auth on mutating calls)
+and the fail-fast guard against a ``None``/``Null`` id leaking into a URL path.
+"""
+
+import pytest
+
+from tostools.api._http import canonical_tos_url
+
+BASE = "https://vi-api.vedur.is/tos/internal"
+
+
+@pytest.mark.parametrize(
+    "endpoint, expected",
+    [
+        # Trailing slash is stripped (the whole point of the migration).
+        ("/history/entity/5245/", f"{BASE}/history/entity/5245"),
+        ("/basic_search/", f"{BASE}/basic_search"),
+        (
+            "/entity/search/station/geophysical/",
+            f"{BASE}/entity/search/station/geophysical",
+        ),
+        ("/entity_subtypes/", f"{BASE}/entity_subtypes"),
+        # Already slashless → unchanged.
+        ("/join/28865", f"{BASE}/join/28865"),
+        ("/entity/parent_history/17234", f"{BASE}/entity/parent_history/17234"),
+        # Leading slash optional on the endpoint.
+        ("join/28865", f"{BASE}/join/28865"),
+    ],
+)
+def test_canonical_url_normalizes_trailing_slash(endpoint, expected):
+    assert canonical_tos_url(BASE, endpoint) == expected
+
+
+def test_base_url_with_trailing_slash_does_not_double():
+    # Callers rstrip base_url, but the helper must not produce '//' regardless.
+    assert canonical_tos_url(BASE + "/", "/join/1") == f"{BASE}/join/1"
+
+
+def test_inline_query_string_is_preserved():
+    # A query string must survive; only the path segment is trimmed.
+    assert (
+        canonical_tos_url(BASE, "/entity/search/?code=marker")
+        == f"{BASE}/entity/search?code=marker"
+    )
+
+
+@pytest.mark.parametrize("null", ["None", "Null", "null", "NULL"])
+def test_none_segment_raises_before_send(null):
+    # A None/Null id in the path (str(None) → 'None') is a formatting bug that
+    # the backend answers with 422 — fail fast with a clear, named error.
+    with pytest.raises(ValueError, match="None/Null value leaked"):
+        canonical_tos_url(BASE, f"/entity/{null}/")
+
+
+def test_none_substring_in_value_is_allowed():
+    # Only an exact 'None' path *segment* is rejected — a legitimate value that
+    # merely contains the letters is fine.
+    assert (
+        canonical_tos_url(BASE, "/entity/search/None_Station")
+        == f"{BASE}/entity/search/None_Station"
+    )


### PR DESCRIPTION
IT revised the TOS backend (2026-06). Functionality is unchanged; they flagged three required **client** changes (URLs only). All three are addressed here.

## 1. `/tos/v1` → `/tos/internal`
The old `/v1` path is being retired. Updated every base-URL site: `tos_client.py`, `tos_writer.py`, `tos.py` (CLI), `cli/main.py`, `tosGPS.py` default, `gps_metadata_qc.py` (+ the `legacy/` copy). `legacy/owner.py` (a dead `:11223` direct-port path) left as-is.

## 2. No trailing slash
The new backend 308-redirects `/`-terminated paths to the slashless form. That redirect adds monitoring noise **and can drop the `Authorization` header on mutating calls** — the likely cause of the intermittent 401 we hit on a live `replace-modem` PATCH.

Handled **centrally**: new `canonical_tos_url()` (`api/_http.py`) strips the trailing slash at the one point every request flows through, so endpoint string literals — and the tests that assert on them — stay unchanged. Wired into `TOSClient._make_request`, `TOSWriter._request`, and the direct `requests.get/post` sites in both `gps_metadata_qc` modules.

## 3. No `None`/`Null` in URLs (422)
IT saw `422` on `/entity/None`. `canonical_tos_url()` now fast-fails with a clear, named error if any path segment is `None`/`Null`, instead of letting it 422 server-side. The `str(id)`-concatenation sites in `gps_metadata_qc` (where a `None` id would leak) route through it too.

## Tests
- New `tests/test_http_url.py` — trailing-slash strip, idempotence, inline-query preservation, `None`/`Null` guard, substring-allowed.
- Composer-oracle **cassette request URIs migrated** to the new path (responses untouched — functionality is identical per IT).
- Full suite green: **1180 passed, 2 skipped**. ruff + black clean.

## Follow-up (separate)
The migration had to touch 8 files because the host/path is hardcoded in ~10 files (54× in `tos.py`, 4 separate URL constants). A follow-up to centralize the TOS base URL into one config is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)